### PR TITLE
docs(corpus): fix stale 'private submodule' message — corpus is public

### DIFF
--- a/scripts/regen_corpus_cpp.sh
+++ b/scripts/regen_corpus_cpp.sh
@@ -40,8 +40,8 @@ fail() { printf '\033[1;31m[regen_corpus]\033[0m %s\n' "$*" >&2; exit 1; }
 
 if [[ ! -f "$ROOT_DIR/corpus/CMakeLists.txt" ]]; then
     fail "validation corpus is not checked out (missing corpus/CMakeLists.txt).
-Maintainers:   git submodule update --init corpus
-Public clones: the TV validation corpus lives in a private submodule only; see CONTRIBUTING.md."
+Run:  git submodule update --init corpus
+(the TV validation corpus is a PUBLIC submodule: https://github.com/pineforge-4pass/pineforge-corpus)"
 fi
 
 command -v docker >/dev/null 2>&1 || fail "docker not found on PATH."

--- a/scripts/run_corpus.sh
+++ b/scripts/run_corpus.sh
@@ -36,8 +36,8 @@ fail() { printf '\033[1;31m[run_corpus]\033[0m %s\n' "$*" >&2; exit 1; }
 
 if [[ ! -f "$ROOT_DIR/corpus/CMakeLists.txt" ]]; then
     fail "validation corpus is not checked out (missing corpus/CMakeLists.txt).
-Maintainers:   git submodule update --init corpus
-Public clones: the TV validation corpus lives in a private submodule only; see CONTRIBUTING.md."
+Run:  git submodule update --init corpus
+(the TV validation corpus is a PUBLIC submodule: https://github.com/pineforge-4pass/pineforge-corpus)"
 fi
 
 # --- 0) (optional) regenerate generated.cpp from strategy.pine --------


### PR DESCRIPTION
run_corpus.sh + regen_corpus_cpp.sh told public users the TV validation corpus
'lives in a private submodule only'. It is a PUBLIC submodule
(https://github.com/pineforge-4pass/pineforge-corpus, https in .gitmodules), so
'git submodule update --init corpus' works for everyone. Corrects the public
reproduce story.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
