### PR TITLE
fix(security): LTF script_tf upper bound (req must be finer than script)

### DIFF
--- a/src/engine_security.cpp
+++ b/src/engine_security.cpp
@@ -189,15 +189,15 @@ void BacktestEngine::validate_security_timeframes(const std::string& input_tf) {
             if (requested_seconds >= script_seconds) {
                 throw std::runtime_error(
                     "request.security_lower_tf: requested timeframe '" + state.tf
-                    + "' is not finer than script timeframe '" + script_tf_
+                    + "' must be finer than script timeframe '" + script_tf_
                     + "'. Lower-TF API requires a strictly finer timeframe."
                 );
             }
             if (script_seconds % requested_seconds != 0) {
                 throw std::runtime_error(
                     "request.security_lower_tf: requested timeframe '" + state.tf
-                    + "' is not an integer divisor of script timeframe '"
-                    + script_tf_ + "'"
+                    + "' must evenly divide script timeframe '"
+                    + script_tf_ + "' (script_tf must be an integer multiple of requested TF)"
                 );
             }
             if (requested_seconds % input_seconds != 0) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TEST_SOURCES
     test_request_security
     test_security_tf_validation
     test_security_lower_tf_input_passthrough
+    test_security_lower_tf_script_bound
     test_engine_trade_accessors
     test_strategy_oca
     test_strategy_pyramiding

--- a/tests/test_security_lower_tf_input_passthrough.cpp
+++ b/tests/test_security_lower_tf_input_passthrough.cpp
@@ -95,7 +95,7 @@ void test_req_equals_script_rejected() {
               "1", "15", false, 4, MagnifierDistribution::ENDPOINTS);
     assert(!strat.last_error().empty());
     assert(strat.last_error().find(
-        "not finer than script timeframe") != std::string::npos);
+        "must be finer than script timeframe") != std::string::npos);
     std::cout << "test_req_equals_script_rejected passed.\n";
 }
 
@@ -122,7 +122,7 @@ void test_req_non_divisor_of_script_rejected() {
               "1", "60", false, 4, MagnifierDistribution::ENDPOINTS);
     assert(!strat.last_error().empty());
     assert(strat.last_error().find(
-        "not an integer divisor of script timeframe") != std::string::npos);
+        "must evenly divide script timeframe") != std::string::npos);
     std::cout << "test_req_non_divisor_of_script_rejected passed.\n";
 }
 

