### PR TITLE
Raw-data reproduce: docker runner for corpus + speed/throughput; engine lib-only CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,8 @@ on:
           - minor
           - major
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 permissions:
   contents: write
-  packages: write
 
 jobs:
   release:
@@ -55,7 +50,7 @@ jobs:
           app-id: ${{ secrets.PINEFORGE_APP_ID }}
           private-key: ${{ secrets.PINEFORGE_APP_PRIVATE_KEY }}
           owner: pineforge-4pass
-          repositories: pineforge-engine,pineforge-release
+          repositories: pineforge-engine
 
       - name: Checkout (full history)
         uses: actions/checkout@v4
@@ -137,8 +132,6 @@ jobs:
         env:
           TAG:      ${{ steps.bump.outputs.tag }}
           PREV:     ${{ steps.prev.outputs.prev }}
-          REGISTRY: ${{ env.REGISTRY }}
-          IMAGE:    ${{ env.IMAGE_NAME }}
         run: |
           set -euo pipefail
           {
@@ -155,60 +148,12 @@ jobs:
             fi
             echo
             echo
-            echo "### Container image"
+            echo "### Prebuilt libraries"
             echo
-            echo '```'
-            echo "docker pull ${REGISTRY}/${IMAGE}:${TAG#v}"
-            echo '```'
+            echo "Per-arch static-lib + headers tarballs are attached below (C ABI)."
+            echo "For the full PineScript -> backtest image, use \`ghcr.io/pineforge-4pass/pineforge-release\`."
           } > RELEASE_NOTES.md
           echo "path=RELEASE_NOTES.md" >> "$GITHUB_OUTPUT"
-
-      - name: Build context metadata
-        id: ctx
-        run: |
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute image tags
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}},value=${{ steps.bump.outputs.tag }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.bump.outputs.tag }}
-            type=semver,pattern={{major}},value=${{ steps.bump.outputs.tag }}
-            type=raw,value=latest
-            type=sha,format=short,prefix=,value=${{ steps.ctx.outputs.sha }}
-
-      - name: Build and push image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            PINEFORGE_VERSION=${{ steps.bump.outputs.next }}
-            PINEFORGE_GIT_SHA=${{ steps.ctx.outputs.sha }}
-            PINEFORGE_BUILD_DATE=${{ steps.ctx.outputs.date }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Create GitHub Release
         env:
@@ -220,28 +165,6 @@ jobs:
             --title "${TAG}" \
             --notes-file "${NOTES}" \
             --verify-tag
-
-      # Every engine release notifies the pineforge-release hub, which bumps its
-      # ENGINE_VERSION pin, rebuilds the combined image (FROM this engine image +
-      # the bundled codegen), and fans out to the MCPs. The hub is the sole
-      # downstream entry point now — we no longer dispatch to mcp-public directly.
-      #
-      # FAIL LOUD (no continue-on-error): a dropped notify means downstream never
-      # rebuilds, and that silent failure is exactly the bug this replaces. The
-      # credential is the org GitHub App (no PAT — minted at runtime, never
-      # expires); `gh api` exits non-zero on HTTP >=4xx so `set -e` fails the job.
-      - name: Dispatch engine-release -> pineforge-release
-        env:
-          GH_TOKEN:   ${{ steps.app.outputs.token }}
-          ENGINE_TAG: ${{ steps.bump.outputs.tag }}
-          RUN_ID:     ${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          gh api repos/pineforge-4pass/pineforge-release/dispatches \
-            -f event_type=engine-release \
-            -F "client_payload[version]=${ENGINE_TAG}" \
-            -F "client_payload[run_id]=${RUN_ID}"
-          echo "dispatched engine-release -> pineforge-release (${ENGINE_TAG})"
 
   # Prebuilt static-lib + headers tarballs, one per (os, arch). Attached
   # to the GitHub Release created above. Tarball layout:
@@ -349,3 +272,34 @@ jobs:
           SHASUM:  ${{ steps.pack.outputs.sha256 }}
         run: |
           gh release upload "${TAG}" "${TARBALL}" "${SHASUM}" --clobber
+
+  # Notify the pineforge-release hub AFTER the tarballs are uploaded — the hub
+  # builds FROM the engine static-lib tarball, so it must exist first. The hub
+  # bumps its ENGINE_VERSION pin, rebuilds the combined image, and fans out to
+  # the MCPs. FAIL LOUD (no continue-on-error): a dropped notify means downstream
+  # never rebuilds. Credential is the org GitHub App (no PAT).
+  notify-hub:
+    needs: [release, prebuilt]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint org App token (hub dispatch)
+        id: app
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PINEFORGE_APP_ID }}
+          private-key: ${{ secrets.PINEFORGE_APP_PRIVATE_KEY }}
+          owner: pineforge-4pass
+          repositories: pineforge-release
+
+      - name: Dispatch engine-release -> pineforge-release
+        env:
+          GH_TOKEN:   ${{ steps.app.outputs.token }}
+          ENGINE_TAG: ${{ needs.release.outputs.tag }}
+          RUN_ID:     ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh api repos/pineforge-4pass/pineforge-release/dispatches \
+            -f event_type=engine-release \
+            -F "client_payload[version]=${ENGINE_TAG}" \
+            -F "client_payload[run_id]=${RUN_ID}"
+          echo "dispatched engine-release -> pineforge-release (${ENGINE_TAG})"

--- a/benchmarks/run_all.sh
+++ b/benchmarks/run_all.sh
@@ -179,19 +179,33 @@ log "running canonical indicators through PineForge"
 
 if [[ "${SKIP_SPEED:-0}" != "1" ]]; then
     log "running per-strategy speed sweep"
-    if [[ ! -f "${ROOT_DIR}/build/CMakeCache.txt" ]] \
-       || ! grep -q "PINEFORGE_BUILD_SPEED_BENCH:BOOL=ON" "${ROOT_DIR}/build/CMakeCache.txt"; then
-        log "configuring with -DPINEFORGE_BUILD_SPEED_BENCH=ON"
-        cmake -B "${ROOT_DIR}/build" -DPINEFORGE_BUILD_SPEED_BENCH=ON -DPINEFORGE_BUILD_TESTS=ON >/dev/null
+    if [[ "${RUNNER:-native}" == "docker" ]]; then
+        # SECONDARY path: time PineForge inside the pineforge-release image
+        # (run_json.py --bench → raw samples_ns). GBench (native) stays the
+        # authoritative source; this is the no-toolchain / ecosystem-parity path.
+        log "PineForge speed via pineforge-release image (--bench); GBench stays authoritative"
+        (cd "${BENCH_DIR}" && uv run python speed/time_pineforge_docker.py \
+            --strategies "${STRATEGIES_DIR}" \
+            --ohlcv "${BENCH_DIR}/assets/data/ETHUSDT_15.csv" \
+            ${IMAGE:+--image "${IMAGE}"}) > "${WORKDIR}/pf_speed.json" 2>"${WORKDIR}/pf_speed.err"
+        PF_FMT=subproc
+    else
+        if [[ ! -f "${ROOT_DIR}/build/CMakeCache.txt" ]] \
+           || ! grep -q "PINEFORGE_BUILD_SPEED_BENCH:BOOL=ON" "${ROOT_DIR}/build/CMakeCache.txt"; then
+            log "configuring with -DPINEFORGE_BUILD_SPEED_BENCH=ON"
+            cmake -B "${ROOT_DIR}/build" -DPINEFORGE_BUILD_SPEED_BENCH=ON -DPINEFORGE_BUILD_TESTS=ON >/dev/null
+        fi
+        cmake --build "${ROOT_DIR}/build" --target pineforge_bench -j >/dev/null \
+            || fail "speed harness build failed (configure with -DPINEFORGE_BUILD_SPEED_BENCH=ON)"
+        "${ROOT_DIR}/build/bin/pineforge_bench" \
+            --benchmark_format=json > "${WORKDIR}/pf_speed.json"
+        PF_FMT=gbench
     fi
