### PR TITLE
fix(drawing): keep deleted records data-accessible

### DIFF
--- a/include/pineforge/drawing.hpp
+++ b/include/pineforge/drawing.hpp
@@ -69,14 +69,18 @@ struct LinefillRec { int32_t line1, line2; bool alive; };
 // ---- error type (spec §3.7) ------------------------------------------------
 // Derives from std::runtime_error so BacktestEngine::run()'s existing
 // `catch (const std::exception& e)` (src/engine_run.cpp) halts the backtest
-// exactly like TradingView when a drawing op touches a dead/na handle.
+// exactly like TradingView when a drawing op touches a na handle.
 // Drawing is ALWAYS-ON and ALWAYS TV-faithful: no compile flag, no lenient mode.
 struct pine_drawing_error : std::runtime_error {
     explicit pine_drawing_error(const std::string& msg) : std::runtime_error(msg) {}
 };
 
-// dead/na handle access is ALWAYS an error — no flag, no lenient mode (spec §3.7)
-#define PF_DRAW_DEAD(arena, handle) throw pine_drawing_error("drawing access on na/deleted handle")
+// A na handle (id < 0) or an out-of-range id is ALWAYS an error — there is no
+// record to read. NOTE: a DEAD record (alive == false, after an explicit
+// line.delete() or FIFO eviction) is NOT an error — TV keeps the object's data
+// read/writable after delete (the object only leaves the chart + the *.all
+// list), so the engine must too. See corpus/validation/drawing-delete-halt,
+// where TV keeps producing trades (2504) after the strategy's line.delete().
 
 // ---- arena template (spec §3.4) --------------------------------------------
 // ids are monotonic and never reused (dead slots are tombstoned, not recycled)
@@ -110,6 +114,11 @@ public:
 
     bool alive(int32_t id) const { return id >= 0 && id < (int)recs_.size() && recs_[id].alive; }
 
+    // Number of slots ever allocated (dead slots retained). ids in [0, size())
+    // reference a real record (live OR dead); ids outside that range or < 0 are
+    // na/invalid.
+    int32_t size() const { return (int32_t)recs_.size(); }
+
     Rec&       at(int32_t id)       { return recs_[id]; }
     const Rec& at(int32_t id) const { return recs_[id]; }
 
@@ -117,11 +126,14 @@ public:
 };
 
 // ---- shared helpers --------------------------------------------------------
-// Returns a reference to the live record for a handle, or THROWS pine_drawing_error
-// (spec §3.7: any getter/setter on a dead/na handle halts, unconditionally).
+// Returns a reference to the record for a handle. Only a na handle (id < 0) or
+// an out-of-range id throws; a DEAD record (alive == false, e.g. after an
+// explicit line.delete() or FIFO eviction) is returned as-is — its geometry
+// remains read/writable, matching TV (delete leaves the chart + *.all, not the
+// data). See corpus/validation/drawing-delete-halt (2504 post-delete trades).
 template <class Rec, class Handle>
 inline Rec& pf_require_live(DrawingArena<Rec>& a, Handle h) {
-    if (!a.alive(h.id)) throw pine_drawing_error("drawing access on na/deleted handle");
+    if (h.id < 0 || h.id >= a.size()) throw pine_drawing_error("drawing access on na handle");
     return a.at(h.id);
 }
 
