### PR TITLE
fix(orders): same-id stop replace ordering + tv_carry_qty leak

### DIFF
--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -219,7 +219,17 @@ protected:
     PositionSide position_side_ = PositionSide::FLAT;
     double position_entry_price_ = 0.0;   // volume-weighted average (for strategy calculations)
     int64_t position_entry_time_ = 0;
-    double position_qty_ = 1.0;
+    // Position is FLAT until the first entry fires; the canonical
+    // accessor ``signed_position_size`` already reads as 0 when FLAT
+    // regardless of this default, but several internal carry- and
+    // risk-gating reads (strategy_entry's tv_carry_qty capture,
+    // check_risk_allow_entry's max-position check) read position_qty_
+    // directly. A non-zero default leaks into those reads on the very
+    // first call of any session, producing phantom carry growth (probe
+    // 62 trade #1 fired qty=2 from a default-leaked carry=1) and
+    // spuriously blocked entries when ``risk_max_position_size_=1``.
+    // Initialising to 0 keeps the canonical and direct reads aligned.
+    double position_qty_ = 0.0;
     int position_entry_count_ = 0;  // number of entries in current direction (for pyramiding)
     int position_open_bar_ = -1;    // bar_index_ when position was opened (for exit delay)
     std::vector<PyramidEntry> pyramid_entries_;  // individual entries for trade reporting

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <pineforge/engine.hpp>
+#include <pineforge/timeframe.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -29,8 +30,42 @@
 namespace pineforge {
 
 namespace {
-inline bool trading_is_active(int64_t current_ms, int64_t start_ms) {
-    return current_ms >= start_ms;
+// TradingView replays the strategy continuously from the FIRST OHLCV bar.
+// The validator's ``trade_start_time`` gate intentionally suppresses
+// strategy commands during the warmup span so TA / var accumulators
+// converge without polluting comparison output. But the gate is set to
+// ``TV first entry - input bar`` (see _trade_start_time_ms_from_tv in
+// the validator) which, on a 15m strategy fed 1m OHLCV, lands one
+// MINUTE before the first TV trade — far inside the script bar that
+// CONTAINS the first TV trade, but BEFORE the script bar that
+// PRECEDES it.
+//
+// A stop/limit placed on the immediately-preceding script bar (where
+// TV's first trade originates) is therefore dropped under the strict
+// gate, and the engine's first in-window trade fires several bars
+// later from a different placement entirely. Validation/62-same-id-
+// stop-cross-before-modify is the canonical victim: TV's 03-31 03:30
+// long entry was longFirst's 03:15 stop firing — pre-fix the 03:15
+// strategy.entry was gated, longModify at 03:30 armed a different
+// stop that fired hours later, and the validator's price-fallback
+// alignment then misaligned 64 in-window trades.
+//
+// Subtracting one script TF interval from the gate restores the
+// previous script bar's strategy commands (just enough to let
+// pre-window placements fire on the first in-window bar) without
+// re-introducing the 411 extra pre-window trades that an
+// unconditional bypass produces in continuously-firing strategies
+// like basic/volty-expan. The buffer matches TV's chart-bar
+// resolution rather than the validator-chosen input-bar resolution.
+inline bool trading_is_active(int64_t current_ms, int64_t start_ms,
+                              int script_tf_seconds) {
+    if (start_ms == std::numeric_limits<int64_t>::min()) {
+        return true;
+    }
+    int64_t buffer_ms = (script_tf_seconds > 0)
+                           ? static_cast<int64_t>(script_tf_seconds) * 1000
+                           : 0;
+    return current_ms >= start_ms - buffer_ms;
 }
 }
 
@@ -39,7 +74,7 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
                                      const std::string& comment,
                                      const std::string& oca_name, int oca_type,
                                      int qty_type) {
-    if (!trading_is_active(current_bar_.timestamp, trade_start_time_)) return;
+    if (!trading_is_active(current_bar_.timestamp, trade_start_time_, tf_to_seconds(script_tf_))) return;
 
     // TradingView broker rule: market-entry orders are admitted only
     // when ``qty * <signal-bar close> * margin_pct/100 <= equity``.
@@ -115,7 +150,21 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
     // captures the post-close position size; when entry is called BEFORE
     // close, ``pending_close_qty_in_bar_`` is still 0 and the carry
     // equals the open position.
-    double effective_pos = std::max(0.0, position_qty_ - pending_close_qty_in_bar_);
+    //
+    // Side-gate: ``position_qty_`` is undefined whenever ``position_side_``
+    // is FLAT — the engine's default ``position_qty_ = 1.0`` would leak
+    // into ``tv_carry_qty`` for the FIRST priced ``strategy.entry`` call
+    // of any session that has never opened a position before, fabricating
+    // a phantom carry. Probe 62 manifests this: the longModify stop
+    // placed at 03:30 (after the warmup gate skipped longFirst at 03:15)
+    // captured carry=1 from the default qty, then fired later with
+    // qty=2 instead of 1, breaking parity from trade #1 onward. Reading
+    // the position size through the canonical ``signed_position_size``
+    // path returns 0 when FLAT regardless of the underlying default.
+    double live_pos_qty = (position_side_ == PositionSide::FLAT)
+                              ? 0.0
+                              : position_qty_;
+    double effective_pos = std::max(0.0, live_pos_qty - pending_close_qty_in_bar_);
     order.tv_carry_qty = effective_pos;
     order.comment = comment;
 
@@ -146,7 +195,7 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
 
 void BacktestEngine::strategy_close(const std::string& id, const std::string& comment,
                                     double qty, double qty_percent, bool immediately) {
-    if (!trading_is_active(current_bar_.timestamp, trade_start_time_)) return;
+    if (!trading_is_active(current_bar_.timestamp, trade_start_time_, tf_to_seconds(script_tf_))) return;
     if (position_side_ == PositionSide::FLAT) {
         return;
     }
@@ -201,7 +250,7 @@ void BacktestEngine::strategy_exit(const std::string& id, const std::string& fro
                                     double trail_price, double qty_percent,
                                     const std::string& comment,
                                     double qty, const std::string& oca_name) {
-    if (!trading_is_active(current_bar_.timestamp, trade_start_time_)) return;
+    if (!trading_is_active(current_bar_.timestamp, trade_start_time_, tf_to_seconds(script_tf_))) return;
     bool has_explicit_qty = !std::isnan(qty);
     double qp = std::isnan(qty_percent) ? 100.0 : std::clamp(qty_percent, 0.0, 100.0);
     // If an explicit qty is given, derive an effective qp from the current
@@ -309,7 +358,7 @@ void BacktestEngine::strategy_cancel_all() {
 void BacktestEngine::strategy_order(const std::string& id, bool is_long, double qty,
                                      double limit_price, double stop_price,
                                      const std::string& oca_name, int oca_type) {
-    if (!trading_is_active(current_bar_.timestamp, trade_start_time_)) return;
+    if (!trading_is_active(current_bar_.timestamp, trade_start_time_, tf_to_seconds(script_tf_))) return;
     int64_t preserved_seq = 0;
     for (const auto& o : pending_orders_) {
         if (o.id == id) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_SOURCES
     test_engine_trade_accessors
     test_strategy_oca
     test_strategy_pyramiding
+    test_same_id_stop_replace
     test_generic_matrix_primitives
     test_generic_matrix_udt
     test_generic_matrix_bool_proxy

--- a/tests/test_same_id_stop_replace.cpp
+++ b/tests/test_same_id_stop_replace.cpp
@@ -1,0 +1,364 @@
+/*
+ * test_same_id_stop_replace.cpp — verify TradingView's same-id
+ * strategy.entry replacement timing relative to the bar's
+ * process-pending-orders pass.
+ *
+ * Pine v6 contract (verified empirically against
+ * validation/62-same-id-stop-cross-before-modify):
+ *
+ *   bar B-1 places stop A.
+ *   bar B begins:
+ *     1. broker evaluates pending orders against bar B's OHLC. If A's
+ *        stop is touched, A fires here at A's stop price. The fill is
+ *        recorded BEFORE strategy logic runs, so ``strategy.position_size``
+ *        on bar B already reflects A's fill.
+ *     2. on_bar (strategy logic) executes. Any ``strategy.entry`` call
+ *        with the SAME id replaces what's left in pending_orders_:
+ *        - if A fired in step 1, pending_orders_ no longer has A; the
+ *          new placement just adds A' for bar B+1 onward.
+ *        - if A did NOT fire in step 1, A is removed and A' takes its
+ *          place; A' is evaluated on bar B+1 (engine ran step 1 already).
+ *     3. There is no second pass over bar B for A' — TV's reference docs
+ *        describe pending-order updates as bar-boundary events, not
+ *        intra-bar. The engine's bar pump enforces this by calling
+ *        ``process_pending_orders`` exactly once before ``on_bar`` in
+ *        the !process_orders_on_close path.
+ *
+ * The three scenarios below exercise each branch of the contract.
+ */
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <pineforge/engine.hpp>
+#include <pineforge/bar.hpp>
+#include <pineforge/na.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+static bool near(double a, double b, double tol = 1e-6) {
+    return std::fabs(a - b) <= tol;
+}
+
+namespace {
+
+// Common probe shell: pyramiding=1, fixed qty=1, no commission/slippage,
+// process_orders_on_close=false (the path probe 62 exercises).
+class StopReplaceProbe : public BacktestEngine {
+public:
+    struct TradeRow {
+        std::string entry_id;
+        double entry_price;
+        double exit_price;
+        double qty;
+        int64_t entry_time;
+        int64_t exit_time;
+    };
+    std::vector<TradeRow> closed_trades;
+    int last_position_qty_seen = 0;
+
+    StopReplaceProbe() {
+        initial_capital_ = 1'000'000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        slippage_ = 0;
+        commission_value_ = 0;
+        pyramiding_ = 1;
+        // The deferred-flip carry rule is gated on the script having a
+        // ``strategy.close`` call — set it true so the carry-leak
+        // regression (default position_qty_ before any fill) would
+        // surface as qty=2 rather than being silently masked.
+        script_has_strategy_close_ = true;
+    }
+
+    void snapshot() {
+        closed_trades.clear();
+        for (const auto& t : trades_) {
+            closed_trades.push_back({t.entry_id, t.entry_price,
+                                     t.exit_price, t.qty,
+                                     t.entry_time, t.exit_time});
+        }
+        last_position_qty_seen = (int)position_qty_;
+    }
+};
+
+// Build a minimal OHLCV array with deterministic OHLC. Each bar:
+//   open = base + i*5, high = open + h_off, low = open - l_off,
+//   close = open + c_off. Timestamps are 1-minute spaced for clarity.
+struct BarSpec { double o, h, l, c; };
+
+static std::vector<Bar> make_bars(const std::vector<BarSpec>& specs) {
+    std::vector<Bar> out;
+    out.reserve(specs.size());
+    for (size_t i = 0; i < specs.size(); ++i) {
+        Bar b;
+        b.open = specs[i].o;
+        b.high = specs[i].h;
+        b.low = specs[i].l;
+        b.close = specs[i].c;
+        b.volume = 1000.0;
+        b.timestamp = (int64_t)((i + 1) * 60'000);
+        out.push_back(b);
+    }
+    return out;
+}
+
+}  // namespace
+
+// Scenario 1: bar B's process_pending_orders fills the prev bar's stop A;
+// strategy.entry on bar B with same id has no effect on the already-
+// filled A. The new A' lives for bar B+1 onward. Since the position is
+// open after step 1, the modify-branch precondition (position_size==0)
+// fails and longModify is never even called — same effective outcome
+// regardless of whether modify guard exists, but this scenario verifies
+// the engine respects the bar-boundary order.
+static void test_filled_stop_unaffected_by_same_id_replace() {
+    std::printf("test_filled_stop_unaffected_by_same_id_replace\n");
+    class Probe : public StopReplaceProbe {
+    public:
+        // Bar 0: place stop A at 100.5 (will fire on bar 1 OHLC).
+        // Bar 1: position is open after step 1 — the same-id replacement
+        //        block in on_bar is therefore predicated on
+        //        position_size==0 and SHOULD NOT replace.
+        // Bar 2: idle.
+        // Bar 3: full close.
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("LE", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               /*stop=*/100.5, 1.0, "first stop");
+            }
+            if (bar_index_ == 1 && position_size() == 0) {
+                // Defensive: if the engine bug REVERSED the bar-boundary
+                // order (replaced before evaluating prev bar's pending
+                // stop), this would fire and the test would observe a
+                // second pyramid entry.
+                strategy_entry("LE", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               /*stop=*/100.5 + 5.0, 1.0, "modified stop");
+            }
+            if (bar_index_ == 3) {
+                strategy_close("LE", "close all");
+            }
+            if (bar_index_ == 4) snapshot();
+        }
+    private:
+        double position_size() const { return signed_position_size(); }
+    };
+
+    auto bars = make_bars({
+        {100.0, 100.4, 99.8, 100.2},  // bar 0: range stays below 100.5
+        {100.0, 101.0, 99.0, 100.5},  // bar 1: high 101 >= stop 100.5 → fires
+        {100.5, 101.5, 100.0, 101.0}, // bar 2
+        {101.0, 102.0, 100.5, 101.5}, // bar 3: close call
+        {101.5, 102.5, 101.0, 102.0}, // bar 4: close fills
+    });
+    Probe p;
+    p.run(bars.data(), (int)bars.size());
+
+    // Exactly one closed trade — single pyramid entry from the first stop.
+    CHECK(p.closed_trades.size() == 1);
+    if (p.closed_trades.size() == 1) {
+        const auto& tr = p.closed_trades[0];
+        CHECK(near(tr.qty, 1.0));
+        CHECK(near(tr.entry_price, 100.5));
+        // Bar 1 fired the entry (no slippage), bar 4 open is the close fill.
+        CHECK(near(tr.exit_price, 101.5));
+    }
+}
+
+// Scenario 2: bar B's pending stop A does NOT fire on bar B's OHLC.
+// strategy.entry on bar B replaces A with A' at a different price.
+// On bar B+1 the new A' is evaluated against bar B+1's OHLC, NOT the
+// old A.
+static void test_unfilled_stop_replaced_for_next_bar() {
+    std::printf("test_unfilled_stop_replaced_for_next_bar\n");
+    class Probe : public StopReplaceProbe {
+    public:
+        void on_bar(const Bar& bar) override {
+            if (bar_index_ == 0) {
+                strategy_entry("LE", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               /*stop=*/100.5, 1.0, "first stop");
+            }
+            // Bar 1 OHLC won't reach 100.5; position stays FLAT.
+            if (bar_index_ == 1 && signed_position_size() == 0) {
+                // Replace with a much higher stop that bar 2 WILL touch.
+                strategy_entry("LE", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               /*stop=*/110.0, 1.0, "raised stop");
+            }
+            if (bar_index_ == 4) {
+                strategy_close("LE", "close all");
+            }
+            if (bar_index_ == 5) snapshot();
+        }
+    };
+
+    auto bars = make_bars({
+        {100.0, 100.4, 99.8, 100.2},   // bar 0: place A=100.5
+        {100.0, 100.4, 99.8, 100.2},   // bar 1: high stays below 100.5; replace
+        {100.0, 110.5, 99.8, 110.2},   // bar 2: high reaches 110.5 → A'=110.0 fires
+        {110.0, 111.0, 109.5, 110.5},  // bar 3
+        {110.5, 111.5, 110.0, 111.0},  // bar 4: close call
+        {111.0, 112.0, 110.5, 111.5},  // bar 5: close fills
+    });
+    Probe p;
+    p.run(bars.data(), (int)bars.size());
+
+    CHECK(p.closed_trades.size() == 1);
+    if (p.closed_trades.size() == 1) {
+        const auto& tr = p.closed_trades[0];
+        CHECK(near(tr.qty, 1.0));
+        // Critical: entry price should be the REPLACED stop's price
+        // (110.0) — gap-fill: bar 2's open is 100.0, low 99.8, high
+        // 110.5. Long stop at 110.0 fills at 110.0 (high-touch path).
+        CHECK(near(tr.entry_price, 110.0));
+        CHECK(near(tr.exit_price, 111.0));
+    }
+}
+
+// Scenario 3: bar B's pending stop A fires on bar B's OHLC. on_bar then
+// places a NEW (different-id) entry. The new entry is for bar B+1 and
+// MUST NOT fill on bar B alongside A. This guards against a regression
+// where a same-bar additional process_pending_orders pass would let new
+// orders placed in on_bar fire on the same bar.
+static void test_new_entry_after_same_bar_fill_defers_to_next_bar() {
+    std::printf("test_new_entry_after_same_bar_fill_defers_to_next_bar\n");
+    class Probe : public StopReplaceProbe {
+    public:
+        Probe() {
+            // Allow 2 entries in the same direction so the "new entry
+            // after stop fill" branch isn't blocked by pyramiding.
+            pyramiding_ = 2;
+        }
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("LE1", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               /*stop=*/100.5, 1.0, "first stop");
+            }
+            // Bar 1: A fires in step 1; we now place a NEW entry with a
+            // DIFFERENT id. If the engine erroneously processes this
+            // new placement on bar 1, the test will observe two trades
+            // dated to bar 1. Correct behavior: the second entry fires
+            // on bar 2 at bar 2's open.
+            if (bar_index_ == 1 && signed_position_size() > 0) {
+                strategy_entry("LE2", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               /*stop=*/95.0, 1.0, "second stop");
+            }
+            if (bar_index_ == 4) {
+                strategy_close("", "close all");
+            }
+            if (bar_index_ == 5) snapshot();
+        }
+    };
+
+    auto bars = make_bars({
+        {100.0, 100.4, 99.8, 100.2},   // bar 0: place LE1 stop=100.5
+        {100.0, 101.0, 99.0, 100.5},   // bar 1: A fires at 100.5; place LE2
+        {100.5, 101.5, 95.0, 99.0},    // bar 2: low 95 ≤ stop 95 → LE2 fires
+        {99.0, 100.0, 98.0, 99.5},     // bar 3
+        {99.5, 100.5, 98.5, 100.0},    // bar 4: close
+        {100.0, 101.0, 99.5, 100.5},   // bar 5: close fills
+    });
+    Probe p;
+    p.run(bars.data(), (int)bars.size());
+
+    CHECK(p.closed_trades.size() == 2);
+    if (p.closed_trades.size() == 2) {
+        const auto& a = p.closed_trades[0];
+        const auto& b = p.closed_trades[1];
+        std::printf("  trade[0] id=%s entry=%lld price=%.4f exit=%.4f\n",
+            a.entry_id.c_str(), (long long)a.entry_time, a.entry_price, a.exit_price);
+        std::printf("  trade[1] id=%s entry=%lld price=%.4f exit=%.4f\n",
+            b.entry_id.c_str(), (long long)b.entry_time, b.entry_price, b.exit_price);
+        CHECK(a.entry_id == "LE1");
+        CHECK(b.entry_id == "LE2");
+        CHECK(near(a.qty, 1.0));
+        CHECK(near(b.qty, 1.0));
+        CHECK(near(a.entry_price, 100.5));
+        // LE2 must fire on bar 2 (not bar 1): its entry timestamp
+        // matches bar 2's timestamp; if the bug leaked back in, LE2's
+        // entry timestamp would equal bar 1's.
+        CHECK(b.entry_time != bars[1].timestamp);
+    }
+}
+
+// Scenario 4 (regression for the position_qty_ default leak): a priced
+// strategy.entry placed BEFORE the first fill of any session must
+// capture tv_carry_qty=0, not the engine's default
+// ``position_qty_=1.0`` value. Pre-fix, the LE order's tv_carry_qty
+// was 1, which combined with ``script_has_strategy_close_=true`` and
+// the order firing from FLAT in the LONG direction produced
+// tv_deferred_flip = (true && true && carry=1>0 && (false?:true=true))
+// → qty = 1 + 1 = 2 instead of 1. Probe 62's first in-window trade
+// fired qty=2 with double the expected PnL (-18.22 vs TV's -9.11),
+// breaking parity even before the warmup-gate buffer fix exposed the
+// preceding-bar placement.
+static void test_carry_capture_on_flat_session_start() {
+    std::printf("test_carry_capture_on_flat_session_start\n");
+    class Probe : public StopReplaceProbe {
+    public:
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                // Session has just started; no fills have happened.
+                // position_side_ == FLAT, position_qty_ == default.
+                // The placed stop's tv_carry_qty must be captured as 0.
+                strategy_entry("LE", true,
+                               std::numeric_limits<double>::quiet_NaN(),
+                               /*stop=*/100.5, 1.0, "first ever stop");
+            }
+            if (bar_index_ == 3) {
+                strategy_close("LE", "close all");
+            }
+            if (bar_index_ == 4) snapshot();
+        }
+    };
+    auto bars = make_bars({
+        {100.0, 100.4, 99.8, 100.2},   // bar 0: place LE
+        {100.0, 101.0, 99.0, 100.5},   // bar 1: high 101 >= stop 100.5 → fires
+        {100.5, 101.5, 100.0, 101.0},  // bar 2
+        {101.0, 102.0, 100.5, 101.5},  // bar 3: close
+        {101.5, 102.5, 101.0, 102.0},  // bar 4: close fills
+    });
+    Probe p;
+    p.run(bars.data(), (int)bars.size());
+
+    CHECK(p.closed_trades.size() == 1);
+    if (p.closed_trades.size() == 1) {
+        const auto& tr = p.closed_trades[0];
+        // qty MUST be 1 — pre-fix bug fired qty=2 from default-leaked
+        // carry; this regression test pins the contract.
+        CHECK(near(tr.qty, 1.0));
+        CHECK(near(tr.entry_price, 100.5));
+    }
+}
+
+int main() {
+    test_filled_stop_unaffected_by_same_id_replace();
+    test_unfilled_stop_replaced_for_next_bar();
+    test_new_entry_after_same_bar_fill_defers_to_next_bar();
+    test_carry_capture_on_flat_session_start();
+
+    std::printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Probe 62 (`validation/62-same-id-stop-cross-before-modify`): moderate → **excellent** (TV=732, eng=732, matched=732)
- 3 additional probes flipped to excellent: `community/MarketShift`, `validation/ies-probe-08-equity-feedback-sizing`, `validation/parity-probe-04-percent-of-equity-sizing`
- 1 additional improvement: `validation_typed_matrix/typed-matrix-probe-01-bool-regime-mask` moderate → strong
- **Total parity: 175 → 179 excellent (+4), 0 regressions**

## Root cause (HANDOFF diagnosis was wrong)
Two latent bugs in the order surface combined with the validator's warmup gate produced the qty=2 leak on first trade:

1. `position_qty_` defaulted to `1.0` in `BacktestEngine`. Most callsites read it guarded by `position_side_ != FLAT`, but `strategy_entry`'s `tv_carry_qty` capture and `check_risk_allow_entry`'s max-position check read it unguarded. On the first `strategy.entry`, captured carry was 1.0 (not 0.0), and combined with `script_has_strategy_close_=true` on a long priced entry it triggered `tv_deferred_flip` → first stop fired qty=2 instead of qty=1.
2. `trading_is_active` gated strategy commands at `trade_start_time_`. Validator sets that to `TV_first_entry - input_bar_ms` (1m on a 15m strategy with 1m feed). The script bar immediately before the comparison window fell on the wrong side of the gate.

The same-id replacement path itself is already correctly deferred (`process_pending_orders` runs before `on_bar`).

## Changes
- `include/pineforge/engine.hpp`: `position_qty_` default 1.0 → 0.0
- `src/engine_strategy_commands.cpp`: side-gate `tv_carry_qty` capture; widen `trading_is_active` gate by one script TF interval
- `tests/test_same_id_stop_replace.cpp` (new): 4 scenarios pinning same-id replace contract + carry-leak regression

## Test plan
- [x] `ctest --test-dir build`: 28/28 pass (including new `test_same_id_stop_replace`)
- [x] Cold-cache full corpus parity (179/197 excellent, 0 regressions)
- [x] Critical probes (52, 63, 72, 93, 95, 96, all OCA-using) remain excellent

🤖 Generated with [Claude Code](https://claude.com/claude-code)