-    cmake --build "${ROOT_DIR}/build" --target pineforge_bench -j >/dev/null \
-        || fail "speed harness build failed (configure with -DPINEFORGE_BUILD_SPEED_BENCH=ON)"
-    "${ROOT_DIR}/build/bin/pineforge_bench" \
-        --benchmark_format=json > "${WORKDIR}/pf_speed.json"
     (cd "${BENCH_DIR}" && uv run python speed/time_pynecore.py) > "${WORKDIR}/pc_speed.json" 2>"${WORKDIR}/pc_speed.err"
     (cd "${BENCH_DIR}" && node speed/time_pinets.mjs) > "${WORKDIR}/pt_speed.json" 2>"${WORKDIR}/pt_speed.err"
     (cd "${BENCH_DIR}" && uv run python speed/aggregate.py \
         --pineforge "${WORKDIR}/pf_speed.json" \
+        --pineforge-format "${PF_FMT}" \
         --pynecore  "${WORKDIR}/pc_speed.json" \
         --pinets    "${WORKDIR}/pt_speed.json")
 fi

--- a/benchmarks/speed/aggregate.py
+++ b/benchmarks/speed/aggregate.py
@@ -104,7 +104,12 @@ def load_subproc(p: Path) -> dict[str, dict]:
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--pineforge", type=Path, required=True,
-                    help="GBench JSON (pineforge_bench --benchmark_format=json)")
+                    help="PineForge timing JSON. gbench format = pineforge_bench "
+                         "--benchmark_format=json (default, AUTHORITATIVE); subproc "
+                         "format = speed/time_pineforge_docker.py {slug:{median_ms,...}}.")
+    ap.add_argument("--pineforge-format", choices=["gbench", "subproc"], default="gbench",
+                    help="How to parse --pineforge (default gbench). 'subproc' for the "
+                         "secondary docker --bench path (image-emitted samples_ns).")
     ap.add_argument("--pynecore", type=Path, required=True,
                     help="PyneCore JSON (speed/time_pynecore.py)")
     ap.add_argument("--pinets", type=Path, required=True,
@@ -115,7 +120,7 @@ def main() -> None:
                     help="Output path (default: benchmarks/results/speed.md)")
     args = ap.parse_args()
 
-    pf = load_gbench(args.pineforge)
+    pf = load_gbench(args.pineforge) if args.pineforge_format == "gbench" else load_subproc(args.pineforge)
     pc = load_subproc(args.pynecore)
     pt = load_subproc(args.pinets)
     vbt = load_subproc(args.vectorbt) if args.vectorbt and args.vectorbt.exists() else {}

