### PR TITLE
fix: pyramiding per-leg PnL + OCA cross-bracket isolation

### DIFF
--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -369,7 +369,9 @@ protected:
                        double trail_offset = std::numeric_limits<double>::quiet_NaN(),
                        double trail_price = std::numeric_limits<double>::quiet_NaN(),
                        double qty_percent = 100.0,
-                       const std::string& comment = "");
+                       const std::string& comment = "",
+                       double qty = std::numeric_limits<double>::quiet_NaN(),
+                       const std::string& oca_name = "");
     void strategy_cancel(const std::string& id);
     void strategy_cancel_all();
     void strategy_order(const std::string& id, bool is_long, double qty,

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -314,6 +314,14 @@ void BacktestEngine::run_simple_bar_loop(const Bar* input_bars, int n_input) {
         is_last_tick_ = true;
         barstate_islast_ = (i == n_input - 1);
         diag_script_bars_processed_++;
+        // Reset per-bar pending-close accumulator. Each on_bar call captures
+        // fresh ``strategy.close*`` qty for the same-bar close-then-entry
+        // source-order rule (see engine.hpp). Without the reset the
+        // accumulator monotonically grows and starves every subsequent
+        // priced-entry's tv_carry_qty (validation/52, 63, 72, 93, 95, 96
+        // pre-fix: per-leg PnL drifts because the deferred-flip carry
+        // chain is wiped after the first fire).
+        pending_close_qty_in_bar_ = 0.0;
 
         // Feed security evaluators
         for (auto& state : security_eval_states_) {
@@ -368,6 +376,11 @@ void BacktestEngine::run_aggregation_bar_loop(const Bar* input_bars, int n_input
             emitted_script_bars++;
             barstate_islast_ = (emitted_script_bars == expected_script_bars);
             diag_script_bars_processed_++;
+            // Reset per-bar pending-close accumulator. See run_simple_bar_loop
+            // for the regression history; the aggregated path was missing the
+            // same reset, which is why all 8 affected probes are scripts that
+            // run with input_tf < script_tf (1m feeds, 15m strategies).
+            pending_close_qty_in_bar_ = 0.0;
 
             if (bar_magnifier && !group_sub_bars.empty()) {
                 // Magnifier mode: process sub-bars with price path sampling

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -199,9 +199,20 @@ void BacktestEngine::strategy_exit(const std::string& id, const std::string& fro
                                     double limit_price, double stop_price,
                                     double trail_points, double trail_offset,
                                     double trail_price, double qty_percent,
-                                    const std::string& comment) {
+                                    const std::string& comment,
+                                    double qty, const std::string& oca_name) {
     if (!trading_is_active(current_bar_.timestamp, trade_start_time_)) return;
+    bool has_explicit_qty = !std::isnan(qty);
     double qp = std::isnan(qty_percent) ? 100.0 : std::clamp(qty_percent, 0.0, 100.0);
+    // If an explicit qty is given, derive an effective qp from the current
+    // position size so downstream FIFO accounting (compute_exit_reserved_qty,
+    // already-reserved tally, etc.) sees a consistent fraction. The order
+    // itself stores the absolute qty so the per-fill execution path
+    // honours the literal request.
+    if (has_explicit_qty && position_qty_ > 1e-10) {
+        double clamped_qty = std::min(qty, position_qty_);
+        qp = (clamped_qty / position_qty_) * 100.0;
+    }
     bool is_partial = qp < 100.0 - 1e-9;
     bool has_trail_request = !std::isnan(trail_points);
 
@@ -217,9 +228,39 @@ void BacktestEngine::strategy_exit(const std::string& id, const std::string& fro
                               preserved_seq, preserved_reserved_qty);
 
     double reserved_qty = std::numeric_limits<double>::quiet_NaN();
-    if (!compute_exit_reserved_qty(from_entry, preserved_reserved_qty,
-                                   qp, is_partial, reserved_qty)) {
-        return;
+    if (has_explicit_qty) {
+        // Honour the explicit qty literally (clamped to the live position
+        // and subject to the same already-reserved accounting). This is
+        // the path Pine's ``strategy.exit(... qty=N)`` follows when N is
+        // strictly smaller than the open position size — required for
+        // multi-bracket per-position exits (validation_oca/oca-three-way-
+        // probe-02 has two qty=1 brackets attached to a qty=2 entry).
+        if (position_side_ == PositionSide::FLAT) {
+            // Defer placement; FIFO accounting will recompute when a
+            // position eventually exists.
+            reserved_qty = std::min(qty, std::numeric_limits<double>::infinity());
+        } else {
+            double already_reserved = 0.0;
+            for (const auto& o : pending_orders_) {
+                if (o.type != OrderType::EXIT || o.from_entry != from_entry) continue;
+                if (!std::isnan(o.qty)) {
+                    already_reserved += o.qty;
+                } else {
+                    double oqp = std::isnan(o.qty_percent) ? 100.0
+                        : std::clamp(o.qty_percent, 0.0, 100.0);
+                    already_reserved += position_qty_ * (oqp / 100.0);
+                }
+            }
+            double available = std::max(0.0, position_qty_ - already_reserved);
+            reserved_qty = std::min(qty, available);
+            if (reserved_qty <= 1e-10) return;
+        }
+        is_partial = reserved_qty < position_qty_ - 1e-9;
+    } else {
+        if (!compute_exit_reserved_qty(from_entry, preserved_reserved_qty,
+                                       qp, is_partial, reserved_qty)) {
+            return;
+        }
     }
 
     PendingOrder order;
@@ -235,8 +276,15 @@ void BacktestEngine::strategy_exit(const std::string& id, const std::string& fro
     order.qty_type = -1;
     order.qty_percent = qp;
     order.requested_partial = is_partial;
-    order.oca_name = "";
-    order.oca_type = 0;
+    // OCA-name plumbing: ``strategy.exit`` supports oca_name (Pine v6) so
+    // siblings in different OCA groups can fire independently. The cancel
+    // sweep predicate (engine_fills.cpp::apply_filled_order_to_state →
+    // cancel_oca_group) already isolates groups by name; without this
+    // assignment all strategy.exit-issued orders shared an empty name and
+    // the first bracket's TP would silently leave the other bracket's
+    // legs intact (probe oca-three-way-02 lost ~42% of its trades).
+    order.oca_name = oca_name;
+    order.oca_type = oca_name.empty() ? 0 : 1;  // strategy.exit semantics: cancel
     order.created_bar = bar_index_;
     order.created_seq = preserved_seq > 0 ? preserved_seq : next_order_seq_++;
     order.created_position_side = position_side_;

--- a/tests/test_strategy_oca.cpp
+++ b/tests/test_strategy_oca.cpp
@@ -391,6 +391,111 @@ static void test_none_unchanged() {
     if (b) CHECK(near(b->qty, 5.0));
 }
 
+// Two strategy.exit brackets attached to the same long entry, each with
+// its own qty + oca_name. Tests that:
+//   (a) ``qty=N`` on strategy.exit is honoured as an absolute reservation
+//       (so two qty=1 brackets coexist against a qty=2 position instead
+//       of the first one swallowing 100% of the position).
+//   (b) When bracket A's TP fires, only Group A siblings are cancelled —
+//       Group B remains pending and can fire later.
+//
+// Pre-fix: ``strategy_exit`` ignored both ``qty`` and ``oca_name`` (the
+// codegen warned + dropped them). Symptoms in
+// validation_oca/oca-three-way-probe-02-multi-group-partial: TV=1242
+// trades, engine=716 trades (engine misses ~42% because the first
+// bracket's qty_percent=100 reserved the whole position so the second
+// bracket never placed).
+static void test_strategy_exit_two_brackets_independent_oca_groups() {
+    std::printf("test_strategy_exit_two_brackets_independent_oca_groups\n");
+    class TwoBracketProbe : public BacktestEngine {
+    public:
+        struct TradeRow {
+            std::string entry_id;
+            std::string exit_id;
+            double qty;
+            double exit_price;
+        };
+        std::vector<TradeRow> closed_trades;
+
+        TwoBracketProbe() {
+            initial_capital_ = 1'000'000;
+            default_qty_type_ = QtyType::FIXED;
+            default_qty_value_ = 2.0;
+            slippage_ = 0;
+            commission_value_ = 0;
+            pyramiding_ = 1;
+        }
+        void on_bar(const Bar& bar) override {
+            (void)bar;
+            // Bar 0: open long qty 2 (default_qty_value_).
+            if (bar_index_ == 0) {
+                strategy_entry("L", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               std::numeric_limits<double>::quiet_NaN(),
+                               2.0, "long entry");
+            }
+            // Bars 1+: while long, attach two qty=1 brackets in distinct
+            // OCA groups. Bracket A is tight (TP=110, SL=90); bracket B
+            // is wide (TP=130, SL=70).
+            if (position_side_ == PositionSide::LONG) {
+                strategy_exit("X_A", "L",
+                              /*limit=*/110.0, /*stop=*/90.0,
+                              /*trail_points=*/std::numeric_limits<double>::quiet_NaN(),
+                              /*trail_offset=*/std::numeric_limits<double>::quiet_NaN(),
+                              /*trail_price=*/std::numeric_limits<double>::quiet_NaN(),
+                              /*qty_percent=*/100.0,
+                              /*comment=*/"X_A",
+                              /*qty=*/1.0,
+                              /*oca_name=*/"GRP_A");
+                strategy_exit("X_B", "L",
+                              /*limit=*/130.0, /*stop=*/70.0,
+                              /*trail_points=*/std::numeric_limits<double>::quiet_NaN(),
+                              /*trail_offset=*/std::numeric_limits<double>::quiet_NaN(),
+                              /*trail_price=*/std::numeric_limits<double>::quiet_NaN(),
+                              /*qty_percent=*/100.0,
+                              /*comment=*/"X_B",
+                              /*qty=*/1.0,
+                              /*oca_name=*/"GRP_B");
+            }
+            if (bar_index_ == 6) {
+                for (const auto& t : trades_) {
+                    closed_trades.push_back({t.entry_id, t.exit_id, t.qty, t.exit_price});
+                }
+            }
+        }
+    };
+    TwoBracketProbe p;
+    Bar bars[7];
+    // Bar 1 fills L at open=100. Bar 2: high=112 → X_A's TP=110 fires
+    // (qty=1). Bar 3: high=132 → X_B's TP=130 fires (qty=1). Both
+    // brackets must trigger independently; pre-fix only X_A would.
+    double opens[7]  = { 100, 100, 105, 120, 120, 120, 120 };
+    double highs[7]  = { 101, 105, 112, 132, 121, 121, 121 };
+    double lows[7]   = {  99,  99, 104, 119, 119, 119, 119 };
+    double closes[7] = { 100, 105, 112, 130, 120, 120, 120 };
+    for (int i = 0; i < 7; ++i) {
+        bars[i].open      = opens[i];
+        bars[i].high      = highs[i];
+        bars[i].low       = lows[i];
+        bars[i].close     = closes[i];
+        bars[i].volume    = 1000.0;
+        bars[i].timestamp = (int64_t)(i + 1) * 60'000;
+    }
+    p.run(bars, 7);
+
+    // Both bracket fires must produce a trade. With the bug, only X_A
+    // fired (X_B was never placed because X_A reserved 100% of qty).
+    CHECK(p.closed_trades.size() == 2);
+    bool seen_a = false, seen_b = false;
+    for (const auto& tr : p.closed_trades) {
+        CHECK(near(tr.qty, 1.0));
+        if (tr.exit_id == "X_A") { seen_a = true; CHECK(near(tr.exit_price, 110.0)); }
+        if (tr.exit_id == "X_B") { seen_b = true; CHECK(near(tr.exit_price, 130.0)); }
+    }
+    CHECK(seen_a);
+    CHECK(seen_b);
+}
+
 int main() {
     test_reduce_two_sibling_partial();
     test_reduce_three_sibling();
@@ -399,6 +504,7 @@ int main() {
     test_cross_group_isolation();
     test_cancel_oca_partial_fill_keeps_sibling();
     test_none_unchanged();
+    test_strategy_exit_two_brackets_independent_oca_groups();
 
     std::printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
     return tests_failed == 0 ? 0 : 1;

--- a/tests/test_strategy_pyramiding.cpp
+++ b/tests/test_strategy_pyramiding.cpp
@@ -395,10 +395,172 @@ static void test_two_cycle_siblings_independent_carry() {
     CHECK(b_seen);
 }
 
+// Scenario 4 (regression for the per-bar pending_close_qty_in_bar_ reset
+// in run_simple_bar_loop / run_aggregation_bar_loop): re-runs the
+// open-guaranteed flip-stop probe through the script_tf-aware run()
+// overload (the validator's actual code path) and asserts the per-cycle
+// qty chain ascends 1, 2, 3, ... — same shape as
+// validation/95-multi-cycle-open-guaranteed-stops, but with deterministic
+// 1m → 1m passthrough so no aggregation can mask the regression.
+//
+// Pre-fix: the bar loop never reset ``pending_close_qty_in_bar_`` so it
+// monotonically grew across bars. Once it exceeded the live position
+// size, every subsequent ``strategy.entry`` placement saw
+// ``effective_pos = max(0, pos_qty - pending_close)`` clamp to 0 and
+// captured carry=0, freezing the qty chain at base_qty=1 forever (each
+// cycle would emit a fresh qty=1 trade instead of growing). The PnL
+// formula per trade still computed (exit-entry)*qty correctly, but the
+// qty chain was wrong from cycle 4 onward — the symptom listed in the
+// task as "pnl_p90 ~ 0.5–0.92 USD/row".
+//
+// Per-trade FIFO PnL formula being verified: each emit_close_trade row
+// must equal (exit_price - leg_entry_price) * leg_qty * point_value
+// (point_value=1 here for cleanness). With pyramiding=1, each cycle has
+// exactly one PyramidEntry whose qty == cycle index N, and its entry
+// price equals the prior cycle's exit price. We assert both the qty
+// chain and the per-row PnL.
+static void test_per_bar_pending_close_resets_in_script_tf_run() {
+    std::printf("test_per_bar_pending_close_resets_in_script_tf_run\n");
+    DeferredFlipProbe p;
+
+    constexpr int N = 12;
+    Bar bars[N];
+    double open_price = 100.0;
+    for (int i = 0; i < N; ++i) {
+        bars[i].open  = open_price;
+        bars[i].high  = open_price + 1.0;
+        bars[i].low   = open_price - 1.0;
+        bars[i].close = open_price;
+        bars[i].volume = 1000.0;
+        bars[i].timestamp = (int64_t)(i + 1) * 60'000;
+        open_price += 5.0;
+    }
+
+    // Use the script_tf-aware overload (validator path). Same TF on
+    // input + script keeps the loop in run_simple_bar_loop — the same
+    // place that lacked the reset before this fix.
+    p.run(bars, N, "1", "1");
+
+    // Expect a strictly ascending qty chain: 1, 2, 3, 4, ... (the cycle
+    // count caps at the bar window length / 2). Pre-fix the chain
+    // collapses to 1, 2, 1, 1, 1, ... once pending_close_qty_in_bar_
+    // overruns the live position.
+    CHECK(p.closed_trades.size() >= 4);
+    int expected_qty = 1;
+    int max_qty = 0;
+    for (const auto& tr : p.closed_trades) {
+        CHECK((int)tr.qty == expected_qty);
+        ++expected_qty;
+        if ((int)tr.qty > max_qty) max_qty = (int)tr.qty;
+    }
+    // Sanity: chain must reach at least 4 to demonstrate the regression
+    // would have collapsed it. test_deferred_flip_chain_grows already
+    // covers the 1-bump case via the legacy direct-run overload.
+    CHECK(max_qty >= 4);
+}
+
+// Scenario 5 (per-leg FIFO PnL formula): pyramiding=3 with three
+// distinct entry prices. Each strategy.exit-driven close emits a
+// per-leg trade row whose PnL must be computed against THAT leg's
+// entry price (not the volume-weighted average), with the leg's own
+// qty. This test catches the wrong-formula regression listed in the
+// task description: snapping avg_entry across legs in the same bar
+// would produce a single qty=N row at avg-entry, not N qty=1 rows
+// each at its own leg entry.
+static void test_per_leg_fifo_pnl_three_legs() {
+    std::printf("test_per_leg_fifo_pnl_three_legs\n");
+    class ThreePyramidProbe : public BacktestEngine {
+    public:
+        struct TradeRow {
+            std::string entry_id;
+            double entry_price;
+            double exit_price;
+            double qty;
+            double pnl;
+        };
+        std::vector<TradeRow> closed_trades;
+
+        ThreePyramidProbe() {
+            initial_capital_ = 1'000'000;
+            default_qty_type_ = QtyType::FIXED;
+            default_qty_value_ = 1.0;
+            slippage_ = 0;
+            commission_value_ = 0;
+            pyramiding_ = 3;
+            script_has_strategy_close_ = true;
+        }
+        void on_bar(const Bar& bar) override {
+            (void)bar;
+            // Three sequential market entries at distinct opens: bar
+            // 0 → leg1, bar 1 → leg2, bar 2 → leg3 (each fills at the
+            // NEXT bar's open in the no-process_orders_on_close path).
+            if (bar_index_ == 0)
+                strategy_entry("L1", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               std::numeric_limits<double>::quiet_NaN(),
+                               1.0, "leg 1");
+            if (bar_index_ == 1)
+                strategy_entry("L2", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               std::numeric_limits<double>::quiet_NaN(),
+                               1.0, "leg 2");
+            if (bar_index_ == 2)
+                strategy_entry("L3", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               std::numeric_limits<double>::quiet_NaN(),
+                               1.0, "leg 3");
+            // Bar 4: full close. Engine emits ONE trade per pyramid
+            // entry — three rows total, each with its own entry price.
+            if (bar_index_ == 4 && position_side_ == PositionSide::LONG)
+                strategy_close("", "close all");
+            if (bar_index_ == 6) {
+                for (const auto& t : trades_) {
+                    closed_trades.push_back(
+                        {t.entry_id, t.entry_price, t.exit_price, t.qty, t.pnl});
+                }
+            }
+        }
+    };
+    ThreePyramidProbe p;
+    Bar bars[7];
+    double opens[7] = { 100, 110, 120, 130, 140, 145, 150 };
+    for (int i = 0; i < 7; ++i) {
+        bars[i].open      = opens[i];
+        bars[i].high      = opens[i] + 1.0;
+        bars[i].low       = opens[i] - 1.0;
+        bars[i].close     = opens[i];
+        bars[i].volume    = 1000.0;
+        bars[i].timestamp = (int64_t)(i + 1) * 60'000;
+    }
+    p.run(bars, 7, "1", "1");
+
+    // Three legs, three trade rows. Each leg's entry price is the
+    // bar AFTER the placement (market order fills at next-bar open).
+    CHECK(p.closed_trades.size() == 3);
+    if (p.closed_trades.size() == 3) {
+        // Leg 1: placed bar 0, fills bar 1 open = 110.
+        // Leg 2: placed bar 1, fills bar 2 open = 120.
+        // Leg 3: placed bar 2, fills bar 3 open = 130.
+        // All three close at bar 5 open = 145.
+        double leg_entries[3] = { 110.0, 120.0, 130.0 };
+        double exit_price = 145.0;
+        for (int i = 0; i < 3; ++i) {
+            const auto& tr = p.closed_trades[i];
+            CHECK(near(tr.entry_price, leg_entries[i]));
+            CHECK(near(tr.exit_price, exit_price));
+            CHECK(near(tr.qty, 1.0));
+            // Per-leg FIFO formula: pnl = (exit - leg_entry) * leg_qty.
+            CHECK(near(tr.pnl, (exit_price - leg_entries[i]) * 1.0));
+        }
+    }
+}
+
 int main() {
     test_deferred_flip_chain_grows();
     test_same_direction_no_carry();
     test_two_cycle_siblings_independent_carry();
+    test_per_bar_pending_close_resets_in_script_tf_run();
+    test_per_leg_fifo_pnl_three_legs();
 
     std::printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
     return tests_failed == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

Two related runtime fixes for pyramiding and multi-bracket exits:

- **fix(orders)**: bar-loop entrypoints (`run_simple_bar_loop`, `run_aggregation_bar_loop`) never reset `pending_close_qty_in_bar_` between script bars. The accumulator grew monotonically and starved every subsequent priced entry's `tv_carry_qty`, freezing the deferred-flip carry chain at qty=1 after a few cycles. Per-leg PnL therefore drifted across the chain even though trade counts matched TV exactly. Only the legacy direct `run(bars, n)` overload had the reset; the script_tf-aware overloads (the validator's actual code path) were missing it.

- **fix(fills)**: `strategy.exit(... qty=N, oca_name="GRP_X")` was dropping both parameters at the engine API surface. With `qty_percent` defaulting to 100, the first bracket reserved the whole position and subsequent brackets short-circuited; with `oca_name` empty the OCA cancel sweep returned early so independent groups could not isolate from each other. Added `qty` + `oca_name` to the `strategy_exit` API and routed the cancel sweep through `oca_name` matching.

Companion codegen change in pineforge-codegen: https://github.com/fullpass-4pass/pineforge-codegen/pull/new/fix/strategy-exit-oca-name-and-qty (drops `qty`/`oca_name` from `STRATEGY_UNSUPPORTED_PARAMS["exit"]` and emits both as the new trailing args to the runtime call).

## Corpus parity impact

Baseline (main + clean codegen): **168/197 excellent**.
After both fixes: **175/197 excellent** (+7).

Probes flipped to excellent (all previously `strong`/`minimal`):
- validation/52-stop-entry-cancel-opposite
- validation/63-dual-stop-cancel-rotation
- validation/72-cross-opposite-entry-close
- validation/93-flip-stop-pyramiding-2
- validation/95-multi-cycle-open-guaranteed-stops
- validation/96-multi-cycle-pooc-cross-bar
- validation_oca/oca-three-way-probe-02-multi-group-partial

No probes regressed.

## Per-trade PnL formula identified (Bug A)

Pre-fix engine emitted each closed-trade row as `(exit - leg_entry) * 1 * pv` because `tv_carry_qty` was zeroed after the first bar. TV emits `(exit - leg_entry) * leg_qty * pv` with `leg_qty` growing per cycle (1, 2, 3, ..., 14 in probe 95). Validator pnl_p90 dropped from 0.92 to 0 on probe 95.

## Test plan

- [x] `ctest --test-dir build` -> 26/26 pass (added `test_per_bar_pending_close_resets_in_script_tf_run`, `test_per_leg_fifo_pnl_three_legs`, `test_strategy_exit_two_brackets_independent_oca_groups`)
- [x] Corpus parity: 175/197 excellent (was 168/197)
- [x] Codegen pytest suite: 933 passed (with worktree headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)