### PR TITLE
feat(docker): engine image -> pure runtime base

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,10 +407,10 @@ git clone https://github.com/pineforge-4pass/pineforge-engine.git
 cd pineforge-engine
 git submodule update --init corpus
 
-# (Optional) Reproduce the C++ from strategy.pine via the engine image.
+# (Optional) Reproduce the C++ from strategy.pine via the pineforge-release image.
 # VERIFY=1 proves the shipped generated.cpp is byte-identical to the
 # transpiler output (drift guard, no overwrite); drop it to regenerate.
-docker pull ghcr.io/pineforge-4pass/pineforge-engine:latest
+docker pull ghcr.io/pineforge-4pass/pineforge-release:latest
 VERIFY=1 scripts/regen_corpus_cpp.sh
 
 # Build + run + verify TV parity. (Add REGEN=1 to regenerate the C++

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,22 +1,22 @@
-# PineForge runtime container.
+# PineForge runtime base image — PURE RUNTIME, no transpiler.
 #
 # Stage 1 builds libpineforge.a and stages the public headers.
-# Stage 2 is a thin runtime: g++, python3, the prebuilt static
-# library, and the JSON harness. Each `docker run` compiles the
-# user-supplied generated.cpp against libpineforge.a and runs it
-# against the user-supplied OHLCV, emitting a JSON report on stdout.
+# Stage 2 is a thin runtime base: g++, Eigen, python3, the prebuilt static
+# library, and the public headers. It compiles + runs a *pre-transpiled*
+# generated.cpp against libpineforge.a (the C ABI).
+#
+# This image deliberately does NOT bundle the PineScript->C++ transpiler
+# (pineforge-codegen) and has NO Pine entrypoint. The full `.pine -> trades`
+# pipeline (transpiler + entrypoint + JSON harness) lives in the combined
+# image **ghcr.io/pineforge-4pass/pineforge-release**, which builds FROM this
+# base. Run a `.pine` there, not here.
 #
 # Build args (release.yml passes these; sane defaults for local builds):
 #   PINEFORGE_VERSION  semver "MAJOR.MINOR.PATCH" (defaults to VERSION file)
 #   PINEFORGE_GIT_SHA  full commit sha
 #
 # Build:
-#   docker build -t pineforge -f docker/Dockerfile .
-# Run:
-#   docker run --rm \
-#     -v $(pwd)/strategy.cpp:/in/strategy.cpp:ro \
-#     -v $(pwd)/ohlcv.csv:/in/ohlcv.csv:ro \
-#     pineforge > report.json
+#   docker build -t pineforge-engine -f docker/Dockerfile .
 
 # === Stage 1: build libpineforge.a =====================================
 FROM debian:bookworm-slim AS builder
@@ -27,15 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         git \
         libeigen3-dev \
-        python3-pip \
     && rm -rf /var/lib/apt/lists/*
-
-# Stage the pure-Python transpiler here so the runtime never needs pip or
-# network: target-install gives a plain directory tree to COPY across.
-# PINNED: the codegen version is explicit so image builds are reproducible AND
-# the buildx (gha) layer cache busts when we need a newer codegen. Bump this in
-# lockstep with a pineforge-codegen release.
-RUN pip3 install --break-system-packages --no-cache-dir -U --target /opt/codegen pineforge-codegen==0.7.5
 
 WORKDIR /src
 # VERSION file is the version source-of-truth inside the build context;
@@ -57,52 +49,46 @@ RUN cmake -B build \
 # stage 2 can copy a single tree.
 RUN cp build/include/pineforge/version.h include/pineforge/version.h
 
-# === Stage 2: runtime =================================================
+# === Stage 2: runtime base ============================================
 FROM debian:bookworm-slim
 
 ARG PINEFORGE_VERSION=unknown
 ARG PINEFORGE_GIT_SHA=unknown
 ARG PINEFORGE_BUILD_DATE=unknown
 
-LABEL org.opencontainers.image.title="pineforge" \
-      org.opencontainers.image.description="Deterministic PineScript v6 backtest runtime" \
+LABEL org.opencontainers.image.title="pineforge-engine" \
+      org.opencontainers.image.description="Deterministic PineScript v6 backtest runtime (pure base; transpiler ships in pineforge-release)" \
       org.opencontainers.image.version="${PINEFORGE_VERSION}" \
       org.opencontainers.image.revision="${PINEFORGE_GIT_SHA}" \
       org.opencontainers.image.created="${PINEFORGE_BUILD_DATE}" \
       org.opencontainers.image.source="https://github.com/pineforge-4pass/pineforge-engine" \
       org.opencontainers.image.licenses="Apache-2.0"
 
-# g++ + Eigen to compile the generated TU; python3 for the JSON harness and
-# the bundled PineScript->C++ transpiler (pineforge-codegen, target-installed
-# in the builder stage and COPY'd in — the runtime carries no pip, no
-# ca-certificates, and never touches the network). With codegen baked in, the
-# container accepts strategy.pine directly and transpiles locally — no hosted
-# API, no API key, source never leaves the box.
+# g++ + Eigen to compile a pre-transpiled generated.cpp against the static lib.
+# python3 stays: the pineforge-release image builds FROM this base and its
+# JSON harness (run_json.py) needs it — keeping it here avoids re-installing it
+# in the release layer. The bare engine image carries NO transpiler and NO Pine
+# entrypoint (see header); those live in pineforge-release.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         g++ \
         libeigen3-dev \
         python3 \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man /usr/share/locale /usr/share/info
 
-# Bundle the prebuilt static library, the public headers (curated +
-# generated version.h), and the JSON harness. Users only mount their
-# own code.
-RUN mkdir -p /opt/pineforge/lib /opt/pineforge/include /opt/pineforge/bin
-COPY --from=builder /opt/codegen /opt/pineforge/pycodegen
+# Bundle the prebuilt static library and the public headers (curated +
+# generated version.h). Consumers link their own compiled strategy against this.
+RUN mkdir -p /opt/pineforge/lib /opt/pineforge/include
 COPY --from=builder /src/build/lib/libpineforge.a /opt/pineforge/lib/
 COPY --from=builder /src/include/pineforge        /opt/pineforge/include/pineforge
 
-COPY docker/run_json.py    /opt/pineforge/bin/run_json.py
-COPY docker/entrypoint.sh  /opt/pineforge/bin/entrypoint.sh
-RUN chmod +x /opt/pineforge/bin/entrypoint.sh /opt/pineforge/bin/run_json.py
-
 ENV PINEFORGE_PREFIX=/opt/pineforge \
     PINEFORGE_VERSION=${PINEFORGE_VERSION} \
-    PINEFORGE_GIT_SHA=${PINEFORGE_GIT_SHA} \
-    PYTHONPATH=/opt/pineforge/pycodegen
+    PINEFORGE_GIT_SHA=${PINEFORGE_GIT_SHA}
 
-# Drop root: the entrypoint compiles and runs everything under mktemp dirs.
+# Drop root.
 RUN useradd -r -u 10001 -s /usr/sbin/nologin pineforge
 USER pineforge
 
-ENTRYPOINT ["/opt/pineforge/bin/entrypoint.sh"]
+# No ENTRYPOINT: this is a base/runtime image, not a standalone Pine tool.
+# Make a bare `docker run` self-documenting instead of silently doing nothing.
+CMD ["sh", "-c", "echo 'pineforge-engine is a pure runtime base (compile + run a pre-transpiled generated.cpp against /opt/pineforge/lib/libpineforge.a). For PineScript .pine -> backtest, use ghcr.io/pineforge-4pass/pineforge-release.' >&2; exit 64"]

--- a/scripts/regen_corpus_cpp.sh
+++ b/scripts/regen_corpus_cpp.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 # scripts/regen_corpus_cpp.sh — regenerate (or verify) every corpus
 # generated.cpp straight from strategy.pine, using the bundled transpiler
-# in the pineforge-engine Docker image. Docker is the only dependency —
+# in the pineforge-release Docker image. Docker is the only dependency —
 # no host Python, pip, or C++ toolchain needed for this step.
 #
 # This closes the reproducibility loop: the shipped corpus/*/*/generated.cpp