--- a/benchmarks/speed/time_pineforge_docker.py
+++ b/benchmarks/speed/time_pineforge_docker.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""SECONDARY PineForge speed timer: time each bench strategy INSIDE the
+pineforge-release container (run_json.py --bench → raw samples_ns) and emit
+{slug: {median_ms, p95_ms, n}} — the same shape as the competitor timers
+(speed/time_pynecore.py etc), so speed/aggregate.py loads it with
+`--pineforge-format subproc`.
+
+The from-source GBench harness (pineforge_bench.cpp) stays AUTHORITATIVE; this
+no-toolchain path is for ecosystem/CI parity. Timing happens inside the
+container (around run_backtest_full only); the host NEVER stopwatches `docker
+run` (container/transpile/dlopen cold-start would swamp the hot loop). Mirrors
+the GBench `with_magnifier` benchmark: magnifier ON, 4 samples, endpoints.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+
+# scripts/pf_release_run.py (repo root /scripts) — this file is benchmarks/speed/.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+import pf_release_run as rel  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--strategies", type=Path, required=True,
+                    help="bench strategies dir (each <slug>/generated.cpp)")
+    ap.add_argument("--ohlcv", type=Path, required=True, help="bench OHLCV CSV")
+    ap.add_argument("--image", default=None, help="pineforge-release image")
+    ap.add_argument("--warmup", type=int, default=3)
+    ap.add_argument("--repeats", type=int, default=20)
+    ap.add_argument("--only", default="", help="substring filter on slug")
+    args = ap.parse_args()
+
+    out: dict[str, dict] = {}
+    for d in sorted(p for p in args.strategies.iterdir() if p.is_dir()):
+        gen = d / "generated.cpp"
+        if not gen.exists():
+            continue
+        if args.only and args.only not in d.name:
+            continue
+        kw = dict(bar_magnifier=True, magnifier_samples=4, magnifier_dist="endpoints",
+                  bench=True, warmup=args.warmup, repeats=args.repeats)
+        if args.image:
+            kw["image"] = args.image
+        try:
+            rep = rel.run_release(gen, args.ohlcv, **kw)
+        except rel.ReleaseRunError as e:
+            print(f"skip {d.name}: {e}", file=sys.stderr)
+            continue
+        samples = (rep.get("diagnostics", {}).get("timing", {}) or {}).get("samples_ns") or []
+        if not samples:
+            print(f"skip {d.name}: no timing samples", file=sys.stderr)
+            continue
+        ms = sorted(s / 1e6 for s in samples)
+        median_ms = statistics.median(ms)
+        p95_ms = ms[min(len(ms) - 1, int(0.95 * len(ms)))]
+        out[d.name] = {"median_ms": median_ms, "p95_ms": p95_ms, "n": len(ms)}
+        print(f"{d.name}: median={median_ms:.3f}ms p95={p95_ms:.3f}ms n={len(ms)}",
+              file=sys.stderr)
+
+    json.dump(out, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/throughput/plot_quartile.py
+++ b/benchmarks/throughput/plot_quartile.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -74,9 +75,47 @@ def load_dynamic_data(json_path: Path) -> dict[str, float]:
         print(f"Error parsing JSON: {e}. Using fallback data.")
         return FALLBACK_DATA
 
+def load_subproc_data(json_path: Path) -> dict[str, float]:
+    """Load throughput results from the docker --bench driver
+    (time_throughput_docker.py): {slug: {m_per_s, ...}} → {slug: M/s}.
+
+    This is the SECONDARY, no-toolchain path. The from-source GBench JSON
+    (load_dynamic_data) stays authoritative for the published chart.
+    """
+    if not json_path.exists():
+        print(f"Warning: subproc results file '{json_path}' not found. Using fallback data.")
+        return FALLBACK_DATA
+    try:
+        with open(json_path, "r") as f:
+            raw = json.load(f)
+        results = {}
+        for slug, rec in raw.items():
+            m = rec.get("m_per_s") if isinstance(rec, dict) else rec
+            if m is not None:
+                results[slug] = float(m)
+        if not results:
+            print("Warning: No m_per_s entries in subproc JSON. Using fallback data.")
+            return FALLBACK_DATA
+        return results
+    except Exception as e:
+        print(f"Error parsing subproc JSON: {e}. Using fallback data.")
+        return FALLBACK_DATA
+
+
 def main():
-    json_path = Path(__file__).parent / "benchmark_results.json"
-    results = load_dynamic_data(json_path)
+    ap = argparse.ArgumentParser(description="PineForge throughput quartile plot")
+    ap.add_argument("--results", type=Path, default=None,
+                    help="results JSON (default: benchmark_results.json next to this script)")
+    ap.add_argument("--format", choices=["gbench", "subproc"], default="gbench",
+                    help="gbench=from-source GBench JSON (default/authoritative); "
+                         "subproc=docker --bench driver output (time_throughput_docker.py)")
+    args = ap.parse_args()
+
+    json_path = args.results or (Path(__file__).parent / "benchmark_results.json")
+    if args.format == "subproc":
+        results = load_subproc_data(json_path)
+    else:
+        results = load_dynamic_data(json_path)
 
     data = list(results.values())
     data.sort()

--- a/benchmarks/throughput/reproduce.sh
+++ b/benchmarks/throughput/reproduce.sh
@@ -9,27 +9,44 @@ echo "=== PineForge Performance & Optimization Reproduction Pipeline ==="
 echo "Engine root: $ENGINE_ROOT"
 echo "reproduce directory: $SCRIPT_DIR"
 
-# 1. Compile the engine and strategies
-echo ""
-echo "Step 1: Compiling engine and strategies in Release mode..."
-cmake -B "$ENGINE_ROOT/build" -S "$ENGINE_ROOT" \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DPINEFORGE_BUILD_TESTS=ON \
-    -DPINEFORGE_BUILD_BENCH_STRATEGIES=ON
-cmake --build "$ENGINE_ROOT/build" --target bench_strategies -j4
+if [[ "${RUNNER:-native}" == "docker" ]]; then
+    # SECONDARY path: time throughput INSIDE the pineforge-release image
+    # (run_json.py --bench, magnifier OFF → base-bar throughput). No host C++
+    # toolchain. GBench (native, below) stays the authoritative published source.
+    echo ""
+    echo "Step 1+2 (docker): timing throughput via pineforge-release image (--bench)..."
+    python3 "$SCRIPT_DIR/time_throughput_docker.py" \
+        --strategies "$ENGINE_ROOT/benchmarks/assets/strategies" \
+        --ohlcv "$ENGINE_ROOT/benchmarks/assets/data/ETHUSDT_15.csv" \
+        ${IMAGE:+--image "$IMAGE"} > "$SCRIPT_DIR/throughput_docker.json"
 
-# 2. Run Google Benchmarks and export results to JSON
-echo ""
-echo "Step 2: Executing throughput benchmarks and exporting results..."
-"$ENGINE_ROOT/build/bin/pineforge_bench" \
-    --benchmark_filter=".*throughput/no_magnifier.*" \
-    --benchmark_out="$SCRIPT_DIR/benchmark_results.json" \
-    --benchmark_out_format=json
+    echo ""
+    echo "Step 3 (docker): parsing results and generating quartile plot..."
+    python3 "$SCRIPT_DIR/plot_quartile.py" \
+        --results "$SCRIPT_DIR/throughput_docker.json" --format subproc
+else
+    # 1. Compile the engine and strategies
+    echo ""
+    echo "Step 1: Compiling engine and strategies in Release mode..."
+    cmake -B "$ENGINE_ROOT/build" -S "$ENGINE_ROOT" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DPINEFORGE_BUILD_TESTS=ON \
+        -DPINEFORGE_BUILD_BENCH_STRATEGIES=ON
+    cmake --build "$ENGINE_ROOT/build" --target bench_strategies -j4
 
-# 3. Compute stats and draw quartile plot using Matplotlib
-echo ""
-echo "Step 3: Parsing benchmark results and generating quartile plot..."
-python3 "$SCRIPT_DIR/plot_quartile.py"
+    # 2. Run Google Benchmarks and export results to JSON
+    echo ""
+    echo "Step 2: Executing throughput benchmarks and exporting results..."
+    "$ENGINE_ROOT/build/bin/pineforge_bench" \
+        --benchmark_filter=".*throughput/no_magnifier.*" \
+        --benchmark_out="$SCRIPT_DIR/benchmark_results.json" \
+        --benchmark_out_format=json
+
+    # 3. Compute stats and draw quartile plot using Matplotlib
+    echo ""
+    echo "Step 3: Parsing benchmark results and generating quartile plot..."
+    python3 "$SCRIPT_DIR/plot_quartile.py"
+fi
 
 # 4. Run parameter sweep / grid search on wunder-bots
 echo ""

--- a/benchmarks/throughput/time_throughput_docker.py
+++ b/benchmarks/throughput/time_throughput_docker.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""SECONDARY PineForge throughput timer: time each bench strategy INSIDE the
+pineforge-release container (run_json.py --bench → raw samples_ns) and emit
+{slug: {m_per_s, items_per_second, median_ns, n}} — a subproc-shape JSON that
+plot_quartile.py loads with `--format subproc`.
+
+The from-source GBench harness (pineforge_bench.cpp, throughput/no_magnifier)
+stays AUTHORITATIVE; this no-toolchain path is for ecosystem/CI parity. Timing
+happens inside the container (around run_backtest_full only); the host NEVER
+stopwatches `docker run`. Mirrors the GBench `throughput/no_magnifier`
+benchmark: magnifier OFF, so items_processed = base OHLCV bars and the timed
+region is the base-bar loop.
+
+  items_per_second = items_processed / (median_ns / 1e9)
+  M/s              = items_per_second / 1e6
+
+GBench/docker biases: container CPU throttling + FFI make the docker median a
+slight under-read of native throughput. This path is advisory, not published.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+
+# scripts/pf_release_run.py (repo root /scripts) — this file is benchmarks/throughput/.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+import pf_release_run as rel  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--strategies", type=Path, required=True,
+                    help="bench strategies dir (each <slug>/generated.cpp)")
+    ap.add_argument("--ohlcv", type=Path, required=True, help="bench OHLCV CSV")
+    ap.add_argument("--image", default=None, help="pineforge-release image")
+    ap.add_argument("--warmup", type=int, default=3)
+    ap.add_argument("--repeats", type=int, default=20)
+    ap.add_argument("--only", default="", help="substring filter on slug")
+    args = ap.parse_args()
+
+    out: dict[str, dict] = {}
+    for d in sorted(p for p in args.strategies.iterdir() if p.is_dir()):
+        gen = d / "generated.cpp"
+        if not gen.exists():
+            continue
+        if args.only and args.only not in d.name:
+            continue
+        # magnifier OFF → base-bar throughput, matching throughput/no_magnifier.
+        kw = dict(bar_magnifier=False, bench=True,
+                  warmup=args.warmup, repeats=args.repeats)
+        if args.image:
+            kw["image"] = args.image
+        try:
+            rep = rel.run_release(gen, args.ohlcv, **kw)
+        except rel.ReleaseRunError as e:
+            print(f"skip {d.name}: {e}", file=sys.stderr)
+            continue
+        tp = (rep.get("diagnostics", {}) or {}).get("throughput", {}) or {}
+        samples = tp.get("samples_ns") or []
+        items = tp.get("items_processed")
+        if not samples or not items:
+            print(f"skip {d.name}: no throughput samples", file=sys.stderr)
+            continue
+        median_ns = statistics.median(samples)
+        if median_ns <= 0:
+            print(f"skip {d.name}: non-positive median_ns", file=sys.stderr)
+            continue
+        items_per_second = items * 1e9 / median_ns
+        m_per_s = items_per_second / 1e6
+        out[d.name] = {
+            "m_per_s": m_per_s,
+            "items_per_second": items_per_second,
+            "median_ns": median_ns,
+            "items_processed": int(items),
+            "n": len(samples),
+        }
+        print(f"{d.name}: {m_per_s:.3f} M/s (items={int(items)} median={median_ns/1e6:.3f}ms n={len(samples)})",
+              file=sys.stderr)
+
+    json.dump(out, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -113,7 +113,10 @@ echo "[pineforge] compiling strategy.cpp ..." >&2
 # whole-archive forces the c_abi.cpp symbols (pf_version_get,
 # strategy_set_trace_enabled, etc.) into the .so even though the
 # strategy body never references them.
-g++ -std=c++17 -O2 -fPIC -shared \
+# -ffp-contract=off is parity-critical: the static lib is built with it
+# (CMakeLists.txt) so FMA contraction can't reassociate float ops. The strategy
+# TU must match or any inlined TA/sizing math drifts at the last ULP.
+g++ -std=c++17 -O2 -ffp-contract=off -fPIC -shared \
     -I"${PREFIX}/include" \
     -I/usr/include/eigen3 \
     "${SRC}" \
@@ -122,6 +125,22 @@ g++ -std=c++17 -O2 -fPIC -shared \
     || { echo "[pineforge] compile failed" >&2; exit 3; }
 
 echo "[pineforge] running backtest ..." >&2
+
+# Optional per-run knobs (mirror scripts/run_strategy.py). Built conditionally so
+# unset env never passes an empty/invalid flag.
+#   PINEFORGE_TRADE_START_MS            unix-ms; suppress orders before it
+#   PINEFORGE_CHART_TZ                  IANA tz for date builtins
+#   PINEFORGE_MAGNIFIER_VOLUME_WEIGHTED 1/true → vw magnifier (needs BAR_MAGNIFIER)
+#   PINEFORGE_SYMINFO                   path to a syminfo.json
+#   PINEFORGE_BENCH (+_WARMUP/_REPEATS) 1/true → timing mode
+extra=()
+[[ -n "${PINEFORGE_TRADE_START_MS:-}" ]] && extra+=(--trade-start-ms "${PINEFORGE_TRADE_START_MS}")
+[[ -n "${PINEFORGE_CHART_TZ:-}" ]]       && extra+=(--chart-tz "${PINEFORGE_CHART_TZ}")
+[[ "${PINEFORGE_MAGNIFIER_VOLUME_WEIGHTED:-}" =~ ^(1|true|yes|on)$ ]] && extra+=(--magnifier-volume-weighted)
+[[ -n "${PINEFORGE_SYMINFO:-}" ]]        && extra+=(--syminfo "${PINEFORGE_SYMINFO}")
+if [[ "${PINEFORGE_BENCH:-}" =~ ^(1|true|yes|on)$ ]]; then
+    extra+=(--bench --warmup "${PINEFORGE_WARMUP:-3}" --repeats "${PINEFORGE_REPEATS:-20}")
+fi
 
 python3 "${PREFIX}/bin/run_json.py" \
     --so "${SO}" \
@@ -135,4 +154,5 @@ python3 "${PREFIX}/bin/run_json.py" \
     --magnifier-dist    "${PINEFORGE_MAGNIFIER_DIST:-endpoints}" \
     --generated-cpp     "${SRC}" \
     --transpiled        "${TRANSPILED}" \
+    ${extra[@]+"${extra[@]}"} \
     || { echo "[pineforge] backtest failed" >&2; exit 4; }

--- a/docker/run_json.py
+++ b/docker/run_json.py
@@ -533,6 +533,20 @@ def load_strategy(so_path: Path) -> ctypes.CDLL:
         if hasattr(lib, _n):
             getattr(lib, _n).argtypes = [ctypes.c_void_p, ctypes.c_char_p]
 
+    # Validation-parity setters mirrored from scripts/run_strategy.py. All
+    # hasattr-guarded: trade_start_time + chart_timezone are runtime PF exports;
+    # magnifier_volume_weighted is a PER-STRATEGY codegen symbol (may be absent
+    # on a .so that didn't emit it) — never call it unconditionally.
+    if hasattr(lib, "strategy_set_trade_start_time"):
+        lib.strategy_set_trade_start_time.argtypes = [ctypes.c_void_p, ctypes.c_int64]
+        lib.strategy_set_trade_start_time.restype = None
+    if hasattr(lib, "strategy_set_chart_timezone"):
+        lib.strategy_set_chart_timezone.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+        lib.strategy_set_chart_timezone.restype = None
+    if hasattr(lib, "strategy_set_magnifier_volume_weighted"):
+        lib.strategy_set_magnifier_volume_weighted.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        lib.strategy_set_magnifier_volume_weighted.restype = None
+
     lib.strategy_free.argtypes = [ctypes.c_void_p]
     lib.report_free.argtypes   = [ctypes.POINTER(ReportC)]
     return lib
@@ -719,6 +733,36 @@ def parse_bool(s: str) -> bool:
     return s.strip().lower() in ("1", "true", "yes", "on")
 
 
+def _timing_block(samples_ns, *, warmup, repeats, bar_magnifier,
+                  magnifier_samples, magnifier_dist, volume_weighted) -> dict:
+    """diagnostics.timing payload from raw per-repeat run_backtest_full samples.
+    Pure (no engine handle) so the --bench contract is unit-testable; consumed
+    by benchmarks/speed/time_pineforge_docker.py."""
+    return {
+        "mode": "run_backtest_full",
+        "warmup": int(warmup),
+        "repeats": int(repeats),
+        "samples_ns": list(samples_ns),
+        "magnifier": {
+            "enabled": bool(bar_magnifier),
+            "samples": magnifier_samples,
+            "dist": magnifier_dist,
+            "volume_weighted": volume_weighted,
+        },
+    }
+
+
+def _throughput_block(items_processed, samples_ns, *, bar_magnifier) -> dict:
+    """diagnostics.throughput payload. magnifier_mode mirrors the GBench
+    benchmark split (with_magnifier vs no_magnifier); consumed by
+    benchmarks/throughput/time_throughput_docker.py."""
+    return {
+        "items_processed": int(items_processed),
+        "samples_ns": list(samples_ns),
+        "magnifier_mode": "with_magnifier" if bar_magnifier else "no_magnifier",
+    }
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -752,6 +796,23 @@ def main() -> int:
                          "fingerprint as codegen.transpiled_from_pine.")
     ap.add_argument("--syminfo", type=Path, default=None,
                     help="syminfo.json to apply via strategy_set_syminfo_*")
