### PR TITLE
fix(orders+fills): deferred-flip carry cycle scope + OCA cancel full-fill gate

### DIFF
--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -791,7 +791,8 @@ private:
                               PositionSide created_position_side = PositionSide::FLAT,
                               bool close_only_opposite = false,
                               bool is_priced_entry = false,
-                              double tv_carry_qty = 0.0);
+                              double tv_carry_qty = 0.0,
+                              int created_bar = -1);
     void execute_market_exit(double fill_price);
     void execute_partial_exit_qty(double fill_price, double qty_to_close);
     void execute_partial_exit(double fill_price, double qty_percent);
@@ -907,7 +908,8 @@ private:
                                 double fill_price, double explicit_qty,
                                 int explicit_qty_type,
                                 PositionSide created_position_side,
-                                bool is_priced_entry, double tv_carry_qty);
+                                bool is_priced_entry, double tv_carry_qty,
+                                int created_bar);
     void add_to_pyramid_market(const std::string& id, bool is_long,
                                double fill_price, double explicit_qty,
                                int explicit_qty_type,
@@ -922,7 +924,8 @@ private:
     void open_fresh_position(PositionSide requested, double fill_price,
                              double qty, const std::string& id);
     void consume_tv_carry_from_siblings(const std::string& id,
-                                        PositionSide created_position_side);
+                                        PositionSide created_position_side,
+                                        int created_bar);
 
     // run() helpers (defined in engine_run.cpp).
     int  count_expected_script_bars(const Bar* input_bars, int n_input,

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -369,7 +369,9 @@ void BacktestEngine::apply_market_order_fill(PendingOrder& order, double fill_pr
                                              const Bar& bar,
                                              double& trail_best_path_state) {
     execute_market_entry(order.id, order.is_long, fill_price, order.qty, order.qty_type,
-                         order.created_position_side, false);
+                         order.created_position_side, /*close_only_opposite=*/false,
+                         /*is_priced_entry=*/false, /*tv_carry_qty=*/0.0,
+                         order.created_bar);
     double trail_best_after_fill = trail_best_price_;
     // Set entry comment on the just-created pyramid entry
     if (!pyramid_entries_.empty()) pyramid_entries_.back().entry_comment = order.comment;
@@ -405,7 +407,8 @@ void BacktestEngine::apply_entry_order_fill(PendingOrder& order, double fill_pri
     execute_market_entry(order.id, order.is_long, fill_price, order.qty, order.qty_type,
                          order.created_position_side, close_only_opposite,
                          /*is_priced_entry=*/true,
-                         order.tv_carry_qty);
+                         order.tv_carry_qty,
+                         order.created_bar);
 
     bool did_execute =
         (position_side_ != side_before)

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -350,8 +350,22 @@ void BacktestEngine::apply_filled_order_to_state(
     // (type 2, Pine v6 strategy.oca.reduce) reduces siblings' remaining
     // qty by the qty just filled — only siblings whose qty drops to 0
     // are removed. See TradingView Pine v6 docs strategy.oca.reduce.
+    //
+    // OCA-cancel full-fill gate (validation_oca/oca-three-way-probe-02):
+    // TV cancels CANCEL-group siblings only after the originating order
+    // is FULLY filled, not after the first contract fills. With qty=4
+    // long + qty=2 sibling A_TP: A_TP fills qty=2, position=2 remaining,
+    // A_SL stays alive until the second sibling fires. We compare the
+    // qty actually transacted (``filled_qty``) against the order's
+    // explicit qty. If the request was default-sized (qty == NaN), we
+    // can't compute a residual so we conservatively cancel siblings on
+    // any fill (matches the prior, blanket-cancel behaviour for that
+    // subset). The OCA group name scoping inside cancel_oca_group /
+    // reduce_oca_group already isolates groups from each other.
     if (!order.oca_name.empty()) {
-        if (order.oca_type == 1) {
+        bool fully_filled = std::isnan(order.qty)
+            || filled_qty + 1e-12 >= order.qty;
+        if (order.oca_type == 1 && fully_filled) {
             cancel_oca_group(order.oca_name, order.id);
         } else if (order.oca_type == 2) {
             reduce_oca_group(order.oca_name, order.id, filled_qty);

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -48,7 +48,8 @@ void BacktestEngine::execute_market_entry(const std::string& id, bool is_long, d
                                           PositionSide created_position_side,
                                           bool close_only_opposite,
                                           bool is_priced_entry,
-                                          double tv_carry_qty) {
+                                          double tv_carry_qty,
+                                          int created_bar) {
     PositionSide requested = is_long ? PositionSide::LONG : PositionSide::SHORT;
     bool is_opposite_entry = position_side_ != PositionSide::FLAT && position_side_ != requested;
     bool direction_blocked =
@@ -70,7 +71,8 @@ void BacktestEngine::execute_market_entry(const std::string& id, bool is_long, d
 
     if (position_side_ == PositionSide::FLAT) {
         enter_market_from_flat(id, is_long, fill_price, explicit_qty, explicit_qty_type,
-                               created_position_side, is_priced_entry, tv_carry_qty);
+                               created_position_side, is_priced_entry, tv_carry_qty,
+                               created_bar);
         return;
     }
 
@@ -390,12 +392,29 @@ void BacktestEngine::open_fresh_position(PositionSide requested, double fill_pri
 // fresh at qty=1. Without this, both siblings would grow and the engine
 // emits an extra-qty pyramid add (or, after the cleanup-loop wipes the
 // survivor, an entire extra round-trip the next day).
+//
+// Cycle scoping: TV consumes carry only when the triggering sibling fires
+// from FLAT. That means a sibling armed in a LATER position cycle (whose
+// own ``tv_carry_qty`` was captured from a different source position
+// later than this firing entry's ``created_bar``) must keep its carry
+// independent — it will apply its own carry when it later fires from
+// flat. Without this scoping, consuming a future-cycle sibling's carry
+// drops one cycle's worth of qty (validation/52, 63, 72, 92, 93, 95, 96
+// pre-fix: row count + qty match TV exactly, but per-leg PnL drifts
+// because the chain qty schedule shifts by one cycle when a sibling is
+// pre-emptively wiped by an earlier-cycle fire).
 void BacktestEngine::consume_tv_carry_from_siblings(const std::string& id,
-                                                    PositionSide created_position_side) {
+                                                    PositionSide created_position_side,
+                                                    int created_bar) {
     for (auto& other : pending_orders_) {
         if (other.id == id) continue;
         if (other.created_position_side != created_position_side) continue;
         if (other.tv_carry_qty <= 0.0) continue;
+        // Cycle-scope: only consume siblings placed no later than the
+        // firing order's own placement. Siblings placed in a LATER bar
+        // captured carry from a DIFFERENT source position cycle and own
+        // their carry — TV does not pre-emptively wipe them.
+        if (other.created_bar > created_bar) continue;
         other.tv_carry_qty = 0.0;
     }
 }
@@ -446,7 +465,8 @@ void BacktestEngine::enter_market_from_flat(const std::string& id, bool is_long,
                                             double fill_price, double explicit_qty,
                                             int explicit_qty_type,
                                             PositionSide created_position_side,
-                                            bool is_priced_entry, double tv_carry_qty) {
+                                            bool is_priced_entry, double tv_carry_qty,
+                                            int created_bar) {
     bool carry_was_long = (created_position_side == PositionSide::LONG);
     bool tv_deferred_flip =
         script_has_strategy_close_
@@ -456,7 +476,7 @@ void BacktestEngine::enter_market_from_flat(const std::string& id, bool is_long,
     double base_qty = calc_qty_for_type(fill_price, explicit_qty, explicit_qty_type);
     double qty = tv_deferred_flip ? (tv_carry_qty + base_qty) : base_qty;
     if (tv_deferred_flip) {
-        consume_tv_carry_from_siblings(id, created_position_side);
+        consume_tv_carry_from_siblings(id, created_position_side, created_bar);
     }
     // NOTE: margin check is performed at SIGNAL time inside
     // strategy_entry / queue_deferred_close_order, NOT here at fill

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TEST_SOURCES
     test_security_lower_tf_input_passthrough
     test_engine_trade_accessors
     test_strategy_oca
+    test_strategy_pyramiding
     test_generic_matrix_primitives
     test_generic_matrix_udt
     test_generic_matrix_bool_proxy

--- a/tests/test_strategy_oca.cpp
+++ b/tests/test_strategy_oca.cpp
@@ -196,6 +196,179 @@ static void test_cancel_unchanged() {
     CHECK(p.find(2, "A") == nullptr);
 }
 
+// Cross-group isolation: when Group A's CANCEL sibling fills, Group
+// B's REDUCE sibling must remain untouched (different oca_name). Both
+// the cancel_oca_group helper and the reduce_oca_group helper already
+// scope by oca_name, so this is a regression guard for the
+// post-fill OCA dispatch in apply_filled_order_to_state.
+static void test_cross_group_isolation() {
+    std::printf("test_cross_group_isolation\n");
+    class CrossGroupProbe : public BacktestEngine {
+    public:
+        struct PendingSnap { std::string id; double qty; std::string oca_name; };
+        std::vector<std::vector<PendingSnap>> pending_per_bar;
+
+        CrossGroupProbe() {
+            initial_capital_ = 1'000'000;
+            default_qty_type_ = QtyType::FIXED;
+            default_qty_value_ = 1.0;
+            slippage_ = 0;
+            commission_value_ = 0;
+            pyramiding_ = 100;
+        }
+        void on_bar(const Bar& bar) override {
+            (void)bar;
+            if (bar_index_ == 1) {
+                // Group A: CANCEL siblings (each qty=2)
+                strategy_order("A_TP", true, 2.0, /*limit=*/100.0,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               "GRP_A", /*cancel=*/1);
+                strategy_order("A_SL", true, 2.0,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               /*stop=*/120.0,
+                               "GRP_A", 1);
+                // Group B: REDUCE siblings (each qty=2)
+                strategy_order("B_TP", true, 2.0, /*limit=*/95.0,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               "GRP_B", /*reduce=*/2);
+                strategy_order("B_SL", true, 2.0,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               /*stop=*/130.0,
+                               "GRP_B", 2);
+            }
+            std::vector<PendingSnap> snap;
+            for (const auto& po : pending_orders_) {
+                snap.push_back({po.id, po.qty, po.oca_name});
+            }
+            pending_per_bar.push_back(std::move(snap));
+        }
+        const PendingSnap* find(int bar, const std::string& id) const {
+            if (bar < 0 || bar >= (int)pending_per_bar.size()) return nullptr;
+            for (const auto& s : pending_per_bar[bar]) {
+                if (s.id == id) return &s;
+            }
+            return nullptr;
+        }
+    };
+    CrossGroupProbe p;
+    Bar bars[5] = {
+        {100, 105,  95, 100, 1000,  60'000},
+        {100, 108,  95, 105, 1000, 120'000},  // place orders
+        {100, 110,  90, 105, 1000, 180'000},  // A_TP @100 fills (qty 2)
+        {100, 110,  85, 105, 1000, 240'000},
+        {100, 110,  85, 105, 1000, 300'000},
+    };
+    p.run(bars, 5);
+
+    // After bar 2: A_TP filled → A_SL cancelled (Group A).
+    CHECK(p.find(2, "A_TP") == nullptr);
+    CHECK(p.find(2, "A_SL") == nullptr);
+    // Group B siblings MUST still be alive — A's fill is in a different
+    // OCA group and must not touch them. Note: B_TP's limit at 95 is
+    // not yet touched (low=90 on bar 2 fills A_TP @ 100 first; B_TP
+    // would fill on the SAME bar but our run executes the priced
+    // entries one per bar, so B_TP fires on a later bar).
+    auto* b_tp = p.find(2, "B_TP");
+    auto* b_sl = p.find(2, "B_SL");
+    if (b_tp == nullptr) {
+        // B_TP may have fired same bar; check Group B's cross-group
+        // isolation by inspecting whether B_SL still has its full qty.
+        CHECK(b_sl != nullptr);
+    } else {
+        // B_TP still pending — verify its qty unchanged (Group A's fill
+        // doesn't reduce or cancel B's siblings).
+        CHECK(near(b_tp->qty, 2.0));
+        CHECK(b_sl != nullptr);
+        CHECK(near(b_sl->qty, 2.0));
+    }
+}
+
+// OCA-CANCEL full-fill gate: when a CANCEL-group order fires for less
+// qty than its requested ``order.qty`` (because the position is smaller
+// than the order size), TV does NOT cancel the remaining siblings until
+// the originating order fully fills. The engine guards this by
+// comparing ``filled_qty`` against ``order.qty`` in
+// apply_filled_order_to_state.
+//
+// In our engine, RAW_ORDER opposite-direction fills close the FULL
+// position regardless of order.qty (apply_raw_order_fill, line 494),
+// so for OCA-cancel siblings of size > position the fill IS partial
+// and ``filled_qty < order.qty``. With the gate, A_SL stays alive.
+// Without the gate, A_SL is wiped immediately.
+static void test_cancel_oca_partial_fill_keeps_sibling() {
+    std::printf("test_cancel_oca_partial_fill_keeps_sibling\n");
+    class PartialFillProbe : public BacktestEngine {
+    public:
+        struct PendingSnap { std::string id; double qty; };
+        std::vector<std::vector<PendingSnap>> pending_per_bar;
+
+        PartialFillProbe() {
+            initial_capital_ = 1'000'000;
+            default_qty_type_ = QtyType::FIXED;
+            default_qty_value_ = 1.0;
+            slippage_ = 0;
+            commission_value_ = 0;
+            pyramiding_ = 100;
+        }
+        void on_bar(const Bar& bar) override {
+            (void)bar;
+            // Bar 1: open long qty 2.
+            if (bar_index_ == 1) {
+                strategy_entry("L", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               std::numeric_limits<double>::quiet_NaN(),
+                               2.0, "long entry");
+            }
+            // Bar 2: place A_TP (limit, short, qty=4 — bigger than
+            // position) and A_SL (stop, short, qty=4) in OCA-CANCEL.
+            // A_SL has stop BELOW the bar range (80) so only A_TP
+            // (limit=100) is touched at fire time. When A_TP fires,
+            // the engine fills a SHORT order against the long position
+            // — this closes the position (qty=2), not the full order
+            // qty 4. filled_qty (2) < order.qty (4) → fully_filled =
+            // false → cancel_oca_group should NOT run. A_SL remains
+            // pending.
+            if (bar_index_ == 2 && position_side_ == PositionSide::LONG) {
+                strategy_order("A_TP", false, 4.0, /*limit=*/100.0,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               "GRP_A", /*cancel=*/1);
+                strategy_order("A_SL", false, 4.0,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               /*stop=*/80.0,
+                               "GRP_A", 1);
+            }
+            std::vector<PendingSnap> snap;
+            for (const auto& po : pending_orders_) {
+                snap.push_back({po.id, po.qty});
+            }
+            pending_per_bar.push_back(std::move(snap));
+        }
+        const PendingSnap* find(int bar, const std::string& id) const {
+            if (bar < 0 || bar >= (int)pending_per_bar.size()) return nullptr;
+            for (const auto& s : pending_per_bar[bar]) {
+                if (s.id == id) return &s;
+            }
+            return nullptr;
+        }
+    };
+    PartialFillProbe p;
+    Bar bars[5] = {
+        {100, 105,  95, 100, 1000,  60'000},
+        {100, 105,  95, 100, 1000, 120'000},  // place L
+        {100, 105,  95, 100, 1000, 180'000},  // place A_TP/A_SL while long
+        {100, 110,  90, 105, 1000, 240'000},  // A_TP @100 fires; partial fill (only qty 2)
+        {100, 110,  90, 105, 1000, 300'000},
+    };
+    p.run(bars, 5);
+
+    // After bar 3: A_TP filled qty=2 against position size 2. order.qty
+    // was 4 — so fully_filled=false. A_SL must remain pending.
+    CHECK(p.find(3, "A_TP") == nullptr);  // A_TP itself is gone (consumed)
+    auto* a_sl = p.find(3, "A_SL");
+    CHECK(a_sl != nullptr);
+    if (a_sl) CHECK(near(a_sl->qty, 4.0));  // unchanged
+}
+
 // Sanity: oca.none leaves siblings untouched on fill.
 static void test_none_unchanged() {
     std::printf("test_none_unchanged\n");
@@ -223,6 +396,8 @@ int main() {
     test_reduce_three_sibling();
     test_reduce_full_fill_cascade();
     test_cancel_unchanged();
+    test_cross_group_isolation();
+    test_cancel_oca_partial_fill_keeps_sibling();
     test_none_unchanged();
 
     std::printf("\n%d passed, %d failed\n", tests_passed, tests_failed);

--- a/tests/test_strategy_pyramiding.cpp
+++ b/tests/test_strategy_pyramiding.cpp
@@ -1,0 +1,405 @@
+/*
+ * test_strategy_pyramiding.cpp — verify TradingView's deferred-flip
+ * carry consumption rule on BacktestEngine.
+ *
+ * Background: a priced (stop/limit) entry placed while a position was
+ * open captures that position's qty into ``PendingOrder::tv_carry_qty``
+ * at placement time. If the source position is later closed and the
+ * priced entry now fires from FLAT in the OPPOSITE direction, TV opens
+ * the new position at ``base_qty + tv_carry_qty`` (validation/52, 63,
+ * 72, 92, 95, 96 chains). Sibling priced entries (same created_position
+ * cycle, same direction) must lose their carry when one fires from flat
+ * — otherwise probe 93 (pyramiding=2, two opposite-direction stops
+ * armed during separate long cycles) double-grows.
+ *
+ * The cycle-scope predicate is the load-bearing piece: a sibling armed
+ * in a LATER cycle (created_bar > firing order's created_bar) captures
+ * carry from a DIFFERENT source position; it owns its carry and TV does
+ * not pre-emptively wipe it. Without that scope, the next-cycle sibling
+ * fires fresh and the qty schedule shifts by one full cycle, leaking
+ * ~qty × mintick of per-leg PnL drift across the whole chain (probe 95
+ * is the oracle: open-guaranteed stops eliminate sub-bar precision so
+ * any mismatch must come from the carry rule itself).
+ */
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <pineforge/engine.hpp>
+#include <pineforge/bar.hpp>
+#include <pineforge/na.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+static bool near(double a, double b, double tol = 1e-6) {
+    return std::fabs(a - b) <= tol;
+}
+
+namespace {
+
+// Open-guaranteed flip-stop probe — same shape as
+// validation/95-multi-cycle-open-guaranteed-stops:
+//   - bar 1 (down):  enter SE short stop @ high*10, cancel LE
+//   - bar 2 (up):    enter LE long stop @ low*0.1, cancel SE,
+//                    close prior short if any
+// Stop levels are engineered so the fill price is always next bar's
+// open (high*10 always >= low → SE fills at min(open, high*10)=open;
+// low*0.1 always <= high → LE fills at max(open, low*0.1)=open). This
+// makes the fill price independent of any sub-bar path so per-leg PnL
+// drift can only come from the carry-qty schedule.
+class DeferredFlipProbe : public BacktestEngine {
+public:
+    struct TradeRow { std::string entry_id; double qty; double pnl; };
+    std::vector<TradeRow> closed_trades;
+
+    DeferredFlipProbe() {
+        initial_capital_ = 1'000'000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        slippage_ = 0;
+        commission_value_ = 0;
+        pyramiding_ = 1;
+        // The deferred-flip rule is gated on the script having a
+        // ``strategy.close`` call at compile time. The codegen would
+        // set this flag from an AST scan; here we set it directly.
+        script_has_strategy_close_ = true;
+    }
+
+    void on_bar(const Bar& bar) override {
+        bool isDown = (bar_index_ % 2) == 0;  // bars 0,2,4,... are "down"
+        bool isUp   = (bar_index_ % 2) == 1;  // bars 1,3,5,... are "up"
+
+        if (isDown) {
+            // Short stop priced at high*10 — guaranteed to fill at next
+            // bar's open (low <= high*10 always true).
+            strategy_entry("SE", /*is_long=*/false,
+                           std::numeric_limits<double>::quiet_NaN(),
+                           /*stop_price=*/bar.high * 10.0,
+                           /*qty=*/1.0,
+                           "open-guaranteed short");
+            strategy_cancel("LE");
+        }
+        if (isUp) {
+            strategy_entry("LE", /*is_long=*/true,
+                           std::numeric_limits<double>::quiet_NaN(),
+                           /*stop_price=*/bar.low * 0.1,
+                           /*qty=*/1.0,
+                           "open-guaranteed long");
+            strategy_cancel("SE");
+        }
+        // Daily flip-flat closes happen AFTER the entries are placed,
+        // mirroring probe 95 source order. Empty id closes everything.
+        if (isDown && position_side_ == PositionSide::LONG) {
+            strategy_close("LE", "flip flat long");
+        }
+        if (isUp && position_side_ == PositionSide::SHORT) {
+            strategy_close("SE", "flip flat short");
+        }
+
+        // Snapshot at run end so the test can inspect the closed trades
+        // after the bar loop returns. Subclass has access to protected
+        // ``trades_``; the harness does not.
+        last_bar_index_seen = bar_index_;
+        closed_trades.clear();
+        for (const auto& t : trades_) {
+            closed_trades.push_back({t.entry_id, t.qty, t.pnl});
+        }
+    }
+
+    int last_bar_index_seen = -1;
+};
+
+}  // namespace
+
+// Scenario 1: deferred-flip oracle (probe 95-style). Cycle qty grows
+// 1, 1, 2, 2, 3, 3, ... — each cycle pair is a flip from prior side
+// followed by a fresh entry of the next-larger size. With the carry
+// rule working correctly, the qty chain ascends; without it, qty stays
+// stuck at 1.
+static void test_deferred_flip_chain_grows() {
+    std::printf("test_deferred_flip_chain_grows\n");
+    DeferredFlipProbe p;
+
+    // Build a simple OHLCV: each bar is a tight 2-tick range so high*10
+    // and low*0.1 produce extreme stops. Open price drifts so each
+    // cycle's fill price differs.
+    constexpr int N = 12;
+    Bar bars[N];
+    double open_price = 100.0;
+    for (int i = 0; i < N; ++i) {
+        bars[i].open  = open_price;
+        bars[i].high  = open_price + 1.0;
+        bars[i].low   = open_price - 1.0;
+        bars[i].close = open_price;
+        bars[i].volume = 1000.0;
+        bars[i].timestamp = (int64_t)(i + 1) * 60'000;
+        open_price += 5.0;
+    }
+
+    p.run(bars, N);
+
+    // First entry should be qty=1 (no prior carry). Each subsequent
+    // entry from FLAT after a strategy.close should grow by previous
+    // qty (carry).
+    CHECK(p.closed_trades.size() >= 4);
+
+    // Check that qty chain grows (the carry rule must apply at least
+    // once). This catches the bug where mis-cycled carry would leave
+    // qty stuck at 1.
+    int max_qty = 0;
+    for (const auto& tr : p.closed_trades) {
+        if ((int)tr.qty > max_qty) max_qty = (int)tr.qty;
+    }
+    CHECK(max_qty >= 2);
+}
+
+// Scenario 2: deferred-flip is gated on opposite direction. A
+// pre-armed SAME-direction priced entry (long stop placed during a
+// long, position closes, long stop later fires from flat) should NOT
+// apply carry — TV only flips qty when the new direction is OPPOSITE
+// to the carry source.
+static void test_same_direction_no_carry() {
+    std::printf("test_same_direction_no_carry\n");
+    class SameDirProbe : public BacktestEngine {
+    public:
+        struct TradeRow { std::string entry_id; double qty; };
+        std::vector<TradeRow> closed_trades;
+        double final_position_qty = 0.0;
+        PositionSide final_position_side = PositionSide::FLAT;
+
+        SameDirProbe() {
+            initial_capital_ = 1'000'000;
+            default_qty_type_ = QtyType::FIXED;
+            default_qty_value_ = 1.0;
+            slippage_ = 0;
+            commission_value_ = 0;
+            pyramiding_ = 1;
+            script_has_strategy_close_ = true;
+        }
+        void on_bar(const Bar& bar) override {
+            if (bar_index_ == 0) {
+                strategy_entry("L1", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               std::numeric_limits<double>::quiet_NaN(),
+                               2.0, "first long qty 2");
+            }
+            // Bar 1: while long-2, place SAME-direction long stop +
+            // close current long. Stop fires next bar from flat.
+            if (bar_index_ == 1 && position_side_ == PositionSide::LONG) {
+                strategy_entry("L2", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               /*stop=*/bar.low * 0.1,
+                               1.0, "L2 same dir stop");
+                strategy_close("L1", "close first long");
+            }
+            // Bar 4: snapshot final state.
+            if (bar_index_ == 4) {
+                final_position_qty = position_qty_;
+                final_position_side = position_side_;
+                for (const auto& t : trades_) {
+                    closed_trades.push_back({t.entry_id, t.qty});
+                }
+            }
+        }
+    };
+    SameDirProbe p;
+    Bar bars[5] = {
+        {100, 101,  99, 100, 1000,  60'000},
+        {100, 101,  99, 100, 1000, 120'000},  // place L2 + close L1
+        {100, 101,  99, 100, 1000, 180'000},  // L1 close fires; L2 fires from flat — qty should be 1
+        {100, 101,  99, 100, 1000, 240'000},
+        {100, 101,  99, 100, 1000, 300'000},
+    };
+    p.run(bars, 5);
+
+    // L2 should have qty 1 (no carry applied since direction == carry-source direction).
+    // Either it closed with qty 1, or it's the open position with qty 1
+    // (the test bars are too short to drive a separate exit).
+    bool found_l2 = false;
+    for (const auto& tr : p.closed_trades) {
+        if (tr.entry_id == "L2") {
+            CHECK(near(tr.qty, 1.0));
+            found_l2 = true;
+        }
+    }
+    if (!found_l2 && p.final_position_side == PositionSide::LONG) {
+        // L2 fired and is open at end. Verify no carry leaked.
+        CHECK(near(p.final_position_qty, 1.0));
+    }
+}
+
+// Scenario 3: cycle-scope sibling carry independence. Two short stops
+// armed in DIFFERENT position cycles. The earlier sibling fires while
+// the later sibling is still pending — without the cycle-scope guard,
+// the firing sibling's consume call zeros the later sibling's carry,
+// so when the later sibling eventually fires from flat it opens at
+// just qty=base instead of qty=base+carry.
+//
+// Trade shape (two pending shorts coexist when the first fires):
+//   bar 0: long LA opened (qty=1).
+//   bar 1: place A_far short stop priced FAR BELOW the bar range
+//          (stop=1.0) so it cannot fire on bar 2. close LA. A_far
+//          captures carry=1 (cycle A), created_bar=1.
+//   bar 2: LA closes. A_far still pending (low=99 > stop=1).
+//   bar 3: long LB opened (qty=1).
+//   bar 4: place B_close short stop priced JUST BELOW low (stop=low-0.5).
+//          close LB. B_close captures carry=1 (cycle B), created_bar=4.
+//          Position is still LONG (close is queued for next bar).
+//   bar 5: LB close fires at open. B_close stop is below this bar's
+//          low, so it fires THIS bar from flat. consume(B_close) walks
+//          pending_orders; A_far is a same-direction sibling. With the
+//          scope guard, A_far's created_bar (1) is < B_close's
+//          created_bar (4), so the guard does NOT skip — A_far IS
+//          consumed.
+//
+// To test the OPPOSITE direction (sibling placed LATER preserved when
+// EARLIER one fires), we need:
+//   bar 1: place EARLY short S_early with stop in range. close LA.
+//   bar 2: S_early fires from flat. consume(S_early) walks pending; we
+//          want a LATER-placed sibling preserved.
+// But on bar 2 the later sibling doesn't exist yet (cycle B hasn't
+// started). So this only matters when:
+//   - cycle A places S with FAR stop (won't fire bar 2)
+//   - cycle B starts, places S2 with NEAR stop
+//   - then S's stop is touched LATER
+// In that case, S firing must NOT consume S2's carry.
+//
+// The test below uses this exact pattern. We make A_in_range start as
+// the EARLIER sibling and engineer prices so it fires LATER (after B's
+// placement). After A fires, B should still have its carry.
+static void test_two_cycle_siblings_independent_carry() {
+    std::printf("test_two_cycle_siblings_independent_carry\n");
+    // Engineer two short-stop siblings with DIFFERENT created_bars but
+    // both still pending when one of them fires from flat. The earlier
+    // sibling is given a stop in range so it fires AFTER the later
+    // sibling has been placed.
+    //
+    // Setup:
+    //   bar 0: long LA opened (qty=1).
+    //   bar 1: arm A short stop at price 90 (close stop, but bar lows
+    //          stay above 90 until bar 6) + close LA. A captures
+    //          carry=1, created_bar=1.
+    //   bar 2: LA closes.
+    //   bar 3: long LB opened (qty=1).
+    //   bar 4: arm B short stop at price 1 (won't fire) + close LB. B
+    //          captures carry=1, created_bar=4. Both A and B now
+    //          pending; A.created_bar (1) < B.created_bar (4).
+    //   bar 5: LB closes.
+    //   bar 6: price drops; A's stop=90 is touched → A fires from FLAT
+    //          with carry=1+1=2. consume_tv_carry_from_siblings(A)
+    //          walks pending_orders_, finds B with same direction,
+    //          same created_position_side=LONG. Without the scope
+    //          guard: B.tv_carry_qty zeroed. With the scope guard:
+    //          B.created_bar (4) > A.created_bar (1) → guard skips B,
+    //          B's carry is preserved.
+    //   bar 7+: snapshot B's tv_carry_qty in pending_orders_. With the
+    //          fix, B still has carry=1.
+    class TwoCycleSiblingProbe : public BacktestEngine {
+    public:
+        struct PendingSnap { std::string id; double carry; int created_bar; };
+        std::vector<PendingSnap> pending_at_end;
+
+        TwoCycleSiblingProbe() {
+            initial_capital_ = 1'000'000;
+            default_qty_type_ = QtyType::FIXED;
+            default_qty_value_ = 1.0;
+            slippage_ = 0;
+            commission_value_ = 0;
+            pyramiding_ = 5;
+            script_has_strategy_close_ = true;
+        }
+        void on_bar(const Bar& bar) override {
+            (void)bar;
+            if (bar_index_ == 0) {
+                strategy_entry("LA", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               std::numeric_limits<double>::quiet_NaN(),
+                               1.0, "long A");
+            }
+            if (bar_index_ == 1 && position_side_ == PositionSide::LONG) {
+                strategy_entry("A", false,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               /*stop=*/90.0,
+                               1.0, "A short — stops at 90");
+                strategy_close("LA", "close long A");
+            }
+            if (bar_index_ == 3 && position_side_ == PositionSide::FLAT) {
+                strategy_entry("LB", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               std::numeric_limits<double>::quiet_NaN(),
+                               1.0, "long B");
+            }
+            if (bar_index_ == 4 && position_side_ == PositionSide::LONG) {
+                strategy_entry("B", false,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               /*stop=*/1.0,
+                               1.0, "B short — far stop");
+                strategy_close("LB", "close long B");
+            }
+            // Bar 7 snapshot — A should have fired by now (bar 6 had a
+            // price drop touching A's stop 90); B should still be
+            // pending with its carry intact thanks to the scope guard.
+            if (bar_index_ == 7) {
+                for (const auto& po : pending_orders_) {
+                    pending_at_end.push_back({po.id, po.tv_carry_qty,
+                                               po.created_bar});
+                }
+            }
+        }
+    };
+    TwoCycleSiblingProbe p;
+    Bar bars[8];
+    // Bars 0..5: prices ~100±1, lows above 90.
+    // Bar 6: price drop, low 85 → A's stop=90 triggers.
+    // Bar 7: prices recover to ~95.
+    double opens[8]      = { 100, 100, 100, 100, 100, 100, 95, 95 };
+    double highs[8]      = { 101, 101, 101, 101, 101, 101, 96, 96 };
+    double lows[8]       = {  99,  99,  99,  99,  99,  99, 85, 94 };
+    double closes[8]     = { 100, 100, 100, 100, 100, 100, 90, 95 };
+    for (int i = 0; i < 8; ++i) {
+        bars[i].open      = opens[i];
+        bars[i].high      = highs[i];
+        bars[i].low       = lows[i];
+        bars[i].close     = closes[i];
+        bars[i].volume    = 1000.0;
+        bars[i].timestamp = (int64_t)(i + 1) * 60'000;
+    }
+    p.run(bars, 8);
+
+    bool b_seen = false;
+    for (const auto& ps : p.pending_at_end) {
+        if (ps.id == "B") {
+            b_seen = true;
+            // With the cycle-scope guard: B's carry preserved (=1).
+            // Without the guard: B's carry zeroed (=0).
+            CHECK(near(ps.carry, 1.0));
+        }
+    }
+    CHECK(b_seen);
+}
+
+int main() {
+    test_deferred_flip_chain_grows();
+    test_same_direction_no_carry();
+    test_two_cycle_siblings_independent_carry();
+
+    std::printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- **fix(orders)**: tighten `consume_tv_carry_from_siblings` with a per-bar `created_bar` scope so a sibling armed in a LATER position cycle keeps its carry when an EARLIER-cycle sibling fires from FLAT. Pre-fix, the consume pass zeroed all same-direction siblings unconditionally — when two pending priced entries from different cycles coexisted, the qty schedule shifted by one full cycle and per-leg PnL drifted by ~`qty x mintick`.
- **fix(fills)**: gate `cancel_oca_group` dispatch on the originating order being FULLY filled (`filled_qty + 1e-12 >= order.qty`). Pre-fix, an OCA-CANCEL sibling whose qty exceeded the open position size would still wipe its CANCEL siblings on the partial fill; TV waits for the originating order to fully transact before cancelling.

`cancel_oca_group` and `reduce_oca_group` already scoped by `oca_name`, so cross-group isolation was already correct on that path. The two new tests guard both invariants.

## Test plan

- [x] `ctest --test-dir build --output-on-failure` -> 24/24 passing (added `test_strategy_pyramiding`, extended `test_strategy_oca`)
- [x] Both new tests fail when their respective fix is reverted (verified via patch -R)
- [x] Corpus parity sweep (`validator/validate.py` against full 197-strategy corpus) -> 177/197 excellent (unchanged from baseline; no regressions). The 6 deferred-flip probes (52, 63, 72, 93, 95, 96) and the 2 OCA-using probes (basic/greedy, validation/44-oca-reduce-orders) remain excellent. The two `validation_oca/oca-three-way-probe-*` files still report `no_compare_trades_interior` because their TV trades csv pre-dates the corpus OHLCV window — unchanged from before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)