### PR TITLE
fix(security): tighten TF validation, split error messages by failure mode

### DIFF
--- a/src/engine_security.cpp
+++ b/src/engine_security.cpp
@@ -77,6 +77,18 @@ int BacktestEngine::security_lower_tf_sub_bar_index(int sec_id) const {
 }
 
 
+// Safe wrapper around tf_to_seconds: returns <=0 on any parse failure
+// (including std::invalid_argument from stoi on garbage like "abc").
+// We use this instead of letting stoi escape so we can attach the
+// offending literal to the diagnostic.
+static int safe_tf_to_seconds(const std::string& tf) {
+    try {
+        return tf_to_seconds(tf);
+    } catch (...) {
+        return 0;
+    }
+}
+
 void BacktestEngine::validate_security_timeframes(const std::string& input_tf) {
     if (input_tf.empty()) {
         if (!security_eval_states_.empty()) {
@@ -87,6 +99,11 @@ void BacktestEngine::validate_security_timeframes(const std::string& input_tf) {
         return;
     }
 
+    // Note: script_tf >= input_tf is enforced separately in
+    // BacktestEngine::run() (see engine_run.cpp ~line 199), which throws
+    // "script timeframe must be coarser than or equal to input timeframe"
+    // when the script_tf/input_tf ratio is invalid. We do not re-check
+    // that invariant here.
     int input_seconds = tf_to_seconds(input_tf);
     for (auto& state : security_eval_states_) {
         state.lower_tf_requested = false;
@@ -97,7 +114,13 @@ void BacktestEngine::validate_security_timeframes(const std::string& input_tf) {
 
         int lower_ratio = 0;
         int lower_seconds = 0;
-        if (supports_lower_tf_emulation(input_tf, state.tf, &lower_ratio, &lower_seconds)) {
+        bool ltf_supported = supports_lower_tf_emulation(
+            input_tf, state.tf, &lower_ratio, &lower_seconds);
+        if (ltf_supported && state.lower_tf_array_requested) {
+            // Only request.security_lower_tf may opt into LTF emulation.
+            // request.security with a finer TF must be rejected even
+            // when the ratio happens to be an integer — see the
+            // finer-than-input check below.
             state.lower_tf_requested = true;
             ensure_supported_lower_tf_emulation_flags(state.lookahead_on, state.gaps_on);
             state.lower_tf_emulation = true;
@@ -106,26 +129,55 @@ void BacktestEngine::validate_security_timeframes(const std::string& input_tf) {
             continue;
         }
 
-        int requested_seconds = tf_to_seconds(state.tf);
-        int req_ratio = tf_ratio(input_tf, state.tf);
-        if ((input_seconds > 0 && requested_seconds > 0 && requested_seconds < input_seconds)
-            || req_ratio == -2) {
-            state.lower_tf_requested = true;
+        // Parse the requested TF defensively so a garbage literal like
+        // "abc" produces a precise diagnostic instead of an opaque
+        // std::invalid_argument from stoi.
+        int requested_seconds = safe_tf_to_seconds(state.tf);
+        if (requested_seconds <= 0) {
+            const char* api = state.lower_tf_array_requested
+                ? "request.security_lower_tf" : "request.security";
             throw std::runtime_error(
-                "request.security lower TF requires finer input bars: requested "
-                + state.tf + " from input timeframe " + input_tf
+                std::string(api) + ": invalid timeframe literal '" + state.tf + "'"
             );
         }
 
-        // ``request.security_lower_tf`` only makes sense when the requested
-        // TF is strictly finer than the chart's input TF AND the ratio is
-        // an exact integer divisor (the supports_lower_tf_emulation check
-        // above). If the requested TF is the same or coarser, TV would
-        // raise an error rather than silently returning an empty array.
+        if (requested_seconds < input_seconds) {
+            // Finer than input — only valid for security_lower_tf with
+            // an integer divisor ratio.
+            if (!state.lower_tf_array_requested) {
+                throw std::runtime_error(
+                    "request.security: requested timeframe '" + state.tf
+                    + "' is finer than input '" + input_tf
+                    + "'. Use request.security_lower_tf for sub-input timeframes."
+                );
+            }
+            // LTF case: must be an exact integer divisor.
+            if (input_seconds % requested_seconds != 0) {
+                throw std::runtime_error(
+                    "request.security_lower_tf: requested timeframe '" + state.tf
+                    + "' is not an integer divisor of input '" + input_tf
+                    + "' (ratio " + std::to_string(
+                        static_cast<double>(input_seconds) / requested_seconds)
+                    + " is non-integer; chart bars cannot be evenly subdivided)"
+                );
+            }
+            // Defensive: integer-ratio finer LTF should already have been
+            // accepted by supports_lower_tf_emulation above. Reaching
+            // here implies a mismatch between the two checks (e.g. a
+            // non-fixed-intraday TF on one side).
+            throw std::runtime_error(
+                "request.security_lower_tf: internal error - passed integer-ratio check but emulation support returned false (requested '"
+                + state.tf + "', input '" + input_tf + "')"
+            );
+        }
+
+        // requested_seconds >= input_seconds: HTF or same TF. Valid for
+        // request.security; never valid for request.security_lower_tf.
         if (state.lower_tf_array_requested) {
             throw std::runtime_error(
-                "request.security_lower_tf requires a timeframe finer than the chart's input timeframe: requested "
-                + state.tf + " from input timeframe " + input_tf
+                "request.security_lower_tf: requested timeframe '" + state.tf
+                + "' is not finer than input '" + input_tf
+                + "'. Lower-TF API requires a strictly finer timeframe."
             );
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_SOURCES
     test_dmi_parity
     test_integration
     test_request_security
+    test_security_tf_validation
     test_engine_trade_accessors
     test_generic_matrix_primitives
     test_generic_matrix_udt

--- a/tests/test_request_security.cpp
+++ b/tests/test_request_security.cpp
@@ -63,7 +63,10 @@ public:
     std::vector<double> completed_closes;
 
     LowerTimeframeEmulationHarness() {
-        register_security_eval(0, "5", "", false, false);
+        // Use the lower-TF API: regular request.security with a
+        // finer-than-input TF is now rejected by the validator;
+        // callers must opt in via register_security_lower_tf_eval.
+        register_security_lower_tf_eval(0, "5", "");
     }
 
     void evaluate_security(int sec_id, const Bar& bar, bool is_complete) override {
@@ -87,7 +90,15 @@ public:
 class LowerTimeframeUnsupportedFlagHarness : public BacktestEngine {
 public:
     explicit LowerTimeframeUnsupportedFlagHarness(bool lookahead_on, bool gaps_on) {
-        register_security_eval(0, "5", "", lookahead_on, gaps_on);
+        // Register the LTF-array path then override the flags so we
+        // can prove LTF emulation rejects non-default lookahead/gaps.
+        register_security_lower_tf_eval(0, "5", "");
+        // The lower-TF-array helper pins flags off; flip them back on
+        // here to drive the unsupported-flag rejection path.
+        if (!security_eval_states_.empty()) {
+            security_eval_states_.back().lookahead_on = lookahead_on;
+            security_eval_states_.back().gaps_on = gaps_on;
+        }
     }
 
     void on_bar(const Bar& bar) override {
@@ -178,7 +189,7 @@ void test_request_security_lower_tf_requires_finer_input_bars() {
     require(!strat.last_error().empty(),
             "Lower-TF request.security should fail without finer input bars");
     require(
-        strat.last_error().find("request.security lower TF requires finer input bars")
+        strat.last_error().find("Use request.security_lower_tf for sub-input timeframes")
             != std::string::npos,
         std::string("Unexpected lower-TF error: ") + strat.last_error()
     );
@@ -462,7 +473,7 @@ void test_request_security_lower_tf_array_rejects_higher_timeframe() {
     );
     require(
         strat.last_error().find(
-            "request.security_lower_tf requires a timeframe finer than the chart's input timeframe"
+            "Lower-TF API requires a strictly finer timeframe"
         ) != std::string::npos,
         std::string("Unexpected higher-TF lower-TF-array error: ") + strat.last_error()
     );
@@ -492,7 +503,7 @@ void test_request_security_lower_tf_array_rejects_non_divisible_timeframe() {
     );
     require(
         strat.last_error().find(
-            "request.security lower TF requires finer input bars"
+            "is not an integer divisor of input"
         ) != std::string::npos,
         std::string("Unexpected non-divisible lower-TF-array error: ")
             + strat.last_error()

--- a/tests/test_security_tf_validation.cpp
+++ b/tests/test_security_tf_validation.cpp
@@ -1,0 +1,143 @@
+// Tests for BacktestEngine::validate_security_timeframes — the matrix
+// of accept/reject across HTF, LTF, same-TF, invalid-literal cases.
+//
+// Style: cassert + plain int main() to match other engine tests.
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+
+namespace {
+
+// Subclass exposing register_security{,_lower_tf}_eval (protected in
+// the base) so each test can wire up exactly one security with the
+// timeframe combo under test.
+struct ValidationHarness : public BacktestEngine {
+    void on_bar(const Bar&) override {}
+    void evaluate_security(int, const Bar&, bool) override {}
+
+    void add_security(const std::string& requested_tf,
+                      const std::string& input_tf) {
+        register_security_eval(0, requested_tf, input_tf, false, false);
+    }
+    void add_security_lower_tf(const std::string& requested_tf,
+                               const std::string& input_tf) {
+        register_security_lower_tf_eval(0, requested_tf, input_tf);
+    }
+};
+
+// Drive a tiny run so validate_security_timeframes is invoked through
+// the normal engine path and any thrown error is captured as
+// last_error(). Returns last_error() (empty on success).
+std::string run_with(ValidationHarness& strat,
+                     const std::string& input_tf) {
+    std::vector<Bar> bars = {
+        {10.0, 10.0, 10.0, 10.0, 100.0, 0},
+        {11.0, 11.0, 11.0, 11.0, 100.0, 900000},
+    };
+    strat.run(bars.data(), static_cast<int>(bars.size()),
+              input_tf, input_tf, false, 4,
+              MagnifierDistribution::ENDPOINTS);
+    return strat.last_error();
+}
+
+void expect_contains(const std::string& haystack, const std::string& needle,
+                     const char* label) {
+    if (haystack.find(needle) == std::string::npos) {
+        std::cerr << label << ": expected error to contain '" << needle
+                  << "' but got: '" << haystack << "'\n";
+        assert(false);
+    }
+}
+
+// 1. request.security HTF — accept (60 from 15, ratio 4)
+void test_security_htf_accept() {
+    ValidationHarness strat;
+    strat.add_security("60", "15");
+    auto err = run_with(strat, "15");
+    assert(err.empty() && "HTF request.security should be accepted");
+    std::cout << "test_security_htf_accept passed.\n";
+}
+
+// 2. request.security finer-than-input — reject with hint
+void test_security_finer_rejected_with_hint() {
+    ValidationHarness strat;
+    strat.add_security("5", "15");
+    auto err = run_with(strat, "15");
+    assert(!err.empty());
+    expect_contains(err, "Use request.security_lower_tf for sub-input timeframes",
+                    "test_security_finer_rejected_with_hint");
+    std::cout << "test_security_finer_rejected_with_hint passed.\n";
+}
+
+// 3. request.security_lower_tf with non-integer divisor — reject
+void test_security_lower_tf_non_divisor_rejected() {
+    ValidationHarness strat;
+    strat.add_security_lower_tf("4", "15");
+    auto err = run_with(strat, "15");
+    assert(!err.empty());
+    expect_contains(err, "is not an integer divisor of input",
+                    "test_security_lower_tf_non_divisor_rejected");
+    std::cout << "test_security_lower_tf_non_divisor_rejected passed.\n";
+}
+
+// 4. request.security_lower_tf with integer divisor — accept (5 from 15)
+void test_security_lower_tf_divisor_accept() {
+    ValidationHarness strat;
+    strat.add_security_lower_tf("5", "15");
+    auto err = run_with(strat, "15");
+    assert(err.empty() && "Integer-divisor LTF should be accepted");
+    std::cout << "test_security_lower_tf_divisor_accept passed.\n";
+}
+
+// 5. request.security_lower_tf with coarser-than-input — reject
+void test_security_lower_tf_not_finer_rejected() {
+    ValidationHarness strat;
+    strat.add_security_lower_tf("60", "15");
+    auto err = run_with(strat, "15");
+    assert(!err.empty());
+    expect_contains(err, "Lower-TF API requires a strictly finer timeframe",
+                    "test_security_lower_tf_not_finer_rejected");
+    std::cout << "test_security_lower_tf_not_finer_rejected passed.\n";
+}
+
+// 6. request.security with garbage TF literal — reject with literal.
+// We register with input_tf="" so the constructor-time tf_ratio path is
+// skipped; validate_security_timeframes (driven from run()) is the
+// layer under test here.
+void test_security_invalid_literal_rejected() {
+    ValidationHarness strat;
+    strat.add_security("abc", "");
+    auto err = run_with(strat, "15");
+    assert(!err.empty());
+    expect_contains(err, "invalid timeframe literal 'abc'",
+                    "test_security_invalid_literal_rejected");
+    std::cout << "test_security_invalid_literal_rejected passed.\n";
+}
+
+// 7. request.security with same TF as input — accept
+void test_security_same_tf_accept() {
+    ValidationHarness strat;
+    strat.add_security("15", "15");
+    auto err = run_with(strat, "15");
+    assert(err.empty() && "Same-TF request.security should be accepted");
+    std::cout << "test_security_same_tf_accept passed.\n";
+}
+
+}  // namespace
+
+int main() {
+    test_security_htf_accept();
+    test_security_finer_rejected_with_hint();
+    test_security_lower_tf_non_divisor_rejected();
+    test_security_lower_tf_divisor_accept();
+    test_security_lower_tf_not_finer_rejected();
+    test_security_invalid_literal_rejected();
+    test_security_same_tf_accept();
+    std::cout << "All test_security_tf_validation tests passed.\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

Hardens \`validate_security_timeframes\` (\`src/engine_security.cpp\`) for all \`request.security[_lower_tf]\` calls.

**Invariants now enforced**
- \`request.security\` requested TF must be \`>= input_tf\` (HTF or same). Reject finer TFs with hint to use \`security_lower_tf\`.
- \`request.security_lower_tf\` requested TF must be \`< input_tf\` AND \`input_tf % requested_tf == 0\` (integer divisor).
- TF literals must parse to \`> 0\` seconds (rejects \`"abc"\`, \`"0"\`, etc.).
- \`script_tf >= input_tf\` already enforced at \`engine_run.cpp:199\`; documented in validate path.

**Pre-existing leak fixed**: \`request.security("X","5",...)\` with \`input_tf="15"\` was silently going through LTF emulation path. Now correctly gated on \`lower_tf_array_requested\`.

## Test plan
- [x] 21/21 ctest pass (incl. new \`test_security_tf_validation.cpp\`)
- [x] Corpus parity unchanged (163/200 strict-excellent, matches main baseline)
- [x] Existing \`test_request_security.cpp\` updated for new error messages