-# can be re-derived from corpus/*/*/strategy.pine through the public engine
-# image (which bundles pineforge-codegen in transpile-only mode).
+# can be re-derived from corpus/*/*/strategy.pine through the public
+# pineforge-release image (engine runtime + bundled pineforge-codegen),
+# in transpile-only mode. NOTE: the bare pineforge-engine image no longer
+# bundles the transpiler — REGEN must use pineforge-release.
 #
 # Env vars:
-#   IMAGE    Engine image to transpile with
-#            (default: ghcr.io/pineforge-4pass/pineforge-engine:latest)
+#   IMAGE    Image to transpile with
+#            (default: ghcr.io/pineforge-4pass/pineforge-release:latest)
 #   ONLY     Substring filter; only process strategies whose path matches
 #   VERIFY   1 = do NOT overwrite; transpile to a temp file and diff against
 #            the committed generated.cpp. Exit non-zero if any file drifts.
@@ -29,7 +31,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-IMAGE="${IMAGE:-ghcr.io/pineforge-4pass/pineforge-engine:latest}"
+IMAGE="${IMAGE:-ghcr.io/pineforge-4pass/pineforge-release:latest}"
 VERIFY="${VERIFY:-0}"
 
 log()  { printf '\033[1;34m[regen_corpus]\033[0m %s\n' "$*"; }

--- a/scripts/run_corpus.sh
+++ b/scripts/run_corpus.sh
@@ -42,12 +42,12 @@ fi
 
 # --- 0) (optional) regenerate generated.cpp from strategy.pine --------
 # REGEN=1 re-derives every corpus/*/*/generated.cpp from its strategy.pine
-# through the engine Docker image (which bundles the transpiler), so the
-# build below compiles freshly-transpiled C++ instead of the committed copy.
+# through the pineforge-release Docker image (engine + bundled transpiler), so
+# the build below compiles freshly-transpiled C++ instead of the committed copy.
 # Requires Docker. Honours ONLY. Off by default → committed C++ is used.
 
 if [[ "${REGEN:-0}" == "1" ]]; then
-    log "regenerating generated.cpp from strategy.pine via the engine image"
+    log "regenerating generated.cpp from strategy.pine via the pineforge-release image"
     "$ROOT_DIR/scripts/regen_corpus_cpp.sh"
 fi
 


### PR DESCRIPTION
Drop the bundled pineforge-codegen transpiler and the Pine entrypoint from the
engine image: it is now a pure base (g++, Eigen, python3, libpineforge.a +
headers) that compiles + runs a pre-transpiled generated.cpp against the C ABI.
The full `.pine -> trades` pipeline (transpiler + entrypoint + run_json) lives
in pineforge-release, which builds FROM this base. A bare `docker run` prints a
migration message (exit 64).

Corpus REGEN now transpiles via the pineforge-release container (regen_corpus_cpp.sh
IMAGE default + run_corpus.sh / README). docker/entrypoint.sh + docker/run_json.py
stay in-repo as the tested harness source (test_entrypoint_indir + fingerprint
self-test); pineforge-release ships its own copy.

Validated: ctest 72/72; corpus parity excellent=245/anomaly=1 (baseline); the
release container transpiles all 246 byte-identically to the engine image (drift
vs committed cpp is pre-existing, image-independent).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
