### PR TITLE
chore(verify): emit report-only entry/exit p99 deltas

### DIFF
--- a/scripts/verify_corpus.py
+++ b/scripts/verify_corpus.py
@@ -703,6 +703,7 @@ def verify_one(strategy_dir: Path, *, verbose: bool = True, show_diffs: int = 0)
             f"  PnL         p90 delta: {pnl_p90    * 100:8.4f}%  ({check(pnl_ok)})\n"
             f"  MAE         p90 delta: {mae_p90    * 100:8.4f}%  ({check(mae_ok)})\n"
             f"  -- report-only (not gated) --\n"
+            f"  Entry/Exit  p99 delta:  {percentile(entry_deltas,0.99)*100:.4f}% / {percentile(exit_deltas,0.99)*100:.4f}%\n"
             f"  Entry/Exit/PnL p100:   {entry_p100*100:.4f}% / {exit_p100*100:.4f}% / {pnl_p100*100:.4f}%\n"
             f"  Qty   p90/p100 delta:  {percentile(qty_deltas,0.90)*100:.4f}% / {qty_p100*100:.4f}%\n"
             f"  PnL%  p90/p100 (pts):  {percentile(pnlpct_deltas,0.90):.4f} / {pnlpct_p100:.4f}\n"


### PR DESCRIPTION
Adds an entry/exit price **p99** delta line to `verify_corpus`'s *report-only (not gated)* block, alongside the existing p100. **Gating is unchanged (still p90)**, so corpus tiers are byte-identical — this only surfaces the tail of the price-delta distribution for diagnostics and the scraped-strategy tracking dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)