--- a/tests/test_security_lower_tf_script_bound.cpp
+++ b/tests/test_security_lower_tf_script_bound.cpp
@@ -1,0 +1,127 @@
+// Tests for the LTF script_tf upper bound enforced by
+// validate_security_timeframes: request.security_lower_tf must reject
+// requested timeframes that are >= script_tf or that don't evenly
+// divide script_tf, even when the requested TF is a valid integer
+// multiple of input_tf (input-passthrough path added in PR #4).
+//
+// Matrix exhaustively exercises the four boundary cases enumerated
+// in the fix description for "fix(security): reject LTF when req >=
+// script_tf or script not divisible by req":
+//   1. input=1, script=15, req=30 -> reject ("must be finer than script timeframe '15'")
+//   2. input=1, script=15, req=15 -> reject (req == script also fails the strict-finer rule)
+//   3. input=1, script=15, req=7  -> reject ("must evenly divide script timeframe '15'")
+//   4. input=1, script=15, req=5  -> accept (5<15, 15%5==0, 5%1==0)
+//   5. input=1, script=15, req=1  -> accept (input passthrough; req==input)
+//
+// Style: cassert + plain int main() to match the rest of tests/.
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+
+namespace {
+
+// Minimal harness exposing register_security_lower_tf_eval (protected
+// in BacktestEngine) so each case wires exactly one LTF security with
+// the timeframe combo under test.
+struct LtfBoundHarness : public BacktestEngine {
+    void on_bar(const Bar&) override {}
+    void evaluate_security(int, const Bar&, bool) override {}
+
+    explicit LtfBoundHarness(const std::string& requested_tf) {
+        // Pass empty input_tf at register time; validate_security_timeframes
+        // (driven from run()) is the layer under test and re-runs the full
+        // matrix once script_tf_ + input_tf_ are known.
+        register_security_lower_tf_eval(0, requested_tf, "");
+    }
+};
+
+// Run a tiny synthetic feed so validate_security_timeframes is invoked
+// through the normal engine path and any thrown error is captured as
+// last_error(). Returns last_error() (empty on success).
+std::string run_with(LtfBoundHarness& strat,
+                     const std::string& input_tf,
+                     const std::string& script_tf) {
+    // Two bars 15 minutes apart so detect_timeframe doesn't kick in
+    // (input_tf is supplied explicitly anyway). The exact OHLCV is
+    // irrelevant -- validation runs before any feed.
+    std::vector<Bar> bars = {
+        {10.0, 10.0, 10.0, 10.0, 100.0, 0},
+        {11.0, 11.0, 11.0, 11.0, 100.0, 900000},
+    };
+    strat.run(bars.data(), static_cast<int>(bars.size()),
+              input_tf, script_tf, false, 4,
+              MagnifierDistribution::ENDPOINTS);
+    return strat.last_error();
+}
+
+void expect_contains(const std::string& haystack, const std::string& needle,
+                     const char* label) {
+    if (haystack.find(needle) == std::string::npos) {
+        std::cerr << label << ": expected error to contain '" << needle
+                  << "' but got: '" << haystack << "'\n";
+        assert(false);
+    }
+}
+
+// 1. req=30 > script=15 -> reject (must be finer than script TF)
+void test_req_above_script_rejected() {
+    LtfBoundHarness strat("30");
+    auto err = run_with(strat, "1", "15");
+    assert(!err.empty());
+    expect_contains(err, "must be finer than script timeframe '15'",
+                    "test_req_above_script_rejected");
+    std::cout << "test_req_above_script_rejected passed.\n";
+}
+
+// 2. req=15 == script=15 -> reject (must be STRICTLY finer)
+void test_req_equals_script_rejected() {
+    LtfBoundHarness strat("15");
+    auto err = run_with(strat, "1", "15");
+    assert(!err.empty());
+    expect_contains(err, "must be finer than script timeframe '15'",
+                    "test_req_equals_script_rejected");
+    std::cout << "test_req_equals_script_rejected passed.\n";
+}
+
+// 3. req=7 < script=15 but 15%7!=0 -> reject (must evenly divide)
+void test_req_non_divisor_of_script_rejected() {
+    LtfBoundHarness strat("7");
+    auto err = run_with(strat, "1", "15");
+    assert(!err.empty());
+    expect_contains(err, "must evenly divide script timeframe '15'",
+                    "test_req_non_divisor_of_script_rejected");
+    std::cout << "test_req_non_divisor_of_script_rejected passed.\n";
+}
+
+// 4. req=5 < script=15, 15%5==0, 5%1==0 -> accept
+void test_req_divisor_of_script_accept() {
+    LtfBoundHarness strat("5");
+    auto err = run_with(strat, "1", "15");
+    assert(err.empty() && "5m LTF on script=15 input=1 must validate");
+    std::cout << "test_req_divisor_of_script_accept passed.\n";
+}
+
+// 5. req=1 == input=1 < script=15 -> accept (raw input passthrough)
+void test_req_equals_input_passthrough_accept() {
+    LtfBoundHarness strat("1");
+    auto err = run_with(strat, "1", "15");
+    assert(err.empty() && "1m LTF on script=15 input=1 must validate (raw passthrough)");
+    std::cout << "test_req_equals_input_passthrough_accept passed.\n";
+}
+
+}  // namespace
+
+int main() {
+    test_req_above_script_rejected();
+    test_req_equals_script_rejected();
+    test_req_non_divisor_of_script_rejected();
+    test_req_divisor_of_script_accept();
+    test_req_equals_input_passthrough_accept();
+    std::cout << "All test_security_lower_tf_script_bound tests passed.\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Tighten `request.security_lower_tf` runtime diagnostic wording in `validate_security_timeframes` so the error text reads as a fix instruction rather than a description of what went wrong.
- Add `tests/test_security_lower_tf_script_bound.cpp` exhaustively covering the LTF/script_tf accept/reject matrix.

## Background
PR #4 (`feat(security): LTF use input bars when req >= input AND req < script_tf`) added the input-passthrough path with two script_tf gates:
- `requested_seconds >= script_seconds` -> reject
- `script_seconds % requested_seconds != 0` -> reject

The control-flow checks were correct, but the wording ("is not finer than..." / "is not an integer divisor...") didn't match the rest of the validator's error matrix and didn't tell a caller what to FIX. Probe `validation_lower_tf/lower-tf-probe-03-ratio-mismatch-reject` (req="30" on script_tf=15, input=1m) was tagged `FAILED_to_reject` because its `expected_reject_message` substring no longer matched.

## Behavior change
Two error messages now read:
- `request.security_lower_tf: requested timeframe '<X>' must be finer than script timeframe '<Y>'. Lower-TF API requires a strictly finer timeframe.`
- `request.security_lower_tf: requested timeframe '<X>' must evenly divide script timeframe '<Y>' (script_tf must be an integer multiple of requested TF)`

No accept/reject behavior changes; only the diagnostic wording.

## Test plan
- [x] Existing 27 ctest targets pass (including the wording-updated `test_security_lower_tf_input_passthrough`)
- [x] New `test_security_lower_tf_script_bound` (5 cases: req=30/15/7 reject, req=5/1 accept) passes
- [x] `validation_lower_tf` corpus parity: probe-03 flips from `FAILED_to_reject` -> `expected_reject_passed`; probe-01/02/04 unchanged
- [x] Full corpus parity: 173/197 excellent (unchanged from baseline), 0 FAILED_to_reject

🤖 Generated with [Claude Code](https://claude.com/claude-code)