+    ap.add_argument("--trade-start-ms", type=int, default=None,
+                    help="Suppress order execution before this unix-ms timestamp "
+                         "(strategy_set_trade_start_time). Mirrors the validation "
+                         "harness tv-window gate. Unset = no gate.")
+    ap.add_argument("--chart-tz", default="",
+                    help="IANA timezone for Pine date builtins (hour/minute/dayofweek) "
+                         "+ intraday-cap rollover (strategy_set_chart_timezone). "
+                         "Empty = engine UTC fast path.")
+    ap.add_argument("--magnifier-volume-weighted", action="store_true",
+                    help="Volume-weighted bar-magnifier sub-bar sampling; only effective "
+                         "with --bar-magnifier (strategy_set_magnifier_volume_weighted).")
+    ap.add_argument("--bench", action="store_true",
+                    help="Timing mode: warm up, then time ONLY run_backtest_full over N "
+                         "repeats; emit diagnostics.timing.samples_ns + diagnostics.throughput. "
+                         "Raw samples only — no median/ratio is computed in the image.")
+    ap.add_argument("--warmup", type=int, default=3, help="Bench warmup runs (default 3).")
+    ap.add_argument("--repeats", type=int, default=20, help="Bench timed repeats (default 20).")
     args = ap.parse_args()
 
     inputs    = parse_kv_json(args.inputs,    "--inputs")
