### PR TITLE
feat(drawing): add drawing objects as data runtime

### DIFF
--- a/include/pineforge/drawing.hpp
+++ b/include/pineforge/drawing.hpp
@@ -87,7 +87,7 @@ class DrawingArena {
     std::deque<int32_t>  order_;  // live ids, oldest -> newest == the *.all order; drives FIFO eviction
     int                  cap_;
 public:
-    explicit DrawingArena(int cap = 50) : cap_(cap) {}
+    explicit DrawingArena(int cap = 50) : cap_(std::max(1, cap)) {}
 
     int32_t alloc(Rec r) {
         while ((int)order_.size() >= cap_) {        // exact-cap FIFO eviction (oldest first)

--- a/include/pineforge/drawing.hpp
+++ b/include/pineforge/drawing.hpp
@@ -1,0 +1,298 @@
+#pragma once
+//
+// PineForge drawing-objects-as-data runtime.
+//
+// Spec: docs/drawing-objects-as-data.md §3 ("C++ Runtime").
+//
+// This is a HEADLESS backtester: drawing objects (line/box/label/linefill) are
+// pure DATA the strategy can create, mutate and read back into trading logic.
+// There is NO rendering, NO graphics — only geometry. The header is fully
+// self-contained and header-only (every function is `inline`); codegen emits
+// calls to the `pf_*` free functions below. Nothing here is exported via the C
+// ABI — these are codegen-emitted in-process calls, not `c_abi.cpp` symbols.
+//
+// The header is gated into the generated include block behind `self._uses_drawing`
+// exactly like `matrix.hpp` is gated behind `_uses_matrix`. The arenas are members
+// of the generated strategy subclass, so reset-per-run is automatic (a fresh
+// strategy instance is constructed per backtest).
+//
+#include <vector>
+#include <deque>
+#include <string>
+#include <algorithm>
+#include <cstdint>
+#include <stdexcept>
+#include <cmath>
+#include <utility>
+#include <pineforge/na.hpp>
+
+namespace pineforge {
+
+// ---- enums (spec §3.2) -----------------------------------------------------
+enum class XLoc : int { bar_index = 0, bar_time = 1 };           // default bar_index
+enum class YLoc : int { price = 0, abovebar = 1, belowbar = 2 }; // default price
+
+// ---- value-view handles (spec §3.2) ----------------------------------------
+// Stored in vars / array<T> / UDT fields. id < 0 == na.
+struct Line     { int32_t id = -1; };
+struct Box      { int32_t id = -1; };
+struct Label    { int32_t id = -1; };
+struct Linefill { int32_t id = -1; };
+
+inline bool is_na(const Line& h)     { return h.id < 0; }
+inline bool is_na(const Box& h)      { return h.id < 0; }
+inline bool is_na(const Label& h)    { return h.id < 0; }
+inline bool is_na(const Linefill& h) { return h.id < 0; }
+
+// ---- pure value type: chart.point (spec §3.2) ------------------------------
+// No arena, no identity, no delete. Lowered inline as aggregate literals by
+// codegen; the engine only needs the struct + its is_na overload.
+struct ChartPoint {
+    int64_t index = na<int64_t>();   // x-coord as bar index (na sentinel INT64_MIN)
+    int64_t time  = na<int64_t>();   // x-coord as UNIX ms
+    double  price = na<double>();    // y-coord (NaN sentinel)
+};
+inline bool is_na(const ChartPoint& p) {
+    return is_na(p.index) && is_na(p.time) && is_na(p.price);
+}
+
+// ---- arena records (spec §3.3) ---------------------------------------------
+// Geometry only — every visual field (color/style/width/...) is dropped at
+// lowering. x-coords are int64_t (xloc.bar_time stores UNIX-ms, overflows
+// int32; na sentinel INT64_MIN); y-coords/prices are double (NaN sentinel).
+// NOTE: BoxRec has NO extend and NO text fields (unlike LineRec / LabelRec).
+struct LineRec     { int64_t x1, x2; double y1, y2; XLoc xloc; bool ext_l, ext_r; bool alive; };
+struct BoxRec      { int64_t left, right; double top, bottom; XLoc xloc; bool alive; };
+struct LabelRec    { int64_t x; double y; XLoc xloc; YLoc yloc; std::string text; bool alive; };
+struct LinefillRec { int32_t line1, line2; bool alive; };
+
+// ---- error type (spec §3.7) ------------------------------------------------
+// Derives from std::runtime_error so BacktestEngine::run()'s existing
+// `catch (const std::exception& e)` (src/engine_run.cpp) halts the backtest
+// exactly like TradingView when a drawing op touches a dead/na handle.
+// Drawing is ALWAYS-ON and ALWAYS TV-faithful: no compile flag, no lenient mode.
+struct pine_drawing_error : std::runtime_error {
+    explicit pine_drawing_error(const std::string& msg) : std::runtime_error(msg) {}
+};
+
+// dead/na handle access is ALWAYS an error — no flag, no lenient mode (spec §3.7)
+#define PF_DRAW_DEAD(arena, handle) throw pine_drawing_error("drawing access on na/deleted handle")
+
+// ---- arena template (spec §3.4) --------------------------------------------
+// ids are monotonic and never reused (dead slots are tombstoned, not recycled)
+// -> no ABA, reproducible across runs. Exact-cap FIFO eviction (oldest first).
+template <class Rec>
+class DrawingArena {
+    std::vector<Rec>     recs_;   // index == id; dead slots retained so ids are stable & monotonic
+    std::deque<int32_t>  order_;  // live ids, oldest -> newest == the *.all order; drives FIFO eviction
+    int                  cap_;
+public:
+    explicit DrawingArena(int cap = 50) : cap_(cap) {}
+
+    int32_t alloc(Rec r) {
+        while ((int)order_.size() >= cap_) {        // exact-cap FIFO eviction (oldest first)
+            int32_t old = order_.front();
+            order_.pop_front();
+            recs_[old].alive = false;
+        }
+        int32_t id = (int32_t)recs_.size();
+        r.alive = true;
+        recs_.push_back(std::move(r));
+        order_.push_back(id);
+        return id;
+    }
+
+    void erase(int32_t id) {                         // delete(): silent no-op on na/dead
+        if (!alive(id)) return;
+        recs_[id].alive = false;
+        order_.erase(std::find(order_.begin(), order_.end(), id));
+    }
+
+    bool alive(int32_t id) const { return id >= 0 && id < (int)recs_.size() && recs_[id].alive; }
+
+    Rec&       at(int32_t id)       { return recs_[id]; }
+    const Rec& at(int32_t id) const { return recs_[id]; }
+
+    const std::deque<int32_t>& order() const { return order_; }  // backs line.all/box.all if ever needed
+};
+
+// ---- shared helpers --------------------------------------------------------
+// Returns a reference to the live record for a handle, or THROWS pine_drawing_error
+// (spec §3.7: any getter/setter on a dead/na handle halts, unconditionally).
+template <class Rec, class Handle>
+inline Rec& pf_require_live(DrawingArena<Rec>& a, Handle h) {
+    if (!a.alive(h.id)) throw pine_drawing_error("drawing access on na/deleted handle");
+    return a.at(h.id);
+}
+
+// Selects the x-coordinate a ChartPoint contributes for a given xloc.
+inline int64_t pf_point_x(const ChartPoint& p, XLoc xloc) {
+    return (xloc == XLoc::bar_time) ? p.time : p.index;
+}
+
+// ============================ line ==========================================
+inline Line pf_line_new(DrawingArena<LineRec>& a, int64_t x1, double y1, int64_t x2, double y2,
+                        XLoc xloc = XLoc::bar_index, bool el = false, bool er = false) {
+    // *_new(na,na,na,na) allocates a LIVE record with na coords (NOT a na handle).
+    return Line{ a.alloc(LineRec{ x1, x2, y1, y2, xloc, el, er, true }) };
+}
+inline Line pf_line_new_pts(DrawingArena<LineRec>& a, ChartPoint p1, ChartPoint p2,
+                            XLoc xloc = XLoc::bar_index) {
+    return Line{ a.alloc(LineRec{ pf_point_x(p1, xloc), pf_point_x(p2, xloc),
+                                  p1.price, p2.price, xloc, false, false, true }) };
+}
+
+inline int64_t pf_line_get_x1(DrawingArena<LineRec>& a, Line h) { return pf_require_live(a, h).x1; }
+inline int64_t pf_line_get_x2(DrawingArena<LineRec>& a, Line h) { return pf_require_live(a, h).x2; }
+inline double  pf_line_get_y1(DrawingArena<LineRec>& a, Line h) { return pf_require_live(a, h).y1; }
+inline double  pf_line_get_y2(DrawingArena<LineRec>& a, Line h) { return pf_require_live(a, h).y2; }
+
+inline void pf_line_set_x1(DrawingArena<LineRec>& a, Line h, int64_t v) { pf_require_live(a, h).x1 = v; }
+inline void pf_line_set_x2(DrawingArena<LineRec>& a, Line h, int64_t v) { pf_require_live(a, h).x2 = v; }
+inline void pf_line_set_y1(DrawingArena<LineRec>& a, Line h, double v)  { pf_require_live(a, h).y1 = v; }
+inline void pf_line_set_y2(DrawingArena<LineRec>& a, Line h, double v)  { pf_require_live(a, h).y2 = v; }
+inline void pf_line_set_xy1(DrawingArena<LineRec>& a, Line h, int64_t x, double y) {
+    LineRec& r = pf_require_live(a, h); r.x1 = x; r.y1 = y;
+}
+inline void pf_line_set_xy2(DrawingArena<LineRec>& a, Line h, int64_t x, double y) {
+    LineRec& r = pf_require_live(a, h); r.x2 = x; r.y2 = y;
+}
+inline void pf_line_set_first_point(DrawingArena<LineRec>& a, Line h, ChartPoint p) {
+    LineRec& r = pf_require_live(a, h); r.x1 = pf_point_x(p, r.xloc); r.y1 = p.price;
+}
+inline void pf_line_set_second_point(DrawingArena<LineRec>& a, Line h, ChartPoint p) {
+    LineRec& r = pf_require_live(a, h); r.x2 = pf_point_x(p, r.xloc); r.y2 = p.price;
+}
+inline void pf_line_set_xloc(DrawingArena<LineRec>& a, Line h, int64_t x1, int64_t x2, XLoc xloc) {
+    // REINTERPRET: stores new numbers + flag; does NOT convert coord spaces (TV-faithful, spec §3.9).
+    LineRec& r = pf_require_live(a, h); r.x1 = x1; r.x2 = x2; r.xloc = xloc;
+}
+
+// real computation: infinite line, ignores extend; valid for xloc.bar_index (spec §3.6).
+inline double pf_line_get_price(DrawingArena<LineRec>& a, Line h, int64_t x) {
+    if (!a.alive(h.id)) PF_DRAW_DEAD(a, h);             // dead/na line -> throw -> halt (like TV)
+    const LineRec& r = a.at(h.id);
+    if (r.xloc == XLoc::bar_time)
+        throw pine_drawing_error("line.get_price requires xloc.bar_index"); // TV errors on bar_time lines
+    if (r.x1 == r.x2) return na<double>();              // degenerate vertical -> na (matches TV)
+    return r.y1 + (r.y2 - r.y1) / (double)(r.x2 - r.x1) * (double)(x - r.x1); // infinite line, ignores extend
+}
+
+inline Line pf_line_copy(DrawingArena<LineRec>& a, Line h) {
+    if (!a.alive(h.id)) return Line{};                 // copy of na/dead -> na handle (silent)
+    LineRec r = a.at(h.id);                             // deep copy = independent new arena record
+    return Line{ a.alloc(r) };
+}
+inline void pf_line_delete(DrawingArena<LineRec>& a, Line h) { a.erase(h.id); } // silent no-op on na/dead
+
+// ============================ box ===========================================
+inline Box pf_box_new(DrawingArena<BoxRec>& a, int64_t left, double top, int64_t right, double bottom,
+                      XLoc xloc = XLoc::bar_index) {
+    return Box{ a.alloc(BoxRec{ left, right, top, bottom, xloc, true }) };
+}
+inline Box pf_box_new_pts(DrawingArena<BoxRec>& a, ChartPoint top_left, ChartPoint bottom_right,
+                          XLoc xloc = XLoc::bar_index) {
+    return Box{ a.alloc(BoxRec{ pf_point_x(top_left, xloc), pf_point_x(bottom_right, xloc),
+                                top_left.price, bottom_right.price, xloc, true }) };
+}
+
+inline int64_t pf_box_get_left  (DrawingArena<BoxRec>& a, Box h) { return pf_require_live(a, h).left; }
+inline int64_t pf_box_get_right (DrawingArena<BoxRec>& a, Box h) { return pf_require_live(a, h).right; }
+inline double  pf_box_get_top   (DrawingArena<BoxRec>& a, Box h) { return pf_require_live(a, h).top; }
+inline double  pf_box_get_bottom(DrawingArena<BoxRec>& a, Box h) { return pf_require_live(a, h).bottom; }
+
+inline void pf_box_set_left  (DrawingArena<BoxRec>& a, Box h, int64_t v) { pf_require_live(a, h).left = v; }
+inline void pf_box_set_right (DrawingArena<BoxRec>& a, Box h, int64_t v) { pf_require_live(a, h).right = v; }
+inline void pf_box_set_top   (DrawingArena<BoxRec>& a, Box h, double v)  { pf_require_live(a, h).top = v; }
+inline void pf_box_set_bottom(DrawingArena<BoxRec>& a, Box h, double v)  { pf_require_live(a, h).bottom = v; }
+inline void pf_box_set_lefttop(DrawingArena<BoxRec>& a, Box h, int64_t left, double top) {
+    BoxRec& r = pf_require_live(a, h); r.left = left; r.top = top;
+}
+inline void pf_box_set_rightbottom(DrawingArena<BoxRec>& a, Box h, int64_t right, double bottom) {
+    BoxRec& r = pf_require_live(a, h); r.right = right; r.bottom = bottom;
+}
+inline void pf_box_set_top_left_point(DrawingArena<BoxRec>& a, Box h, ChartPoint p) {
+    BoxRec& r = pf_require_live(a, h); r.left = pf_point_x(p, r.xloc); r.top = p.price;
+}
+inline void pf_box_set_bottom_right_point(DrawingArena<BoxRec>& a, Box h, ChartPoint p) {
+    BoxRec& r = pf_require_live(a, h); r.right = pf_point_x(p, r.xloc); r.bottom = p.price;
+}
+inline void pf_box_set_xloc(DrawingArena<BoxRec>& a, Box h, int64_t left, int64_t right, XLoc xloc) {
+    BoxRec& r = pf_require_live(a, h); r.left = left; r.right = right; r.xloc = xloc;  // reinterpret only
+}
+
+inline Box pf_box_copy(DrawingArena<BoxRec>& a, Box h) {
+    if (!a.alive(h.id)) return Box{};
+    BoxRec r = a.at(h.id);
+    return Box{ a.alloc(r) };
+}
+inline void pf_box_delete(DrawingArena<BoxRec>& a, Box h) { a.erase(h.id); }
+
+// ============================ label =========================================
+// NOTE: yloc.abovebar / yloc.belowbar should auto-place y at the bar high/low
+// (spec §3.9). The spec's pf_label_new signature is intentionally decoupled from
+// the engine and does NOT receive bar high/low, so y is stored AS-IS and yloc is
+// store-only here. yloc abovebar/belowbar auto-place needs bar high/low at the
+// call site — codegen would pass close()/high()/low() if ever required. Inert:
+// no corpus label reads get_y back (spec note 4), so no parity claim.
+inline Label pf_label_new(DrawingArena<LabelRec>& a, int64_t x, double y, std::string text,
+                          XLoc xloc = XLoc::bar_index, YLoc yloc = YLoc::price) {
+    return Label{ a.alloc(LabelRec{ x, y, xloc, yloc, std::move(text), true }) };
+}
+inline Label pf_label_new_pt(DrawingArena<LabelRec>& a, ChartPoint point, std::string text,
+                             YLoc yloc = YLoc::price) {
+    // xloc carried by the ChartPoint: bar_time only when index is na but time is set.
+    XLoc xloc = (is_na(point.index) && !is_na(point.time)) ? XLoc::bar_time : XLoc::bar_index;
+    return Label{ a.alloc(LabelRec{ pf_point_x(point, xloc), point.price, xloc, yloc,
+                                    std::move(text), true }) };
+}
+
+inline int64_t     pf_label_get_x(DrawingArena<LabelRec>& a, Label h)    { return pf_require_live(a, h).x; }
+inline double      pf_label_get_y(DrawingArena<LabelRec>& a, Label h)    { return pf_require_live(a, h).y; }
+inline std::string pf_label_get_text(DrawingArena<LabelRec>& a, Label h) { return pf_require_live(a, h).text; }
+
+inline void pf_label_set_x(DrawingArena<LabelRec>& a, Label h, int64_t v) { pf_require_live(a, h).x = v; }
+inline void pf_label_set_y(DrawingArena<LabelRec>& a, Label h, double v)  { pf_require_live(a, h).y = v; }
+inline void pf_label_set_xy(DrawingArena<LabelRec>& a, Label h, int64_t x, double y) {
+    LabelRec& r = pf_require_live(a, h); r.x = x; r.y = y;
+}
+inline void pf_label_set_point(DrawingArena<LabelRec>& a, Label h, ChartPoint p) {
+    LabelRec& r = pf_require_live(a, h); r.x = pf_point_x(p, r.xloc); r.y = p.price;
+}
+inline void pf_label_set_xloc(DrawingArena<LabelRec>& a, Label h, int64_t x, XLoc xloc) {
+    LabelRec& r = pf_require_live(a, h); r.x = x; r.xloc = xloc;  // sets x AND xloc
+}
+inline void pf_label_set_yloc(DrawingArena<LabelRec>& a, Label h, YLoc yloc) {
+    pf_require_live(a, h).yloc = yloc;
+}
+inline void pf_label_set_text(DrawingArena<LabelRec>& a, Label h, std::string text) {
+    pf_require_live(a, h).text = std::move(text);
+}
+
+inline Label pf_label_copy(DrawingArena<LabelRec>& a, Label h) {
+    if (!a.alive(h.id)) return Label{};
+    LabelRec r = a.at(h.id);                            // deep copy (incl. std::string text)
+    return Label{ a.alloc(std::move(r)) };
+}
+inline void pf_label_delete(DrawingArena<LabelRec>& a, Label h) { a.erase(h.id); }
+
+// ============================ linefill ======================================
+inline Linefill pf_linefill_new(DrawingArena<LinefillRec>& a, Line l1, Line l2) {
+    // Stores the two Line handle ids inertly (color dropped). linefill.new(na,na,na)
+    // is legal -> a LIVE record over na line ids (spec note 1).
+    return Linefill{ a.alloc(LinefillRec{ l1.id, l2.id, true }) };
+}
+inline Line pf_linefill_get_line1(DrawingArena<LinefillRec>& a, Linefill h) {
+    return Line{ pf_require_live(a, h).line1 };
+}
+inline Line pf_linefill_get_line2(DrawingArena<LinefillRec>& a, Linefill h) {
+    return Line{ pf_require_live(a, h).line2 };
+}
+inline void pf_linefill_delete(DrawingArena<LinefillRec>& a, Linefill h) { a.erase(h.id); }
+
+// ============================ visual no-op sink (spec §3.6) ==================
+// Evaluates + discards args (so side effects/typechecking still happen), returns void.
+// Backs every VISUAL setter/ctor-kwarg: line/box/label set_color/set_style/...
+template <class... A> inline void pf_noop(A&&...) {}
+
+} // namespace pineforge

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ set(TEST_SOURCES
     test_timezone_concurrency
     test_pointvalue
     test_metrics
+    test_drawing
 )
 
 find_package(Threads REQUIRED)

--- a/tests/test_drawing.cpp
+++ b/tests/test_drawing.cpp
@@ -217,6 +217,21 @@ static void test_fifo_eviction() {
 }
 
 // ---------------------------------------------------------------------------
+// Defensive cap floor: Pine strategy caps are validated as >=1 by codegen, but
+// a malformed direct runtime use must not hit empty-deque front() UB.
+static void test_cap_zero_floors_to_one() {
+    std::printf("test_cap_zero_floors_to_one\n");
+    DrawingArena<LineRec> a(0);
+    Line h0 = pf_line_new(a, 0, 0.0, 1, 1.0);
+    Line h1 = pf_line_new(a, 1, 1.0, 2, 2.0);
+
+    CHECK_THROWS(pf_line_get_x1(a, h0));
+    CHECK(pf_line_get_x1(a, h1) == 1);
+    CHECK(a.order().size() == 1u);
+    CHECK(a.order().front() == h1.id);
+}
+
+// ---------------------------------------------------------------------------
 // get_price: linear interp + degenerate x1==x2 -> na + bar_time -> throw (spec §3.6)
 static void test_get_price() {
     std::printf("test_get_price\n");
@@ -370,6 +385,7 @@ int main() {
     test_copy_is_deep();
     test_delete_then_getter_throws();
     test_fifo_eviction();
+    test_cap_zero_floors_to_one();
     test_get_price();
     test_box();
     test_label();

--- a/tests/test_drawing.cpp
+++ b/tests/test_drawing.cpp
@@ -1,0 +1,386 @@
+// Unit tests for the drawing-objects-as-data runtime (include/pineforge/drawing.hpp).
+// Spec: docs/drawing-objects-as-data.md §3. Headless data structures — no rendering.
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <type_traits>
+#include <pineforge/drawing.hpp>
+
+using namespace pineforge;
+
+static int g_fail = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            std::printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);        \
+            ++g_fail;                                                          \
+        }                                                                      \
+    } while (0)
+
+// Asserts that evaluating `expr` throws pine_drawing_error.
+#define CHECK_THROWS(expr)                                                     \
+    do {                                                                       \
+        bool threw = false;                                                    \
+        try { (void)(expr); }                                                  \
+        catch (const pine_drawing_error&) { threw = true; }                    \
+        catch (...) {}                                                         \
+        if (!threw) {                                                          \
+            std::printf("FAIL %s:%d: expected pine_drawing_error: %s\n",       \
+                        __FILE__, __LINE__, #expr);                            \
+            ++g_fail;                                                          \
+        }                                                                      \
+    } while (0)
+
+// Asserts that evaluating `stmt` does NOT throw.
+#define CHECK_NOTHROW(stmt)                                                    \
+    do {                                                                       \
+        try { stmt; }                                                          \
+        catch (...) {                                                          \
+            std::printf("FAIL %s:%d: unexpected throw: %s\n",                  \
+                        __FILE__, __LINE__, #stmt);                            \
+            ++g_fail;                                                          \
+        }                                                                      \
+    } while (0)
+
+static constexpr double TOL = 1e-9;
+static bool near(double a, double b) { return std::fabs(a - b) <= TOL; }
+
+// ---------------------------------------------------------------------------
+// is_na for default handles + na ChartPoint (spec §3.2)
+static void test_is_na_defaults() {
+    std::printf("test_is_na_defaults\n");
+    CHECK(is_na(Line{}));
+    CHECK(is_na(Box{}));
+    CHECK(is_na(Label{}));
+    CHECK(is_na(Linefill{}));
+
+    // na<T>() falls out of na.hpp's generic for the handle types (default {-1}).
+    CHECK(is_na(na<Line>()));
+    CHECK(is_na(na<Box>()));
+    CHECK(is_na(na<Label>()));
+    CHECK(is_na(na<Linefill>()));
+    CHECK(na<Line>().id == -1);
+
+    // Fully-na ChartPoint is na; a from_index/from_time point is NOT na overall.
+    CHECK(is_na(ChartPoint{}));
+    ChartPoint from_index{ /*index*/ 7, na<int64_t>(), na<double>() };
+    CHECK(!is_na(from_index));
+    ChartPoint from_time{ na<int64_t>(), /*time*/ 1000LL, na<double>() };
+    CHECK(!is_na(from_time));
+    ChartPoint only_price{ na<int64_t>(), na<int64_t>(), 42.0 };
+    CHECK(!is_na(only_price));
+}
+
+// ---------------------------------------------------------------------------
+// arena alloc returns monotonic ids (spec §3.4)
+static void test_monotonic_ids() {
+    std::printf("test_monotonic_ids\n");
+    DrawingArena<LineRec> a;  // default cap 50
+    Line l0 = pf_line_new(a, 0, 0.0, 1, 1.0);
+    Line l1 = pf_line_new(a, 0, 0.0, 1, 1.0);
+    Line l2 = pf_line_new(a, 0, 0.0, 1, 1.0);
+    CHECK(l0.id == 0);
+    CHECK(l1.id == 1);
+    CHECK(l2.id == 2);
+    CHECK(!is_na(l0));
+
+    // Deleting then allocating does NOT reuse the id (tombstoned, monotonic).
+    pf_line_delete(a, l1);
+    Line l3 = pf_line_new(a, 0, 0.0, 1, 1.0);
+    CHECK(l3.id == 3);
+}
+
+// ---------------------------------------------------------------------------
+// *_new(na,na,na,na) allocates a LIVE record with na coords (spec §3.7)
+static void test_new_na_coords_is_live() {
+    std::printf("test_new_na_coords_is_live\n");
+    DrawingArena<LineRec> a;
+    Line h = pf_line_new(a, na<int64_t>(), na<double>(), na<int64_t>(), na<double>());
+    CHECK(!is_na(h));               // the handle is LIVE
+    CHECK(h.id == 0);
+    CHECK(is_na(pf_line_get_x1(a, h)));   // ... but its coords are na
+    CHECK(is_na(pf_line_get_y1(a, h)));
+}
+
+// ---------------------------------------------------------------------------
+// mutate-through-handle, incl. via a COPIED handle id (reference semantics)
+static void test_mutate_through_handle() {
+    std::printf("test_mutate_through_handle\n");
+    DrawingArena<LineRec> a;
+    Line h = pf_line_new(a, 1, 10.0, 2, 20.0);
+
+    pf_line_set_x1(a, h, 100);
+    pf_line_set_y1(a, h, 11.0);
+    pf_line_set_xy2(a, h, 200, 22.0);
+    CHECK(pf_line_get_x1(a, h) == 100);
+    CHECK(near(pf_line_get_y1(a, h), 11.0));
+    CHECK(pf_line_get_x2(a, h) == 200);
+    CHECK(near(pf_line_get_y2(a, h), 22.0));
+
+    // A by-value copy of the HANDLE (not pf_line_copy) shares the same arena id:
+    // mutations through one are visible through the other (reference semantics).
+    Line alias = h;
+    pf_line_set_x1(a, alias, 999);
+    CHECK(pf_line_get_x1(a, h) == 999);
+
+    // chart.point setters select x per the record's stored xloc (bar_index here).
+    pf_line_set_first_point(a, h, ChartPoint{ /*index*/ 5, /*time*/ 123456789LL, /*price*/ 50.0 });
+    CHECK(pf_line_get_x1(a, h) == 5);          // bar_index -> .index, not .time
+    CHECK(near(pf_line_get_y1(a, h), 50.0));
+}
+
+// ---------------------------------------------------------------------------
+// set_xloc reinterprets (stores new numbers + flag), no coord conversion
+static void test_set_xloc_reinterpret() {
+    std::printf("test_set_xloc_reinterpret\n");
+    DrawingArena<LineRec> a;
+    Line h = pf_line_new(a, 1, 10.0, 2, 20.0, XLoc::bar_index);
+    int64_t ms1 = 1700000000000LL, ms2 = 1700000600000LL;
+    pf_line_set_xloc(a, h, ms1, ms2, XLoc::bar_time);
+    CHECK(pf_line_get_x1(a, h) == ms1);   // raw stored value read back, xloc-agnostic
+    CHECK(pf_line_get_x2(a, h) == ms2);
+    // get_price on a bar_time line errors like TV.
+    CHECK_THROWS(pf_line_get_price(a, h, ms1));
+}
+
+// ---------------------------------------------------------------------------
+// copy() is a deep, independent arena record (spec §3.6 note 7)
+static void test_copy_is_deep() {
+    std::printf("test_copy_is_deep\n");
+    DrawingArena<LineRec> a;
+    Line orig = pf_line_new(a, 1, 10.0, 2, 20.0);
+    Line cp = pf_line_copy(a, orig);
+    CHECK(!is_na(cp));
+    CHECK(cp.id != orig.id);                 // distinct arena record
+
+    pf_line_set_y2(a, cp, 999.0);            // mutate the copy
+    CHECK(near(pf_line_get_y2(a, orig), 20.0)); // original unchanged
+    CHECK(near(pf_line_get_y2(a, cp), 999.0));
+
+    pf_line_set_y1(a, orig, 7.0);            // mutate the original
+    CHECK(near(pf_line_get_y1(a, cp), 10.0));   // copy unchanged
+
+    // copy of a dead/na handle -> na handle (silent), not a throw.
+    Line na_cp;
+    CHECK_NOTHROW(na_cp = pf_line_copy(a, Line{}));
+    CHECK(is_na(na_cp));
+}
+
+// ---------------------------------------------------------------------------
+// delete() then a getter THROWS; double-delete / na-delete are silent (spec §3.7)
+static void test_delete_then_getter_throws() {
+    std::printf("test_delete_then_getter_throws\n");
+    DrawingArena<LineRec> a;
+    Line h = pf_line_new(a, 1, 10.0, 2, 20.0);
+    pf_line_delete(a, h);
+
+    CHECK_THROWS(pf_line_get_x1(a, h));
+    CHECK_THROWS(pf_line_get_y2(a, h));
+    CHECK_THROWS(pf_line_set_x1(a, h, 5));        // setter on dead also throws
+    CHECK_THROWS(pf_line_get_price(a, h, 3));     // get_price on dead throws
+
+    // getter on a never-allocated na handle throws too.
+    CHECK_THROWS(pf_line_get_x1(a, Line{}));
+
+    // double-delete + na-delete are silent no-ops.
+    CHECK_NOTHROW(pf_line_delete(a, h));          // already deleted
+    CHECK_NOTHROW(pf_line_delete(a, Line{}));     // na handle
+    CHECK_NOTHROW(pf_line_delete(a, Line{ 9999 })); // out-of-range id
+}
+
+// ---------------------------------------------------------------------------
+// FIFO eviction at exact cap (spec §3.8)
+static void test_fifo_eviction() {
+    std::printf("test_fifo_eviction\n");
+    const int cap = 3;
+    DrawingArena<LineRec> a(cap);
+    Line h[5];
+    for (int i = 0; i < 5; ++i)               // create cap+2 = 5
+        h[i] = pf_line_new(a, i, (double)i, i + 1, (double)(i + 1));
+
+    // Oldest two (creation order) are tombstoned; getters on them throw.
+    CHECK_THROWS(pf_line_get_x1(a, h[0]));
+    CHECK_THROWS(pf_line_get_x1(a, h[1]));
+
+    // The newest `cap` survive and read back correctly.
+    CHECK(pf_line_get_x1(a, h[2]) == 2);
+    CHECK(pf_line_get_x1(a, h[3]) == 3);
+    CHECK(pf_line_get_x1(a, h[4]) == 4);
+
+    // order() holds exactly the live ids, oldest -> newest.
+    const auto& ord = a.order();
+    CHECK(ord.size() == (size_t)cap);
+    CHECK(ord.front() == h[2].id);
+    CHECK(ord.back() == h[4].id);
+}
+
+// ---------------------------------------------------------------------------
+// get_price: linear interp + degenerate x1==x2 -> na + bar_time -> throw (spec §3.6)
+static void test_get_price() {
+    std::printf("test_get_price\n");
+    DrawingArena<LineRec> a;
+    // Line (0,10) -> (10,20): slope 1.0.
+    Line h = pf_line_new(a, 0, 10.0, 10, 20.0, XLoc::bar_index);
+    CHECK(near(pf_line_get_price(a, h, 0), 10.0));
+    CHECK(near(pf_line_get_price(a, h, 5), 15.0));
+    CHECK(near(pf_line_get_price(a, h, 10), 20.0));
+    CHECK(near(pf_line_get_price(a, h, 20), 30.0));   // infinite line (ignores extend)
+    CHECK(near(pf_line_get_price(a, h, -5), 5.0));
+
+    // Degenerate vertical (x1 == x2) -> na.
+    Line vert = pf_line_new(a, 5, 10.0, 5, 20.0, XLoc::bar_index);
+    CHECK(is_na(pf_line_get_price(a, vert, 5)));
+
+    // bar_time line -> throws (TV errors).
+    Line tline = pf_line_new(a, 100, 10.0, 200, 20.0, XLoc::bar_time);
+    CHECK_THROWS(pf_line_get_price(a, tline, 150));
+}
+
+// ---------------------------------------------------------------------------
+// box: new (scalar + point), getters/setters, copy deep, delete, eviction
+static void test_box() {
+    std::printf("test_box\n");
+    DrawingArena<BoxRec> a;
+    Box b = pf_box_new(a, 1, 100.0, 5, 50.0);   // left,top,right,bottom
+    CHECK(pf_box_get_left(a, b) == 1);
+    CHECK(pf_box_get_right(a, b) == 5);
+    CHECK(near(pf_box_get_top(a, b), 100.0));
+    CHECK(near(pf_box_get_bottom(a, b), 50.0));
+
+    pf_box_set_lefttop(a, b, 2, 110.0);
+    pf_box_set_rightbottom(a, b, 6, 40.0);
+    CHECK(pf_box_get_left(a, b) == 2);
+    CHECK(near(pf_box_get_top(a, b), 110.0));
+    CHECK(pf_box_get_right(a, b) == 6);
+    CHECK(near(pf_box_get_bottom(a, b), 40.0));
+
+    // point ctor: top_left / bottom_right via ChartPoint (bar_index axis).
+    Box bp = pf_box_new_pts(a, ChartPoint{ 10, na<int64_t>(), 200.0 },
+                               ChartPoint{ 20, na<int64_t>(), 150.0 });
+    CHECK(pf_box_get_left(a, bp) == 10);
+    CHECK(pf_box_get_right(a, bp) == 20);
+    CHECK(near(pf_box_get_top(a, bp), 200.0));
+    CHECK(near(pf_box_get_bottom(a, bp), 150.0));
+
+    // deep copy independence
+    Box cp = pf_box_copy(a, b);
+    CHECK(cp.id != b.id);
+    pf_box_set_top(a, cp, 777.0);
+    CHECK(near(pf_box_get_top(a, b), 110.0));
+
+    // delete -> getter throws; na-delete silent
+    pf_box_delete(a, b);
+    CHECK_THROWS(pf_box_get_top(a, b));
+    CHECK_NOTHROW(pf_box_delete(a, Box{}));
+}
+
+// ---------------------------------------------------------------------------
+// label: text get/set, copy deep (incl. string), delete, store-only yloc
+static void test_label() {
+    std::printf("test_label\n");
+    DrawingArena<LabelRec> a;
+    Label l = pf_label_new(a, 3, 42.0, "hello", XLoc::bar_index, YLoc::price);
+    CHECK(pf_label_get_x(a, l) == 3);
+    CHECK(near(pf_label_get_y(a, l), 42.0));
+    CHECK(pf_label_get_text(a, l) == "hello");
+
+    pf_label_set_text(a, l, "world");
+    pf_label_set_xy(a, l, 9, 84.0);
+    CHECK(pf_label_get_text(a, l) == "world");
+    CHECK(pf_label_get_x(a, l) == 9);
+    CHECK(near(pf_label_get_y(a, l), 84.0));
+
+    // deep copy: mutating the copy's string leaves the original intact.
+    Label cp = pf_label_copy(a, l);
+    CHECK(cp.id != l.id);
+    pf_label_set_text(a, cp, "changed");
+    CHECK(pf_label_get_text(a, l) == "world");
+    CHECK(pf_label_get_text(a, cp) == "changed");
+
+    // na.new(na,na,na) -> LIVE record with na coords (jevondijefferson pattern).
+    Label na_label = pf_label_new(a, na<int64_t>(), na<double>(), "");
+    CHECK(!is_na(na_label));
+    CHECK(is_na(pf_label_get_x(a, na_label)));
+
+    // point ctor selects bar_time when only time is set.
+    Label lt = pf_label_new_pt(a, ChartPoint{ na<int64_t>(), 1700000000000LL, 5.0 }, "t");
+    CHECK(pf_label_get_x(a, lt) == 1700000000000LL);
+
+    pf_label_delete(a, l);
+    CHECK_THROWS(pf_label_get_text(a, l));
+    CHECK_NOTHROW(pf_label_delete(a, l));   // double-delete silent
+}
+
+// ---------------------------------------------------------------------------
+// linefill: stores two line ids, get_line1/2, delete; dead -> throw
+static void test_linefill() {
+    std::printf("test_linefill\n");
+    DrawingArena<LineRec> la;
+    Line l1 = pf_line_new(la, 0, 1.0, 1, 2.0);
+    Line l2 = pf_line_new(la, 0, 3.0, 1, 4.0);
+
+    DrawingArena<LinefillRec> fa;
+    Linefill f = pf_linefill_new(fa, l1, l2);
+    CHECK(!is_na(f));
+    CHECK(pf_linefill_get_line1(fa, f).id == l1.id);
+    CHECK(pf_linefill_get_line2(fa, f).id == l2.id);
+
+    // linefill.new(na, na) is legal -> LIVE record over na line ids.
+    Linefill fna = pf_linefill_new(fa, Line{}, Line{});
+    CHECK(!is_na(fna));
+    CHECK(is_na(pf_linefill_get_line1(fa, fna)));
+
+    pf_linefill_delete(fa, f);
+    CHECK_THROWS(pf_linefill_get_line1(fa, f));
+    CHECK_NOTHROW(pf_linefill_delete(fa, f));     // double-delete silent
+    CHECK_NOTHROW(pf_linefill_delete(fa, Linefill{}));
+}
+
+// ---------------------------------------------------------------------------
+// chart.point value copy independence (spec §3.6: copy is plain by-value)
+static void test_chart_point_value_copy() {
+    std::printf("test_chart_point_value_copy\n");
+    ChartPoint p1{ 1, 1000LL, 10.0 };
+    ChartPoint p2 = p1;          // chart.point.copy(p) lowers to a by-value copy
+    p2.price = 99.0;
+    p2.index = 7;
+    CHECK(near(p1.price, 10.0)); // original untouched
+    CHECK(p1.index == 1);
+    CHECK(near(p2.price, 99.0));
+    CHECK(p2.index == 7);
+}
+
+// ---------------------------------------------------------------------------
+// pf_noop accepts any args and returns void (spec §3.6)
+static void test_pf_noop() {
+    std::printf("test_pf_noop\n");
+    CHECK_NOTHROW(pf_noop());
+    CHECK_NOTHROW(pf_noop(1, 2.0, "three", Line{}));
+    static_assert(std::is_same<decltype(pf_noop(1)), void>::value, "pf_noop returns void");
+}
+
+int main() {
+    test_is_na_defaults();
+    test_monotonic_ids();
+    test_new_na_coords_is_live();
+    test_mutate_through_handle();
+    test_set_xloc_reinterpret();
+    test_copy_is_deep();
+    test_delete_then_getter_throws();
+    test_fifo_eviction();
+    test_get_price();
+    test_box();
+    test_label();
+    test_linefill();
+    test_chart_point_value_copy();
+    test_pf_noop();
+
+    if (g_fail > 0) {
+        std::printf("drawing tests: %d FAILED\n", g_fail);
+        return 1;
+    }
+    std::printf("drawing tests: all passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add header-only Pine v6 drawing runtime data structures for line/box/label/linefill/chart.point.
- Implement value-view handles over per-type DrawingArena with monotonic ids, tombstones, FIFO cap eviction, dead/na access errors, and visual no-op sink.
- Add drawing runtime unit tests, including cap-zero hardening.

## Scope / caveats
- No rendering or C ABI changes.
- egoigor trade-count parity remains out of scope; matched trades are price-exact, but it is not trade-for-trade.
- Working tree has a pre-existing uncommitted corpus submodule pointer that is not part of this PR.

## Verification
- cmake --build build -j4
- ctest --test-dir build --output-on-failure -R drawing
- ./scripts/run_corpus.sh && python scripts/verify_corpus.py --all → 246 strategies: excellent=245, anomaly=1, fail=0