@@ -170,8 +182,9 @@ inline void pf_line_set_xloc(DrawingArena<LineRec>& a, Line h, int64_t x1, int64
 
 // real computation: infinite line, ignores extend; valid for xloc.bar_index (spec §3.6).
 inline double pf_line_get_price(DrawingArena<LineRec>& a, Line h, int64_t x) {
-    if (!a.alive(h.id)) PF_DRAW_DEAD(a, h);             // dead/na line -> throw -> halt (like TV)
-    const LineRec& r = a.at(h.id);
+    if (h.id < 0 || h.id >= a.size())            // na/out-of-range line -> throw -> halt (like TV)
+        throw pine_drawing_error("drawing access on na handle");
+    const LineRec& r = a.at(h.id);               // dead record's geometry is still readable (TV-faithful)
     if (r.xloc == XLoc::bar_time)
         throw pine_drawing_error("line.get_price requires xloc.bar_index"); // TV errors on bar_time lines
     if (r.x1 == r.x2) return na<double>();              // degenerate vertical -> na (matches TV)

--- a/tests/test_drawing.cpp
+++ b/tests/test_drawing.cpp
@@ -169,25 +169,39 @@ static void test_copy_is_deep() {
 }
 
 // ---------------------------------------------------------------------------
-// delete() then a getter THROWS; double-delete / na-delete are silent (spec §3.7)
-static void test_delete_then_getter_throws() {
-    std::printf("test_delete_then_getter_throws\n");
+// delete() keeps the record's data accessible (TV-faithful): an explicit
+// line.delete() removes the object from the chart + *.all, but its geometry
+// stays read/writable — corpus/validation/drawing-delete-halt shows TV keeps
+// producing trades (2504) after the strategy's line.delete(). Only a na handle
+// (never created) or an out-of-range id throws. double-delete / na-delete silent.
+static void test_delete_keeps_data_accessible() {
+    std::printf("test_delete_keeps_data_accessible\n");
     DrawingArena<LineRec> a;
     Line h = pf_line_new(a, 1, 10.0, 2, 20.0);
     pf_line_delete(a, h);
+    CHECK(!a.alive(h.id));                            // tombstoned (out of *.all)
 
-    CHECK_THROWS(pf_line_get_x1(a, h));
-    CHECK_THROWS(pf_line_get_y2(a, h));
-    CHECK_THROWS(pf_line_set_x1(a, h, 5));        // setter on dead also throws
-    CHECK_THROWS(pf_line_get_price(a, h, 3));     // get_price on dead throws
+    // getters on the dead record return the stored geometry (do NOT throw).
+    CHECK(pf_line_get_x1(a, h) == 1);
+    CHECK(near(pf_line_get_y2(a, h), 20.0));
+    // get_price on the dead record interpolates the stored geometry (infinite line).
+    CHECK(near(pf_line_get_price(a, h, 3), 30.0));    // line (1,10)-(2,20) at x=3 -> 30
+    // setters on the dead record mutate the stored geometry (do NOT throw).
+    CHECK_NOTHROW(pf_line_set_x1(a, h, 5));
+    CHECK(pf_line_get_x1(a, h) == 5);
+    // still tombstoned (delete is idempotent; setters don't resurrect into *.all).
+    CHECK(!a.alive(h.id));
 
-    // getter on a never-allocated na handle throws too.
+    // a never-allocated na handle has NO record -> throws.
     CHECK_THROWS(pf_line_get_x1(a, Line{}));
+    CHECK_THROWS(pf_line_set_y2(a, Line{}, 1.0));
+    // an out-of-range id (corrupt) -> throws.
+    CHECK_THROWS(pf_line_get_x1(a, Line{ 9999 }));
 
     // double-delete + na-delete are silent no-ops.
-    CHECK_NOTHROW(pf_line_delete(a, h));          // already deleted
-    CHECK_NOTHROW(pf_line_delete(a, Line{}));     // na handle
-    CHECK_NOTHROW(pf_line_delete(a, Line{ 9999 })); // out-of-range id
+    CHECK_NOTHROW(pf_line_delete(a, h));              // already deleted
+    CHECK_NOTHROW(pf_line_delete(a, Line{}));         // na handle
+    CHECK_NOTHROW(pf_line_delete(a, Line{ 9999 }));   // out-of-range id
 }
 
 // ---------------------------------------------------------------------------
@@ -200,11 +214,14 @@ static void test_fifo_eviction() {
     for (int i = 0; i < 5; ++i)               // create cap+2 = 5
         h[i] = pf_line_new(a, i, (double)i, i + 1, (double)(i + 1));
 
-    // Oldest two (creation order) are tombstoned; getters on them throw.
-    CHECK_THROWS(pf_line_get_x1(a, h[0]));
-    CHECK_THROWS(pf_line_get_x1(a, h[1]));
+    // Oldest two (creation order) are evicted from *.all (tombstoned), but their
+    // geometry stays readable (TV-faithful: eviction leaves the chart, not data).
+    CHECK(!a.alive(h[0].id));
+    CHECK(!a.alive(h[1].id));
+    CHECK(pf_line_get_x1(a, h[0]) == 0);
+    CHECK(pf_line_get_x1(a, h[1]) == 1);
 
-    // The newest `cap` survive and read back correctly.
+    // The newest `cap` are live and read back correctly.
     CHECK(pf_line_get_x1(a, h[2]) == 2);
     CHECK(pf_line_get_x1(a, h[3]) == 3);
     CHECK(pf_line_get_x1(a, h[4]) == 4);
@@ -225,7 +242,9 @@ static void test_cap_zero_floors_to_one() {
     Line h0 = pf_line_new(a, 0, 0.0, 1, 1.0);
     Line h1 = pf_line_new(a, 1, 1.0, 2, 2.0);
 
-    CHECK_THROWS(pf_line_get_x1(a, h0));
+    // h0 is evicted from *.all (tombstoned) but its data is still readable.
+    CHECK(!a.alive(h0.id));
+    CHECK(pf_line_get_x1(a, h0) == 0);
     CHECK(pf_line_get_x1(a, h1) == 1);
     CHECK(a.order().size() == 1u);
     CHECK(a.order().front() == h1.id);
@@ -285,9 +304,10 @@ static void test_box() {
     pf_box_set_top(a, cp, 777.0);
     CHECK(near(pf_box_get_top(a, b), 110.0));
 
-    // delete -> getter throws; na-delete silent
+    // delete -> tombstoned but data still readable; na-delete silent
     pf_box_delete(a, b);
-    CHECK_THROWS(pf_box_get_top(a, b));
+    CHECK(!a.alive(b.id));
+    CHECK(near(pf_box_get_top(a, b), 110.0));
     CHECK_NOTHROW(pf_box_delete(a, Box{}));
 }
 
@@ -324,8 +344,9 @@ static void test_label() {
     CHECK(pf_label_get_x(a, lt) == 1700000000000LL);
 
     pf_label_delete(a, l);
-    CHECK_THROWS(pf_label_get_text(a, l));
-    CHECK_NOTHROW(pf_label_delete(a, l));   // double-delete silent
+    CHECK(!a.alive(l.id));
+    CHECK(pf_label_get_text(a, l) == "world");   // dead record's text still readable
+    CHECK_NOTHROW(pf_label_delete(a, l));        // double-delete silent
 }
 
 // ---------------------------------------------------------------------------
@@ -348,7 +369,8 @@ static void test_linefill() {
     CHECK(is_na(pf_linefill_get_line1(fa, fna)));
 
     pf_linefill_delete(fa, f);
-    CHECK_THROWS(pf_linefill_get_line1(fa, f));
+    CHECK(!fa.alive(f.id));                        // linefill tombstoned in its own arena
+    CHECK(pf_linefill_get_line1(fa, f).id == l1.id);  // dead linefill's line1 still readable
     CHECK_NOTHROW(pf_linefill_delete(fa, f));     // double-delete silent
     CHECK_NOTHROW(pf_linefill_delete(fa, Linefill{}));
 }
@@ -376,6 +398,30 @@ static void test_pf_noop() {
     static_assert(std::is_same<decltype(pf_noop(1)), void>::value, "pf_noop returns void");
 }
 
+// ---------------------------------------------------------------------------
+// Regression for corpus/validation/drawing-delete-halt: after line.delete(lv),
+// the strategy keeps calling line.set_y2(lv, ...) + line.get_y2(lv) every bar
+// and must NOT throw — TV produced 2504 trades post-delete. The level must keep
+// tracking the new y2 values written through the dead handle.
+static void test_delete_halt_probe_pattern() {
+    std::printf("test_delete_halt_probe_pattern\n");
+    DrawingArena<LineRec> a;
+    Line lv = pf_line_new(a, 0, 100.0, 0, 100.0);   // bar 0: degenerate level line
+    // ... strategy runs, updates the level each bar ...
+    pf_line_set_y2(a, lv, 150.0);
+    CHECK(near(pf_line_get_y2(a, lv), 150.0));
+    // entries == 5 -> explicit delete. After this the handle is dead but the
+    // strategy keeps using it; none of the following may throw.
+    CHECK_NOTHROW(pf_line_delete(a, lv));
+    CHECK(!a.alive(lv.id));
+    // subsequent bars keep mutating + reading the dead handle (the 2504-trade path):
+    for (int bar = 1; bar <= 5; ++bar) {
+        double level = 100.0 + bar;                 // a moving "sma" level
+        pf_line_set_y2(a, lv, level);
+        CHECK(near(pf_line_get_y2(a, lv), level));  // dead record tracks the new value
+    }
+}
+
 int main() {
     test_is_na_defaults();
     test_monotonic_ids();
@@ -383,7 +429,7 @@ int main() {
     test_mutate_through_handle();
     test_set_xloc_reinterpret();
     test_copy_is_deep();
-    test_delete_then_getter_throws();
+    test_delete_keeps_data_accessible();
     test_fifo_eviction();
     test_cap_zero_floors_to_one();
     test_get_price();
@@ -392,6 +438,7 @@ int main() {
     test_linefill();
     test_chart_point_value_copy();
     test_pf_noop();
+    test_delete_halt_probe_pattern();
 
     if (g_fail > 0) {
         std::printf("drawing tests: %d FAILED\n", g_fail);


### PR DESCRIPTION
## Summary
- keep deleted/FIFO-evicted drawing records data-accessible, matching TradingView behavior observed in the drawing-delete-halt probe
- update drawing tests to assert getters/setters/get_price still work on dead records while na/out-of-range handles throw
- update corpus submodule to the new drawing validation probe set (252 total, 251 excellent + 1 anomaly)

## Verification
- ctest --output-on-failure: 73/73 passed
- python scripts/verify-engine-local.py drawing-line-level-breakout drawing-box-zone-reentry drawing-udt-alias-identity drawing-chartpoint-trendline drawing-visual-noise-geometry drawing-delete-halt: 6/6 OK, 100% price-exact
- JOBS=8 scripts/run_corpus.sh && scripts/verify_corpus.py --all: 252 strategies — excellent=251, anomaly=1