@@ -767,23 +828,70 @@ def main() -> int:
 
     lib = load_strategy(args.so)
 
-    state = lib.strategy_create(b"{}")
-    for k, v in inputs.items():
-        lib.strategy_set_input(state, k.encode(), v.encode())
-    for k, v in overrides.items():
-        lib.strategy_set_override(state, k.encode(), v.encode())
-    if args.syminfo:
-        apply_syminfo(lib, state, args.syminfo)
+    # Volume-weighted magnifier only meaningful when the magnifier is on.
+    vw_on = bool(args.magnifier_volume_weighted) and bar_magnifier == 1
 
+    def _make_state():
+        """Create + fully configure a fresh strategy state — everything EXCEPT the
+        timed run_backtest_full call. Mirrors scripts/run_strategy.py's setup so the
+        engine behaves identically to the ctypes validation harness."""
+        st = lib.strategy_create(b"{}")
+        for k, v in inputs.items():
+            lib.strategy_set_input(st, k.encode(), v.encode())
+        for k, v in overrides.items():
+            lib.strategy_set_override(st, k.encode(), v.encode())
+        if args.syminfo:
+            apply_syminfo(lib, st, args.syminfo)
+        if args.trade_start_ms is not None and hasattr(lib, "strategy_set_trade_start_time"):
+            lib.strategy_set_trade_start_time(st, int(args.trade_start_ms))
+        if args.chart_tz and hasattr(lib, "strategy_set_chart_timezone"):
+            lib.strategy_set_chart_timezone(st, args.chart_tz.encode())
+        if vw_on and hasattr(lib, "strategy_set_magnifier_volume_weighted"):
+            lib.strategy_set_magnifier_volume_weighted(st, 1)
+        return st
+
+    def _run(st, rep):
+        lib.run_backtest_full(
+            st, bars, n,
+            input_tf, script_tf,
+            bar_magnifier, magnifier_samples, magnifier_dist,
+            ctypes.byref(rep),
+        )
+
+    # --- Bench mode: warm up, then time ONLY run_backtest_full over N repeats. ---
+    # Setup (create/set_input/free) is OUTSIDE the timed region so the sample
+    # isolates the engine hot loop (closest to the GBench harness). dlopen
+    # already happened above (load_strategy), outside any loop.
+    timing = None
+    if args.bench:
+        warmup = max(0, int(args.warmup))
+        repeats = max(1, int(args.repeats))
+        for _ in range(warmup):
+            st = _make_state(); rep = ReportC()
+            try:
+                _run(st, rep)
+            finally:
+                lib.report_free(ctypes.byref(rep)); lib.strategy_free(st)
+        samples_ns: list[int] = []
+        for _ in range(repeats):
+            st = _make_state(); rep = ReportC()
+            try:
+                t0 = time.perf_counter_ns(); _run(st, rep); t1 = time.perf_counter_ns()
+                samples_ns.append(t1 - t0)
+            finally:
+                lib.report_free(ctypes.byref(rep)); lib.strategy_free(st)
+        timing = _timing_block(
+            samples_ns, warmup=warmup, repeats=repeats,
+            bar_magnifier=bar_magnifier, magnifier_samples=magnifier_samples,
+            magnifier_dist=args.magnifier_dist.strip().lower() or "endpoints",
+            volume_weighted=vw_on)
+
+    # --- Body run: one configured run for trades / metrics / diagnostics. ---
+    state = _make_state()
     report = ReportC()
     started = time.time()
     try:
-        lib.run_backtest_full(
-            state, bars, n,
-            input_tf, script_tf,
-            bar_magnifier, magnifier_samples, magnifier_dist,
-            ctypes.byref(report),
-        )
+        _run(state, report)
         elapsed = time.time() - started
         err_msg = ""
         if hasattr(lib, "strategy_get_last_error"):
@@ -804,9 +912,17 @@ def main() -> int:
             "bar_magnifier":      bool(bar_magnifier),
             "magnifier_samples":  magnifier_samples,
             "magnifier_dist":     args.magnifier_dist.strip().lower() or "endpoints",
+            "magnifier_volume_weighted": vw_on,
+            "trade_start_ms":     args.trade_start_ms,
+            "chart_tz":           args.chart_tz or "",
         }
         out = build_report_dict(report, args.ohlcv, n, first_ts, last_ts,
                                 elapsed, inputs, overrides, applied_runtime)
