### PR TITLE
fix(oca): REDUCE reduces sibling qty by filled amount

### DIFF
--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -798,6 +798,10 @@ private:
     void execute_partial_exit_by_entry(double fill_price, const std::string& from_entry);
     void execute_partial_exit_by_entry_percent(double fill_price, const std::string& from_entry, double qty_percent);
     void cancel_oca_group(const std::string& oca_name, const std::string& exclude_id);
+    // Pine v6 oca.reduce: when one sibling fills qty Q, reduce remaining
+    // siblings' qty by Q. Siblings whose qty becomes <= 0 are cancelled.
+    void reduce_oca_group(const std::string& oca_name, const std::string& exclude_id,
+                          double filled_qty);
     void purge_exit_orders();
 
     // process_pending_orders helpers (defined in engine_fills.cpp).

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -313,6 +313,15 @@ void BacktestEngine::apply_filled_order_to_state(
     // Track trades before fill to set exit_comment/exit_id on new trades
     size_t trades_before = trades_.size();
 
+    // Snapshot signed position before the fill so we can compute the
+    // filled qty for OCA-reduce semantics. Long = +qty, Short = -qty.
+    auto signed_pos = [&]() {
+        if (position_side_ == PositionSide::LONG)  return  position_qty_;
+        if (position_side_ == PositionSide::SHORT) return -position_qty_;
+        return 0.0;
+    };
+    double signed_pos_before = signed_pos();
+
     if (order.type == OrderType::MARKET) {
         apply_market_order_fill(order, fill_price, bar, trail_best_path_state);
     } else if (order.type == OrderType::ENTRY) {
@@ -324,6 +333,9 @@ void BacktestEngine::apply_filled_order_to_state(
                              exit_closed_from_bar, exit_closed_was_long);
     }
 
+    double signed_pos_after = signed_pos();
+    double filled_qty = std::abs(signed_pos_after - signed_pos_before);
+
     if (position_side_ == PositionSide::FLAT) {
         trail_best_path_state = trail_best_price_;
     }
@@ -334,12 +346,15 @@ void BacktestEngine::apply_filled_order_to_state(
         trades_[ti].exit_id = order.id;
     }
 
-    // Handle OCA groups: cancel (type 1) or reduce (type 2). For reduce,
-    // TradingView cancels remaining orders in the group when one fills —
-    // the position is sized by the filled order.
+    // Handle OCA groups: cancel (type 1) cancels all siblings; reduce
+    // (type 2, Pine v6 strategy.oca.reduce) reduces siblings' remaining
+    // qty by the qty just filled — only siblings whose qty drops to 0
+    // are removed. See TradingView Pine v6 docs strategy.oca.reduce.
     if (!order.oca_name.empty()) {
-        if (order.oca_type == 1 || order.oca_type == 2) {
+        if (order.oca_type == 1) {
             cancel_oca_group(order.oca_name, order.id);
+        } else if (order.oca_type == 2) {
+            reduce_oca_group(order.oca_name, order.id, filled_qty);
         }
     }
     // When an exit fill causes position to go flat, subsequent EXIT

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -233,6 +233,29 @@ void BacktestEngine::cancel_oca_group(const std::string& oca_name, const std::st
         pending_orders_.end());
 }
 
+// Pine v6 strategy.oca.reduce: when one sibling fills qty Q, every other
+// sibling's remaining qty is reduced by Q. Siblings whose remaining qty
+// reaches <= 0 are cancelled outright (matches TradingView behaviour and
+// degenerates to oca.cancel when the filling order's qty >= sibling qty).
+// Siblings using default sizing (qty == NaN) cannot have a meaningful
+// per-order qty applied at place time, so we conservatively cancel them
+// (this matches the prior, blanket-cancel behaviour for that subset).
+void BacktestEngine::reduce_oca_group(const std::string& oca_name,
+                                      const std::string& exclude_id,
+                                      double filled_qty) {
+    if (oca_name.empty()) return;
+    if (!(filled_qty > 0.0)) return;  // nothing to subtract
+    pending_orders_.erase(
+        std::remove_if(pending_orders_.begin(), pending_orders_.end(),
+            [&](PendingOrder& o) {
+                if (o.oca_name != oca_name || o.id == exclude_id) return false;
+                if (std::isnan(o.qty)) return true;  // default-sized: cancel
+                o.qty -= filled_qty;
+                return o.qty <= 1e-12;
+            }),
+        pending_orders_.end());
+}
+
 
 void BacktestEngine::purge_exit_orders() {
     pending_orders_.erase(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_SOURCES
     test_security_tf_validation
     test_security_lower_tf_input_passthrough
     test_engine_trade_accessors
+    test_strategy_oca
     test_generic_matrix_primitives
     test_generic_matrix_udt
     test_generic_matrix_bool_proxy

--- a/tests/test_strategy_oca.cpp
+++ b/tests/test_strategy_oca.cpp
@@ -1,0 +1,230 @@
+/*
+ * test_strategy_oca.cpp — verify Pine v6 OCA group semantics on
+ * BacktestEngine. Specifically pins down strategy.oca.reduce: when one
+ * sibling fills qty Q, every other sibling's remaining qty drops by Q
+ * (rather than being cancelled outright, which is oca.cancel behaviour).
+ * See TradingView Pine v6 docs strategy.oca.reduce for the reference
+ * semantics. Regression guard for the prior bug where oca_type==2 was
+ * routed to cancel_oca_group (full sibling wipe).
+ */
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+
+#include <pineforge/engine.hpp>
+#include <pineforge/bar.hpp>
+#include <pineforge/na.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+static bool near(double a, double b, double tol = 1e-6) {
+    return std::fabs(a - b) <= tol;
+}
+
+namespace {
+
+// Probe that places a configurable batch of OCA-grouped limit orders on
+// bar 1, then exposes pending_orders_ each bar so the test can inspect
+// remaining qty after the first sibling fires.
+class OcaProbe : public BacktestEngine {
+public:
+    struct Sibling {
+        std::string id;
+        bool is_long;
+        double qty;
+        double limit_price;
+    };
+    std::vector<Sibling> siblings;
+    int oca_type = 2;  // 2 = reduce, 1 = cancel
+    std::string oca_name = "G1";
+
+    // Snapshot of pending orders at the END of each bar (after fills).
+    struct PendingSnap { std::string id; double qty; };
+    std::vector<std::vector<PendingSnap>> pending_per_bar;
+
+    OcaProbe() {
+        initial_capital_ = 1'000'000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        slippage_ = 0;
+        commission_value_ = 0;
+        pyramiding_ = 100;  // allow many entries to coexist
+    }
+
+    void on_bar(const Bar& bar) override {
+        if (bar_index_ == 1) {
+            for (const auto& s : siblings) {
+                strategy_order(s.id, s.is_long, s.qty, s.limit_price,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               oca_name, oca_type);
+            }
+        }
+        std::vector<PendingSnap> snap;
+        for (const auto& o : pending_orders_) {
+            snap.push_back({o.id, o.qty});
+        }
+        pending_per_bar.push_back(std::move(snap));
+    }
+
+    const PendingSnap* find(int bar, const std::string& id) const {
+        if (bar < 0 || bar >= (int)pending_per_bar.size()) return nullptr;
+        for (const auto& s : pending_per_bar[bar]) {
+            if (s.id == id) return &s;
+        }
+        return nullptr;
+    }
+};
+
+}  // namespace
+
+// Case 1: 2-sibling REDUCE, first fills qty 3 (of 5) → other sibling's
+// remaining qty should drop from 5 to 2 (NOT be cancelled).
+static void test_reduce_two_sibling_partial() {
+    std::printf("test_reduce_two_sibling_partial\n");
+    OcaProbe p;
+    p.oca_type = 2;
+    // Bar 2 open=100, low=90: A's limit @ 100 fills (qty 3 long). B's
+    // limit at 80 doesn't trigger (low=90 > 80) so it survives in
+    // pending_orders_, where we can read its post-reduce qty.
+    p.siblings = {
+        {"A", true, 3.0, 100.0},
+        {"B", true, 5.0, 80.0},
+    };
+    Bar bars[4] = {
+        {100, 105,  95, 100, 1000,  60'000},
+        {100, 108,  95, 105, 1000, 120'000},  // place orders
+        {100, 110,  90, 105, 1000, 180'000},  // A fills @ 100 qty 3
+        {100, 110,  85, 105, 1000, 240'000},  // B's limit still 80 — but reduced qty applies if it ever fires
+    };
+    p.run(bars, 4);
+
+    // After bar 2: A is filled (gone). B should still be pending with qty 5-3=2.
+    auto* b_after = p.find(2, "B");
+    CHECK(b_after != nullptr);
+    if (b_after) CHECK(near(b_after->qty, 2.0));
+
+    // A must NOT be in pending after fill.
+    CHECK(p.find(2, "A") == nullptr);
+}
+
+// Case 2: 3-sibling REDUCE, first fills 2 (of 4) → other two siblings
+// should each go from 4 to 2.
+static void test_reduce_three_sibling() {
+    std::printf("test_reduce_three_sibling\n");
+    OcaProbe p;
+    p.oca_type = 2;
+    p.siblings = {
+        {"A", true, 2.0, 100.0},
+        {"B", true, 4.0,  80.0},
+        {"C", true, 4.0,  70.0},
+    };
+    Bar bars[4] = {
+        {100, 105,  95, 100, 1000,  60'000},
+        {100, 108,  95, 105, 1000, 120'000},
+        {100, 110,  90, 105, 1000, 180'000},  // A fills qty 2
+        {100, 110,  85, 105, 1000, 240'000},
+    };
+    p.run(bars, 4);
+
+    auto* b = p.find(2, "B");
+    auto* c = p.find(2, "C");
+    CHECK(b != nullptr);
+    CHECK(c != nullptr);
+    if (b) CHECK(near(b->qty, 2.0));
+    if (c) CHECK(near(c->qty, 2.0));
+}
+
+// Case 3: REDUCE full-fill cascades — when filled qty >= sibling qty,
+// the sibling drops to 0 and is removed (degenerates to oca.cancel for
+// that sibling, matching TV semantics).
+static void test_reduce_full_fill_cascade() {
+    std::printf("test_reduce_full_fill_cascade\n");
+    OcaProbe p;
+    p.oca_type = 2;
+    p.siblings = {
+        {"A", true, 5.0, 100.0},
+        {"B", true, 5.0,  80.0},
+        {"C", true, 3.0,  70.0},
+    };
+    Bar bars[4] = {
+        {100, 105,  95, 100, 1000,  60'000},
+        {100, 108,  95, 105, 1000, 120'000},
+        {100, 110,  90, 105, 1000, 180'000},  // A fills qty 5 → B,C reduced by 5
+        {100, 110,  85, 105, 1000, 240'000},
+    };
+    p.run(bars, 4);
+
+    // B (5-5=0) and C (3-5<0) both removed.
+    CHECK(p.find(2, "B") == nullptr);
+    CHECK(p.find(2, "C") == nullptr);
+    CHECK(p.find(2, "A") == nullptr);
+}
+
+// Sanity: oca.cancel still nukes all siblings on first fill.
+static void test_cancel_unchanged() {
+    std::printf("test_cancel_unchanged\n");
+    OcaProbe p;
+    p.oca_type = 1;
+    p.siblings = {
+        {"A", true, 3.0, 100.0},
+        {"B", true, 5.0,  80.0},
+    };
+    Bar bars[4] = {
+        {100, 105,  95, 100, 1000,  60'000},
+        {100, 108,  95, 105, 1000, 120'000},
+        {100, 110,  90, 105, 1000, 180'000},  // A fills → B cancelled
+        {100, 110,  85, 105, 1000, 240'000},
+    };
+    p.run(bars, 4);
+    CHECK(p.find(2, "B") == nullptr);
+    CHECK(p.find(2, "A") == nullptr);
+}
+
+// Sanity: oca.none leaves siblings untouched on fill.
+static void test_none_unchanged() {
+    std::printf("test_none_unchanged\n");
+    OcaProbe p;
+    p.oca_type = 0;
+    p.siblings = {
+        {"A", true, 3.0, 100.0},
+        {"B", true, 5.0,  80.0},
+    };
+    Bar bars[4] = {
+        {100, 105,  95, 100, 1000,  60'000},
+        {100, 108,  95, 105, 1000, 120'000},
+        {100, 110,  90, 105, 1000, 180'000},  // A fills → B should remain qty 5
+        {100, 110,  85, 105, 1000, 240'000},
+    };
+    p.run(bars, 4);
+
+    auto* b = p.find(2, "B");
+    CHECK(b != nullptr);
+    if (b) CHECK(near(b->qty, 5.0));
+}
+
+int main() {
+    test_reduce_two_sibling_partial();
+    test_reduce_three_sibling();
+    test_reduce_full_fill_cascade();
+    test_cancel_unchanged();
+    test_none_unchanged();
+
+    std::printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Fix Pine v6 `strategy.oca.reduce` semantics — when one sibling fills qty Q, other siblings now have their qty REDUCED by Q (matching TV) instead of being cancelled outright (which is `strategy.oca.cancel` behaviour).
- New `reduce_oca_group` helper in `engine_orders.cpp`; `apply_filled_order_to_state` computes `filled_qty` from signed position delta and dispatches to either `cancel_oca_group` (type 1) or `reduce_oca_group` (type 2). Default-sized (`qty == NaN`) siblings still cancel since per-order qty is unknown at place time.
- Add `tests/test_strategy_oca.cpp` (5 cases / 14 assertions) covering REDUCE partial 2/3-sibling, full-fill cascade, plus CANCEL/NONE no-regression sanity.

## Parity
- Corpus excellent: **168 -> 176** (+8). 9 promotions to excellent (validation probes 52/63/72/93/95/96, mtf-probe-08/09, parity-probe-04, typed-matrix-probe-01).
- 2 demotions (`community/IES`, `validation_lower_tf/lower-tf-probe-02-bool-array`) — neither uses OCA, likely unrelated noise.
- 1 OCA strategy (`oca-three-way-probe-02-multi-group-partial`) windowed-out (no-compare-trades-interior); engine emits 5 trades vs 0 in window — REDUCE shifted trade timing as expected.

## Test plan
- [x] `ctest` 23/23 pass (was 22, +1 new)
- [x] `test_strategy_oca` 14/14 assertions pass
- [x] Full corpus parity sweep (197 strategies, 15m OHLCV)