### PR TITLE
fix: magnifier on_bar timestamp + from_entry exit-bracket retention

### DIFF
--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -997,7 +997,7 @@ protected:
     virtual void clear_security(int sec_id) {}
 
     // Magnifier helpers
-    void run_magnified_bar(const std::vector<Bar>& sub_bars);
+    void run_magnified_bar(const std::vector<Bar>& sub_bars, int64_t script_bar_ts);
     virtual void finalize_bar() {}
 
     // --- Equity extremes update (called after each on_bar) ---

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1187,7 +1187,7 @@ private:
     // siblings' qty by Q. Siblings whose qty becomes <= 0 are cancelled.
     void reduce_oca_group(const std::string& oca_name, const std::string& exclude_id,
                           double filled_qty);
-    void purge_exit_orders();
+    void purge_exit_orders(bool retain_for_pending_entries = false);
 
     // process_pending_orders helpers (defined in engine_fills.cpp).
     // Decomposed during the function-decomposition refactor so the

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -84,9 +84,11 @@ void BacktestEngine::process_pending_orders(const Bar& bar) {
     compact_filled_pending_orders(filled_indices, exit_closed_from_bar, exit_closed_was_long);
     }  // opposing_pass
 
-    // If position is flat after processing, purge any remaining exit orders
+    // If position is flat after processing, purge remaining exit orders — but
+    // RETAIN from_entry brackets whose parent entry is still pending (a limit
+    // entry that has not yet filled), so they fire once the entry fills.
     if (position_side_ == PositionSide::FLAT) {
-        purge_exit_orders();
+        purge_exit_orders(/*retain_for_pending_entries=*/true);
     }
 }
 

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -276,7 +276,29 @@ void BacktestEngine::reduce_oca_group(const std::string& oca_name,
 }
 
 
-void BacktestEngine::purge_exit_orders() {
+void BacktestEngine::purge_exit_orders(bool retain_for_pending_entries) {
+    if (retain_for_pending_entries) {
+        // End-of-bar flat-purge: the position is flat, but a from_entry-bound
+        // EXIT bracket whose parent ENTRY is still a PENDING order (e.g. a limit
+        // entry that could not fill on its creation bar) must be RETAINED — once
+        // the entry fills on a later bar the bracket fires, matching TV. Only
+        // brackets with no live/pending parent entry are stale and dropped.
+        std::unordered_set<std::string> pending_entry_ids;
+        for (const auto& o : pending_orders_) {
+            if (o.type == OrderType::ENTRY || o.type == OrderType::MARKET) {
+                pending_entry_ids.insert(o.id);
+            }
+        }
+        pending_orders_.erase(
+            std::remove_if(pending_orders_.begin(), pending_orders_.end(),
+                [&](const PendingOrder& o) {
+                    return o.type == OrderType::EXIT
+                        && !(!o.from_entry.empty()
+                             && pending_entry_ids.count(o.from_entry));
+                }),
+            pending_orders_.end());
+        return;
+    }
     pending_orders_.erase(
         std::remove_if(pending_orders_.begin(), pending_orders_.end(),
             [](const PendingOrder& o) { return o.type == OrderType::EXIT; }),

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -187,7 +187,7 @@ void BacktestEngine::run(const Bar* bars, int n) {
 
 
 // --- run_magnified_bar ---
-void BacktestEngine::run_magnified_bar(const std::vector<Bar>& sub_bars) {
+void BacktestEngine::run_magnified_bar(const std::vector<Bar>& sub_bars, int64_t script_bar_ts) {
     if (sub_bars.empty()) return;
 
     double bar_open = sub_bars.front().open;
@@ -274,6 +274,14 @@ void BacktestEngine::run_magnified_bar(const std::vector<Bar>& sub_bars) {
                 if (is_last_tick_) {
                     // Force is_first_tick_ true so that on_bar advances the series history.
                     is_first_tick_ = true;
+                    // The strategy body and its time-of-day builtins
+                    // (hour/minute/dayofmonth, intraday session gates) must see
+                    // the SCRIPT bar's canonical open timestamp, not the final
+                    // sub-bar's ts — else exact-time gates ("lock IB at 10:30")
+                    // never fire. Intrabar fills above already used the real
+                    // sub-bar timestamps. No-op when total_sub==1 (synthesized
+                    // magnifier: the single sub-bar IS the script bar).
+                    current_bar_.timestamp = script_bar_ts;
                     _push_source_series();
                     on_bar(current_bar_);
                     process_pending_orders(current_bar_);
@@ -284,6 +292,9 @@ void BacktestEngine::run_magnified_bar(const std::vector<Bar>& sub_bars) {
                 if (is_last_tick_) {
                     // Force is_first_tick_ true so that on_bar advances the series history.
                     is_first_tick_ = true;
+                    // See note above: strategy body sees the script-bar open ts,
+                    // not the final sub-bar ts.
+                    current_bar_.timestamp = script_bar_ts;
                     _push_source_series();
                     on_bar(current_bar_);
                 }
@@ -547,7 +558,7 @@ void BacktestEngine::run_aggregation_bar_loop(const Bar* input_bars, int n_input
                                                             group_sub_bars.front().timestamp);
                 session_isfirstbar_ = session_ismarket_ && !prev_in_session_;
                 session_islastbar_  = false;  // not deterministic in magnifier mode without lookahead
-                run_magnified_bar(group_sub_bars);
+                run_magnified_bar(group_sub_bars, script_bar_ts);
                 prev_in_session_ = session_ismarket_;
                 group_sub_bars.clear();
             } else {


### PR DESCRIPTION
Two engine order/fill correctness fixes. **Guard: `run_corpus.sh` → `verify_corpus.py --all` holds excellent=245, anomaly=1 (no parity regression).**

## Magnifier on_bar timestamp (`8c31ef6`)
In real-bar magnifier mode (input_tf < script_tf), `run_magnified_bar` invoked `on_bar` with the **last sub-bar's** timestamp, so time-of-day-gated strategies (exact `hour`/`minute` gates, intraday resets) produced **0 trades** under the magnifier. Now passes the script-bar open ts; intrabar fills keep their real sub-bar ts. No-op when total_sub==1 (synthesized magnifier), so the magnifier corpus probes are unaffected.

## from_entry exit-bracket retention (`b567269`)
The end-of-bar flat-purge dropped ALL remaining EXIT orders when flat — but a `strategy.exit(from_entry="X", …)` issued alongside a pending LIMIT `strategy.entry("X", limit=…)` leaves the broker flat until the limit fills on a later bar, so the bracket was purged before its parent entry filled (position then rode to a time-stop). TradingView keeps and fires these brackets. The flat-purge now **retains** an EXIT whose `from_entry` matches a still-pending ENTRY; the post-market-exit purge is unchanged (opt-in `retain_for_pending_entries` param). **bnf6082 IB-breakout: moderate→excellent.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)