+        if timing is not None:
+            out["diagnostics"]["timing"] = timing
+            out["diagnostics"]["throughput"] = _throughput_block(
+                report.input_bars_processed, timing["samples_ns"],
+                bar_magnifier=bar_magnifier)
         try:
             out["fingerprint"] = build_fingerprint(build_provenance(
                 engine_version(lib),

--- a/docker/run_json_diagnostics_test.py
+++ b/docker/run_json_diagnostics_test.py
@@ -67,3 +67,38 @@ def test_summary_bars_processed_unchanged():
     """summary.bars_processed stays = input_bars_processed (display = data scanned)."""
     rep = _call()
     assert rep["summary"]["bars_processed"] == 525_600
+
+
+# --- --bench diagnostics contract (timing + throughput) ---------------------
+# These pure blocks back the raw-data benchmark drivers
+# (benchmarks/speed/time_pineforge_docker.py,
+#  benchmarks/throughput/time_throughput_docker.py).
+
+def test_timing_block_shape():
+    t = run_json._timing_block(
+        [10, 20, 30], warmup=2, repeats=3, bar_magnifier=True,
+        magnifier_samples=4, magnifier_dist="endpoints", volume_weighted=False)
+    assert t["mode"] == "run_backtest_full"
+    assert t["warmup"] == 2 and t["repeats"] == 3
+    assert t["samples_ns"] == [10, 20, 30]
+    assert t["magnifier"] == {
+        "enabled": True, "samples": 4, "dist": "endpoints", "volume_weighted": False}
+
+
+def test_throughput_magnifier_mode_mapping():
+    on = run_json._throughput_block(525_600, [10, 20], bar_magnifier=True)
+    off = run_json._throughput_block(525_600, [10, 20], bar_magnifier=False)
+    assert on["magnifier_mode"] == "with_magnifier"
+    assert off["magnifier_mode"] == "no_magnifier"
+    assert on["items_processed"] == 525_600 and isinstance(on["items_processed"], int)
+    assert on["samples_ns"] == [10, 20]
+
+
+def test_timing_throughput_share_samples():
+    """run_json wires throughput.samples_ns = timing.samples_ns (drivers rely on
+    timing for speed and throughput for bars/s — they must be the same run)."""
+    t = run_json._timing_block(
+        [5, 6, 7], warmup=0, repeats=3, bar_magnifier=False,
+        magnifier_samples=1, magnifier_dist="endpoints", volume_weighted=False)
+    tp = run_json._throughput_block(100, t["samples_ns"], bar_magnifier=False)
+    assert tp["samples_ns"] == t["samples_ns"]

--- a/scripts/pf_release_run.py
+++ b/scripts/pf_release_run.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Run a strategy through the pineforge-release container and return its JSON
+report. Shared helper for the docker-runner paths of the corpus harness
+(scripts/run_strategy.py --runner docker) and the speed/throughput benchmark
+drivers.
+
+The image is a PURE RUNNER: it transpiles/compiles/runs and emits raw JSON.
+ALL analysis (tv emit-window, trade trimming, CSV formatting, parity verdict,
+speed median/ratio) stays host-side in the caller. This helper only:
+  - mounts the pre-transpiled generated.cpp (NEVER re-transpiles .pine — the
+    bundled codegen may differ from the one that produced the committed cpp),
+  - mounts the OHLCV (caller pre-trims for ohlcv_start_ms),
+  - maps already-resolved/normalized run knobs to the container's env contract
+    (docker/entrypoint.sh), incl. the validation-parity knobs,
+  - `docker run --rm`, parses stdout JSON, surfaces errors.
+
+The caller is responsible for normalization the image does NOT do (e.g. mapping
+a 'VOLUME_WEIGHTED' magnifier distribution to its real geometric distribution +
+the volume_weighted flag — pass dist already normalized).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+DEFAULT_IMAGE = os.environ.get(
+    "PINEFORGE_RELEASE_IMAGE", "ghcr.io/pineforge-4pass/pineforge-release:latest")
+
+
+class ReleaseRunError(RuntimeError):
+    pass
+
+
+def run_release(
+    generated_cpp: Path,
+    ohlcv: Path,
+    *,
+    image: str = DEFAULT_IMAGE,
+    inputs: dict | None = None,
+    overrides: dict | None = None,
+    input_tf: str = "",
+    script_tf: str = "",
+    bar_magnifier: bool = False,
+    magnifier_samples: int = 4,
+    magnifier_dist: str = "endpoints",
+    magnifier_volume_weighted: bool = False,
+    trade_start_ms: int | None = None,
+    chart_tz: str = "",
+    syminfo: dict | None = None,
+    bench: bool = False,
+    warmup: int = 3,
+    repeats: int = 20,
+    network: bool = False,
+    timeout: int = 600,
+) -> dict:
+    """Run one strategy in the container; return the parsed JSON report dict.
+
+    ``generated_cpp`` is mounted as /in/strategy.cpp (compile + run, no
+    transpile). ``ohlcv`` is mounted as /in/ohlcv.csv. ``syminfo`` (a dict) is
+    written to a temp file and mounted. Knob values must already be resolved by
+    the caller (e.g. magnifier_dist lowercased + not 'VOLUME_WEIGHTED')."""
+    generated_cpp = Path(generated_cpp).resolve()
+    ohlcv = Path(ohlcv).resolve()
+    if not generated_cpp.exists():
+        raise ReleaseRunError(f"generated.cpp not found: {generated_cpp}")
+    if not ohlcv.exists():
+        raise ReleaseRunError(f"ohlcv not found: {ohlcv}")
+
+    cmd = ["docker", "run", "--rm"]
+    if not network:
+        cmd += ["--network=none"]
+    cmd += [
+        "-v", f"{generated_cpp}:/in/strategy.cpp:ro",
+        "-v", f"{ohlcv}:/in/ohlcv.csv:ro",
+    ]
+
+    env = {
+        "PINEFORGE_INPUTS": json.dumps(inputs or {}),
+        "PINEFORGE_OVERRIDES": json.dumps(overrides or {}),
+        "PINEFORGE_INPUT_TF": input_tf or "",
+        "PINEFORGE_SCRIPT_TF": script_tf or "",
+        "PINEFORGE_BAR_MAGNIFIER": "true" if bar_magnifier else "false",
+        "PINEFORGE_MAGNIFIER_SAMPLES": str(int(magnifier_samples or 4)),
+        "PINEFORGE_MAGNIFIER_DIST": (magnifier_dist or "endpoints").lower(),
+    }
+    if trade_start_ms is not None:
+        env["PINEFORGE_TRADE_START_MS"] = str(int(trade_start_ms))
+    if chart_tz:
+        env["PINEFORGE_CHART_TZ"] = str(chart_tz)
+    if magnifier_volume_weighted and bar_magnifier:
+        env["PINEFORGE_MAGNIFIER_VOLUME_WEIGHTED"] = "1"
+    if bench:
+        env["PINEFORGE_BENCH"] = "1"
+        env["PINEFORGE_WARMUP"] = str(int(warmup))
+        env["PINEFORGE_REPEATS"] = str(int(repeats))
+
+    # syminfo dict -> temp JSON mounted into the container.
+    tmp_syminfo: Path | None = None
+    if syminfo:
+        import tempfile
+        fd, p = tempfile.mkstemp(suffix=".json", prefix="pf_syminfo_")
+        tmp_syminfo = Path(p)
+        with os.fdopen(fd, "w") as f:
+            json.dump(syminfo, f)
+        cmd += ["-v", f"{tmp_syminfo}:/in/syminfo.json:ro"]
+        env["PINEFORGE_SYMINFO"] = "/in/syminfo.json"
+
+    for k, v in env.items():
+        cmd += ["-e", f"{k}={v}"]
+    cmd += [image]
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    finally:
+        if tmp_syminfo is not None:
+            tmp_syminfo.unlink(missing_ok=True)
+
+    if proc.returncode != 0:
+        raise ReleaseRunError(
+            f"docker run failed (exit {proc.returncode}) for {generated_cpp.parent.name}\n"
+            f"stderr tail:\n{proc.stderr[-2000:]}")
+    out = proc.stdout.strip()
+    if not out:
+        raise ReleaseRunError(f"empty stdout from container for {generated_cpp.parent.name}")
+    # The report is the last JSON line (engine logs go to stderr, but be defensive).
+    try:
+        report = json.loads(out.splitlines()[-1])
+    except json.JSONDecodeError as e:
+        raise ReleaseRunError(f"non-JSON container stdout: {e}\n{out[-1000:]}")
+    if isinstance(report, dict) and report.get("error"):
+        raise ReleaseRunError(f"engine error: {report['error']}")
+    return report
+
+
+def report_trades_to_runstrategy_shape(report: dict) -> list[dict]:
+    """Map run_json.py trades[] -> the dict shape scripts/run_strategy.py's
+    write_engine_trades_csv expects. Key diff: run_json emits ``side`` ('long'/
+    'short'); the writer reads ``is_long``. max_drawdown stays POSITIVE (the
+    writer negates it for the TV export). All other keys already match."""
+    out = []
+    for t in report.get("trades", []):
+        out.append({
+            "entry_time": int(t["entry_time"]),
+            "exit_time": int(t["exit_time"]),
+            "entry_price": float(t["entry_price"]),
+            "exit_price": float(t["exit_price"]),
+            "pnl": float(t["pnl"]),
+            "pnl_pct": float(t["pnl_pct"]),
+            "is_long": (t["side"] == "long"),
+            "max_runup": float(t["max_runup"]),
+            "max_drawdown": float(t["max_drawdown"]),
+            "qty": float(t["qty"]),
+            "commission": float(t.get("commission", 0.0)),
+            "entry_bar_index": int(t.get("entry_bar_index", -1)),
+            "exit_bar_index": int(t.get("exit_bar_index", -1)),
+        })
+    return out

--- a/scripts/run_corpus.sh
+++ b/scripts/run_corpus.sh
@@ -29,6 +29,11 @@ else
 fi
 
 PY="${PYTHON:-python3}"
+# RUNNER=docker runs each probe's committed generated.cpp through the
+# pineforge-release image (no host C++ toolchain) instead of an in-process
+# strategy.so. IMAGE overrides the image tag. engine_trades.csv is identical
+# either way; verify_corpus.py judges parity. docker mode skips the CMake build.
+RUNNER="${RUNNER:-ctypes}"
 
 log()  { printf '\033[1;34m[run_corpus]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[run_corpus]\033[0m %s\n' "$*" >&2; }
@@ -53,7 +58,7 @@ fi
 
 # --- 1) build ---------------------------------------------------------
 
-if [[ "${SKIP_BUILD:-0}" != "1" ]]; then
+if [[ "${SKIP_BUILD:-0}" != "1" && "$RUNNER" != "docker" ]]; then
     log "configuring CMake (build_type=$BUILD_TYPE, dir=$BUILD_DIR)"
     cmake -B "$BUILD_DIR" -S . \
         -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
@@ -68,7 +73,11 @@ fi
 # --- 2) run -----------------------------------------------------------
 
 if [[ "${SKIP_RUN:-0}" != "1" ]]; then
-    log "running every strategy.so against the reference OHLCV feed"
+    if [[ "$RUNNER" == "docker" ]]; then
+        log "running every committed generated.cpp via the pineforge-release image${IMAGE:+ ($IMAGE)}"
+    else
+        log "running every strategy.so against the reference OHLCV feed"
+    fi
     n_ok=0
     n_fail=0
     failed=()
@@ -76,21 +85,28 @@ if [[ "${SKIP_RUN:-0}" != "1" ]]; then
 
     for strat_dir in corpus/*/*/; do
         strat_dir="${strat_dir%/}"
-        [[ -f "$strat_dir/strategy.so" || -f "$strat_dir/strategy.dylib" || -f "$strat_dir/strategy.dll" ]] || continue
         if [[ -n "${ONLY:-}" && "$strat_dir" != *"$ONLY"* ]]; then
             continue
         fi
 
-        # Pick whichever shared lib extension actually exists for this platform.
-        if [[ -f "$strat_dir/strategy.dylib" ]]; then
-            so_name="strategy.dylib"
-        elif [[ -f "$strat_dir/strategy.dll" ]]; then
-            so_name="strategy.dll"
+        if [[ "$RUNNER" == "docker" ]]; then
+            [[ -f "$strat_dir/generated.cpp" ]] || continue
+            run_cmd=("$PY" scripts/run_strategy.py "$strat_dir" --runner docker)
+            [[ -n "${IMAGE:-}" ]] && run_cmd+=(--image "${IMAGE}")
         else
-            so_name="strategy.so"
+            [[ -f "$strat_dir/strategy.so" || -f "$strat_dir/strategy.dylib" || -f "$strat_dir/strategy.dll" ]] || continue
+            # Pick whichever shared lib extension actually exists for this platform.
+            if [[ -f "$strat_dir/strategy.dylib" ]]; then
+                so_name="strategy.dylib"
+            elif [[ -f "$strat_dir/strategy.dll" ]]; then
+                so_name="strategy.dll"
+            else
+                so_name="strategy.so"
+            fi
+            run_cmd=("$PY" scripts/run_strategy.py "$strat_dir" --so-name "$so_name")
         fi
 
-        if "$PY" scripts/run_strategy.py "$strat_dir" --so-name "$so_name" >/dev/null 2>&1; then
+        if "${run_cmd[@]}" >/dev/null 2>&1; then
             n_ok=$((n_ok + 1))
         else
             n_fail=$((n_fail + 1))

--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -44,6 +44,7 @@ import csv
 import ctypes
 import hashlib
 import json
+import os
 import re
 import sys
 import time
@@ -1009,6 +1010,97 @@ def _infer_bar_interval_ms(csv_path: Path) -> int:
             prev = ts
     return 15 * 60 * 1000
 
+# --- docker runner (pineforge-release image) ---------------------------
+
+def _run_via_docker(strategy_dir: Path, ohlcv_path: Path, params: dict,
+                    run_kwargs: dict, trade_start_ms, image) -> dict:
+    """Run the COMMITTED generated.cpp through the pineforge-release container and
+    return a report dict shaped like Strategy.run / _report_to_dict, so the
+    host-side emit-window filter + write_engine_trades_csv work UNCHANGED.
+
+    Mirrors Strategy.run's engine setup exactly: inputs filter, strategy_overrides,
+    input_tf/script_tf, magnifier (incl. the VOLUME_WEIGHTED->ENDPOINTS+vw mapping),
+    trade_start_time, chart_timezone, syminfo. ohlcv_start_ms is applied by
+    pre-trimming the CSV fed to the container (the ctypes path trims in _load_bars).
+    NEVER re-transpiles .pine (uses the committed cpp, no codegen variance)."""
+    import pf_release_run as _rel
+    generated_cpp = strategy_dir / "generated.cpp"
+    if not generated_cpp.exists():
+        raise FileNotFoundError(f"generated.cpp not found for --runner docker: {generated_cpp}")
+
+    # ohlcv_start_ms: ctypes trims bars in _load_bars; the container needs an
+    # already-trimmed CSV (M8 — feed the same trimmed feed downstream).
+    ohlcv_for_image = ohlcv_path
+    tmp_ohlcv = None
+    start_ms = run_kwargs.get("ohlcv_start_ms")
+    if start_ms is not None:
+        import tempfile
+        fd, p = tempfile.mkstemp(suffix=".csv", prefix="pf_ohlcv_")
+        tmp_ohlcv = Path(p)
+        with ohlcv_path.open(newline="", encoding="utf-8") as fin, \
+                os.fdopen(fd, "w", newline="") as fout:
+            r = csv.DictReader(fin)
+            w = csv.DictWriter(fout, fieldnames=r.fieldnames)
+            w.writeheader()
+            for row in r:
+                if int(row["timestamp"]) >= int(start_ms):
+                    w.writerow(row)
+        ohlcv_for_image = tmp_ohlcv
+
+    # Magnifier dist/vw: mirror Strategy.run. 'VOLUME_WEIGHTED' is not a geometric
+    # distribution — fall back to ENDPOINTS for the t-grid AND toggle vw.
+    dist = str(run_kwargs.get("magnifier_distribution") or "ENDPOINTS")
+    vw = bool(run_kwargs.get("magnifier_volume_weighted")) or dist.upper() == "VOLUME_WEIGHTED"
+    if dist.upper() == "VOLUME_WEIGHTED":
+        dist = "ENDPOINTS"
+
+    # Inputs forwarded to the engine: same filter as Strategy.run (drop tv_*/meta).
+    inputs_for_image = {
+        str(k): str(v) for k, v in params.items()
+        if not str(k).startswith("tv_") and k not in _VALIDATION_META_KEYS
+    }
+    # syminfo from runtime_overrides. apply_syminfo covers mintick/pointvalue/
+    # timezone/session; syminfo_metadata (fundamentals) is NOT covered — 0 corpus
+    # probes use it (documented gap).
+    syminfo: dict = {}
+    if run_kwargs.get("syminfo_timezone"):
+        syminfo["timezone"] = run_kwargs["syminfo_timezone"]
+    if run_kwargs.get("syminfo_session"):
+        syminfo["session"] = run_kwargs["syminfo_session"]
+    if run_kwargs.get("syminfo_mintick") is not None:
+        syminfo["mintick"] = run_kwargs["syminfo_mintick"]
+    if run_kwargs.get("syminfo_pointvalue") is not None:
+        syminfo["pointvalue"] = run_kwargs["syminfo_pointvalue"]
+
+    kw = dict(
+        inputs=inputs_for_image,
+        overrides=run_kwargs.get("strategy_overrides") or {},
+        input_tf=run_kwargs.get("input_tf") or "",
+        script_tf=run_kwargs.get("script_tf") or "",
+        bar_magnifier=bool(run_kwargs.get("bar_magnifier")),
+        magnifier_samples=int(run_kwargs.get("magnifier_samples") or 4),
+        magnifier_dist=dist,
+        magnifier_volume_weighted=vw,
+        trade_start_ms=trade_start_ms,
+        chart_tz=run_kwargs.get("chart_timezone") or "",
+        syminfo=syminfo or None,
+    )
+    if image:
+        kw["image"] = image
+    try:
+        raw = _rel.run_release(generated_cpp, ohlcv_for_image, **kw)
+    finally:
+        if tmp_ohlcv is not None:
+            tmp_ohlcv.unlink(missing_ok=True)
+    return {
+        "trades": _rel.report_trades_to_runstrategy_shape(raw),
+        "net_profit": float(raw.get("summary", {}).get("net_pnl", 0.0)),
+        "input_bars_processed": int(raw.get("diagnostics", {}).get("input_bars_processed", 0)),
+        "trace": [],
+        "trace_names": [],
+    }
+
+
 # --- CLI ---------------------------------------------------------------
 
 def main() -> int:
@@ -1052,6 +1144,15 @@ def main() -> int:
                     help="Write a {token,digest,provenance} fingerprint of this "
                          "run to PATH. Off by default (keeps corpus output and "
                          "run_corpus.sh parity untouched).")
+    ap.add_argument("--runner", choices=["ctypes", "docker"], default="ctypes",
+                    help="Engine backend. 'ctypes' (default) loads the prebuilt "
+                         "strategy.so in-process. 'docker' runs the committed "
+                         "generated.cpp through the pineforge-release image (no host "
+                         "C++ toolchain) — same engine_trades.csv, verified by "
+                         "verify_corpus.py tolerance tiers.")
+    ap.add_argument("--image", default=None,
+                    help="pineforge-release image for --runner docker (default: "
+                         "$PINEFORGE_RELEASE_IMAGE or ghcr .../pineforge-release:latest).")
     args = ap.parse_args()
 
     strategy_dir = args.strategy_dir.resolve()
@@ -1062,10 +1163,7 @@ def main() -> int:
         return 0
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    so_path = find_strategy_lib(strategy_dir, args.so_name)
-
     started = time.time()
-    strat = Strategy(so_path)
     inputs_path = (args.inputs_json.resolve() if args.inputs_json
                    else strategy_dir / "inputs.json")
     params = {}
@@ -1090,10 +1188,22 @@ def main() -> int:
         if emit_window is None:
             emit_window = _load_window_ms(REFERENCE_OHLCV)
     trade_start_ms = emit_window[0] if (emit_window is not None and (tv_window_used or args.disable_trading_before_window)) else None
-    report = strat.run(ohlcv_path, params=params,
-                       trace_enabled=args.trace_json is not None,
-                       trade_start_time_ms=trade_start_ms,
-                       **run_kwargs)
+
+    if args.runner == "docker":
+        if args.trace_json is not None:
+            sys.exit("error: --trace-json needs --emit-plots (deferred); not supported with --runner docker.")
+        if args.fingerprint_json is not None:
+            sys.exit("error: --fingerprint-json is not supported with --runner docker.")
+        strat = None
+        report = _run_via_docker(strategy_dir, ohlcv_path, params, run_kwargs,
+                                 trade_start_ms, args.image)
+    else:
+        so_path = find_strategy_lib(strategy_dir, args.so_name)
+        strat = Strategy(so_path)
+        report = strat.run(ohlcv_path, params=params,
+                           trace_enabled=args.trace_json is not None,
+                           trade_start_time_ms=trade_start_ms,
+                           **run_kwargs)
     raw_trade_count = len(report["trades"])
     trades_to_write = _filter_trades_to_window(report["trades"], emit_window)
     write_engine_trades_csv(trades_to_write, out_path)


### PR DESCRIPTION
## What

Lets the public reproduce **parity** and **performance** from the published
`pineforge-release` image with **no host C++ toolchain**. The image emits RAW
per-run data; all analysis (parity verdict, speed/throughput stats) stays
host-side in `corpus/` + `benchmarks/`.

### Harness (mirrored to pineforge-release)
- `run_json.py`: `--trade-start-ms`, `--chart-tz`, `--magnifier-volume-weighted`,
  and `--bench` (`--warmup`/`--repeats`) timing **only** `run_backtest_full` per
  repeat via `perf_counter_ns` → `diagnostics.timing.samples_ns` +
  `diagnostics.throughput`. Pure `_timing_block`/`_throughput_block` helpers.
- `entrypoint.sh`: forward the new `PINEFORGE_*` env → flags; add
  `-ffp-contract=off` to the strategy-TU compile (parity-critical).

### Repro drivers (host)
- `scripts/pf_release_run.py` (NEW): shared image runner.
- `run_strategy.py --runner {ctypes,docker}` (default `ctypes`); `run_corpus.sh`
  `RUNNER` env. `engine_trades.csv` is identical either way; `verify_corpus.py` judges.
- `benchmarks/speed`: `time_pineforge_docker.py`, `aggregate.py --pineforge-format`,
  `run_all.sh` `RUNNER=docker` branch. **GBench stays authoritative**; docker is advisory.
- `benchmarks/throughput`: `time_throughput_docker.py`, `plot_quartile.py --format subproc`,
  `reproduce.sh` `RUNNER=docker` branch.

### CI (lib-only)
- Engine no longer builds a container (pineforge-release is the sole image, built
  FROM the engine tarball). Drop in-engine docker build + dead env. Hub dispatch
  moved to `notify-hub` (needs `[release, prebuilt]`) so the tarball exists first.

## Validation
- `ctest`: **72/72**.
- Native `run_corpus.sh` (ctypes): **246 ran, excellent=245 / anomaly=1** (baseline); corpus tree byte-clean.
- Docker `run_corpus.sh` (local hub image): 246 ran, **245/1**, all `engine_trades.csv` byte-identical to committed.
- `check_c_abi_runtime.py` exit 0; run_json pytest **7/7**.
- Speed/throughput spot-checks end-to-end through a freshly built image.
- **No `src/` or `include/` changes.**