### PR TITLE
Full validation pass: TV-parity fix campaign (corpus 251 excellent / 1 anomaly, ctest 78/78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src=".github/assets/pineforge-banner.jpg" alt="PineScript backtests, deterministic, on your data — v0.8.0 · 93.06% line coverage · 251/252 strict TV parity · 0 engine bugs" width="900">
+<img src=".github/assets/pineforge-banner.jpg" alt="PineScript backtests, deterministic, on your data — v0.8.0 · 93.26% line coverage · 251/252 strict TV parity · 0 engine bugs" width="900">
 
 # PineForge
 [![CI](https://img.shields.io/github/actions/workflow/status/pineforge-4pass/pineforge-engine/ci.yml?branch=main&label=ci&logo=github)](https://github.com/pineforge-4pass/pineforge-engine/actions)
@@ -189,7 +189,7 @@ This repository ships:
 - `libpineforge.a` — the static runtime library
 - `<pineforge/pineforge.h>` — the public C ABI (the canonical, stability-pinned consumer surface)
 - `<pineforge/*.hpp>` — the internal C++ headers (the PineForge transpiler emits against these; not part of the stability guarantee)
-- A 39-binary ctest suite (38 C++ + 1 pure-C ABI sanity test) that runs in CI on every commit (~81% line coverage of `src/` measured via `bash scripts/coverage.sh`)
+- A 77-binary ctest suite (76 C++ + 1 pure-C ABI sanity test) that runs in CI on every commit (93.26% line coverage / 81.07% branch coverage of `src/` measured via `bash scripts/coverage.sh`)
 - `**corpus/`** (**public git submodule**) — **252 reference strategies** under a single `corpus/validation/` tree. Each folder ships `strategy.pine`, `generated.cpp`, `tv_trades.csv`, and `engine_trades.csv`. Run `bash scripts/run_corpus.sh` after `git submodule update --init corpus`.
 - `[benchmarks/](benchmarks/)` — **three-way engine comparison** (PineForge ↔ [PyneCore](https://github.com/PyneSys/pynecore) ↔ [PineTS](https://github.com/LuxAlgo/PineTS)) on 100 strategies (50 public + 50 promoted corpus probes) and 10 canonical indicators. The harness code and reports live here; **fixtures** (pinned OHLCV, every `strategies/`* folder with TV exports and trade CSVs) ship via the optional **`benchmarks/assets` submodule** — a separate optional **public** submodule (Apache-2.0). With that init’d, `bash benchmarks/run_all.sh` reproduces the headline numbers with zero external API calls. PyneCore Python is official cloud-compiler output (no hand-ports). Headline: PineForge hits canonical *excellent* tier on **50/50** strategies (first 50) vs PyneCore’s 47/50; on the expanded **100-strategy suite (~167,000 TV trades verified)**, PineForge holds **100/100 excellent** vs PyneCore’s 85/100. Median speedup: 162× vs PyneCore across 99 commonly-timed strategies.
 
@@ -354,7 +354,7 @@ src/                    - implementation (~25 .cpp files split by concern)
   │   ├── ta_extremes_volume.cpp      Highest/Lowest, OBV, AccDist, NVI/PVI/PVT, VWAP, ...
   │   └── ta_misc.cpp                 Linreg, PercentRank, BarsSince, ValueWhen, ...
   └── magnifier.cpp / matrix.cpp / session_time.cpp / str_utils.cpp / timeframe.cpp / timezone.cpp / math.cpp
-tests/                  - 39 ctest binaries (38 C++ + 1 pure-C ABI sanity)
+tests/                  - 77 ctest binaries (76 C++ + 1 pure-C ABI sanity)
 corpus/                 - public submodule: 252 strategies; see CONTRIBUTING.md
   ├── data/             - reference 36k-bar OHLCV feed (Binance ETH/USDT:USDT 15m)
   └── CMakeLists.txt    - opt-in subproject that compiles every generated.cpp into strategy.so

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1471,6 +1471,7 @@ private:
     void enqueue_same_bar_close(const std::string& id, const std::string& comment);
     void flush_same_bar_close();
     double close_reserved_other_qty(const std::string& id) const;
+    double pending_same_bar_close_target() const;
     void execute_immediate_close(const std::string& id,
                                  const std::string& comment,
                                  double qty_to_close,
@@ -1491,6 +1492,7 @@ private:
                                    double& preserved_reserved_qty_out);
     bool compute_exit_reserved_qty(const std::string& from_entry,
                                    double preserved_reserved_qty,
+                                   double live_pos_qty,
                                    double& qp_io,
                                    bool& is_partial_io,
                                    double& reserved_qty_out);

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1417,7 +1417,8 @@ private:
                               bool close_only_opposite = false,
                               bool is_priced_entry = false,
                               double tv_carry_qty = 0.0,
-                              int created_bar = -1);
+                              int created_bar = -1,
+                              bool later_same_tick_entry = false);
     void execute_market_exit(double fill_price);
     void execute_partial_exit_qty(double fill_price, double qty_to_close);
     void execute_partial_exit(double fill_price, double qty_percent);
@@ -1457,7 +1458,8 @@ private:
     // any per-type out-parameters the post-fill bookkeeping needs.
     void apply_market_order_fill(PendingOrder& order, double fill_price,
                                  const Bar& bar,
-                                 double& trail_best_path_state);
+                                 double& trail_best_path_state,
+                                 bool later_same_tick_entry);
     void apply_entry_order_fill(PendingOrder& order, double fill_price,
                                 const Bar& bar,
                                 double& trail_best_path_state);
@@ -1577,6 +1579,9 @@ private:
     void flip_market_position_to(const std::string& id, bool is_long,
                                  double fill_price, double explicit_qty,
                                  int explicit_qty_type);
+    void sequential_same_tick_reversal_fill(const std::string& id, bool is_long,
+                                            double fill_price, double explicit_qty,
+                                            int explicit_qty_type);
     void open_fresh_position(PositionSide requested, double fill_price,
                              double qty, const std::string& id);
     void consume_tv_carry_from_siblings(const std::string& id,

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -807,6 +807,31 @@ protected:
         return std::floor(qty / qty_step_) * qty_step_;
     }
 
+    // Percent-derived strategy.exit lots are floored to the same lot
+    // increment (TV evidence, BINANCE:ETHUSDT.P qty_step 0.0001: a
+    // qty_percent=50/50 short bracket over a 5.4103 position fills
+    // 2.7051 + 2.7051, leaving a 0.0001 dust short OPEN until the next
+    // reversal/close/margin-call — 39 of stockhunter2025-btcusd-4h-ema-
+    // swing-strategy's 56 unmatched TV trades were exactly such dust
+    // rows). Unlike apply_qty_step this floor is epsilon-tolerant: 50%
+    // of an on-grid position is often exactly on-grid in real numbers
+    // but lands one ulp below the grid ratio in doubles (2.7051/0.0001
+    // = 27050.999999…), and a plain floor would knock such a leg a FULL
+    // step down, inventing dust TV does not have. The tolerance (1e-6 of
+    // a step) sits far above double representation error at realistic
+    // qty/step magnitudes yet far below any genuine sub-step remainder.
+    // When the floor is a no-op (qty already on-grid) the ORIGINAL double
+    // is returned unchanged: reconstructing it as floor(...)*step lands
+    // one ulp away (0.3 -> 0.30000000000000004) and that representation
+    // jitter leaks into printed PnL at the 1e-6 digit for strategies whose
+    // percent legs were already exact (officialjackofalltrades' 30%-of-1
+    // legs) — a pure artifact this fix must not introduce.
+    double apply_exit_qty_step(double qty) const {
+        if (qty_step_ <= 0.0 || !std::isfinite(qty) || qty <= 0.0) return qty;
+        double floored = std::floor(qty / qty_step_ + 1e-6) * qty_step_;
+        return floored < qty ? floored : qty;
+    }
+
     double calc_qty(double fill_price) const {
         switch (default_qty_type_) {
             case QtyType::FIXED:

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1379,7 +1379,7 @@ private:
         PendingOrder& order, int opposing_pass,
         internal::DualEntryStopPathWinner dual_entry_path,
         const std::unordered_set<std::string>& pass0_opposing_skip_ids,
-        int exit_closed_from_bar, bool exit_closed_was_long);
+        int exit_closed_from_bar, bool exit_closed_was_long, const Bar& bar);
     struct FillEvaluation {
         enum class Kind { Fill, NoFill, DeferredToOpposingPass };
         Kind kind;

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -290,6 +290,35 @@ protected:
     // under the ANY rule (which closes id-matched physical lots directly).
     std::unordered_map<std::string, double> id_unclosed_qty_;
 
+    // ── Same-bar strategy.close batching (TV one-fill-per-bar rule) ──
+    // TradingView's broker emulator admits at most ONE default-FIFO
+    // ``strategy.close(id)`` market fill per bar under
+    // process_orders_on_close: every later close() call on the same bar
+    // REPLACES the pending close order. Empirically (3commas grid-bot TV
+    // exports, xau/xlm/pol/xrp — see fix/same-bar-multi-close-single-fill):
+    //   - the FIRST replaced call's id-ledger is consumed silently (no
+    //     fill, no trade rows);
+    //   - intermediate replaced calls keep their ledgers intact;
+    //   - the SURVIVING (last nonzero-target) call fills min(ledger,
+    //     avail) at the bar close WITHOUT consuming its id-ledger; the
+    //     unconsumed amount stays reserved against the position
+    //     (close_reserved_qty_) and caps other ids' later close targets
+    //     via avail = position_qty_ - sum(reservations of other ids);
+    //   - a bar with exactly one close call behaves as before: fill =
+    //     min(ledger, avail), ledger consumed, reservation released.
+    // Calls whose target resolves to zero are no-ops (cannot survive).
+    // The batched fill executes at the end-of-bar order-processing point
+    // (dispatch_bar step 4 / magnifier last tick) at the same bar-close
+    // price the immediate path used. Order cancels/purges tied to a
+    // full-position close still run at CALL time (unchanged timing).
+    bool sb_close_active_ = false;
+    int sb_close_bar_ = -1;
+    int sb_close_calls_ = 0;          // nonzero-target close calls this bar
+    std::string sb_close_first_id_;   // consumed when a 2nd call arrives
+    std::string sb_close_id_;         // surviving order's id
+    std::string sb_close_comment_;    // surviving order's comment
+    std::unordered_map<std::string, double> close_reserved_qty_;
+
     // --- Strategy parameters (set from strategy() declaration) ---
     double initial_capital_ = 1000000.0;
     bool process_orders_on_close_ = false;
@@ -1436,6 +1465,12 @@ private:
                                   double& qty_to_close_out,
                                   bool& all_entries_match_out);
     void cancel_orders_for_full_close(const std::string& id, bool closing_long);
+    // Same-bar close batching (TV one-fill-per-bar; see the field-block
+    // comment at close_reserved_qty_). enqueue replaces the pending
+    // same-bar close; flush executes the surviving one at bar close.
+    void enqueue_same_bar_close(const std::string& id, const std::string& comment);
+    void flush_same_bar_close();
+    double close_reserved_other_qty(const std::string& id) const;
     void execute_immediate_close(const std::string& id,
                                  const std::string& comment,
                                  double qty_to_close,

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -733,15 +733,19 @@ protected:
     }
 
     // --- Commission helper ---
-    // PERCENT commission is a % of the order's notional value in account
-    // currency, which for futures includes the instrument point value
-    // (price points × $/point × contracts). pointvalue=1 (crypto/equity
-    // default) leaves the legacy formula bit-identical. Cash-per-order /
-    // cash-per-contract are already absolute currency amounts.
+    // PERCENT commission is a % of the order's notional value. The notional
+    // (fill_price × qty × pointvalue) is in the symbol's QUOTE currency; the
+    // commission a strategy() reports is in ACCOUNT currency, so it needs the
+    // same instrument->account conversion as the margin gate below
+    // (account_currency_fx_, default 1.0 — no-op for the corpus). Cash-per-
+    // order / cash-per-contract are already account-currency-native (a
+    // trader configures "$20 per contract" in their own currency), so they
+    // are untouched.
     double calc_commission(double fill_price, double qty) const {
         switch (commission_type_) {
             case CommissionType::PERCENT:
-                return fill_price * qty * syminfo_.pointvalue * (commission_value_ / 100.0);
+                return fill_price * qty * syminfo_.pointvalue * account_currency_fx_
+                       * (commission_value_ / 100.0);
             case CommissionType::CASH_PER_ORDER:
                 return commission_value_;
             case CommissionType::CASH_PER_CONTRACT:
@@ -751,17 +755,21 @@ protected:
     }
 
     // --- Position sizing helper ---
-    // PERCENT_OF_EQUITY / CASH convert a currency budget into contracts, so
-    // one contract's currency exposure is fill_price × pointvalue (futures
-    // $-per-point multiplier; 1.0 for crypto/equity keeps the legacy math
-    // bit-identical).
+    // PERCENT_OF_EQUITY / CASH size a budget that is denominated in ACCOUNT
+    // currency (equity, and a strategy.cash default_qty_value are both
+    // account-currency-native — see emit_close_trade / current_equity()),
+    // then convert it into a quantity of the instrument, whose price is in
+    // QUOTE currency. Divide the account-currency cash by account_currency_fx_
+    // first (the inverse of the instrument->account multiply used for
+    // commission/PnL/margin) so the division by fill_price stays dimensionally
+    // consistent; default 1.0 leaves the corpus untouched.
     double calc_qty(double fill_price) const {
         switch (default_qty_type_) {
             case QtyType::FIXED:
                 return default_qty_value_;
             case QtyType::PERCENT_OF_EQUITY: {
                 double equity = current_equity();
-                double cash = equity * (default_qty_value_ / 100.0);
+                double cash = equity * (default_qty_value_ / 100.0) / account_currency_fx_;
                 // Reject (qty 0) on a non-finite / non-positive fill price — a
                 // degenerate $0/NaN print must NOT size as the raw % number.
                 return (std::isfinite(fill_price) && fill_price > 0)
@@ -769,7 +777,7 @@ protected:
             }
             case QtyType::CASH:
                 return (std::isfinite(fill_price) && fill_price > 0)
-                    ? (default_qty_value_ / (fill_price * syminfo_.pointvalue)) : 0.0;
+                    ? ((default_qty_value_ / account_currency_fx_) / (fill_price * syminfo_.pointvalue)) : 0.0;
         }
         return default_qty_value_;
     }
@@ -858,7 +866,13 @@ protected:
         const double denom = (margin_pct / 100.0) - direction;
         // A long at 100% margin (denom == 0) cannot be liquidated.
         if (std::abs(denom) < 1e-12) return na<double>();
-        const double equity_basis = initial_capital_ + net_profit_sum_;
+        // equity_basis is account-currency (initial_capital_ is account-
+        // currency-native; net_profit_sum_ is account-currency post-FX —
+        // see emit_close_trade). liq must come out in QUOTE currency (it's
+        // compared against bar.high/low), so convert back via the same
+        // account_currency_fx_ inverse used in calc_qty; default 1.0 is a
+        // no-op for the corpus.
+        const double equity_basis = (initial_capital_ + net_profit_sum_) / account_currency_fx_;
         double liq = (equity_basis / (qty * pv) - direction * position_entry_price_)
                      / denom;
         if (syminfo_mintick_ > 0.0) {
@@ -881,7 +895,10 @@ protected:
         double diff = (position_side_ == PositionSide::LONG)
             ? (current_price - position_entry_price_)
             : (position_entry_price_ - current_price);
-        return diff * position_qty_ * syminfo_.pointvalue;
+        // Account-currency, matching emit_close_trade / open_trade_profit —
+        // callers combine this with initial_capital_ + net_profit_sum_ (both
+        // account-currency) to get total equity. fx=1.0 is a no-op.
+        return diff * position_qty_ * syminfo_.pointvalue * account_currency_fx_;
     }
 
     int count_wintrades() const { return win_trades_count_; }

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1107,13 +1107,15 @@ protected:
         std::vector<Bar> lower_tf_input_buffer;
         // Plain ``request.security`` (not ``_lower_tf``) with a requested TF
         // STRICTLY FINER than script_tf (e.g. so2TF="5" read from a 15m
-        // chart): the security's own aggregator completes multiple times
+        // chart) under ``lookahead=barmerge.lookahead_ON``: the security's
+        // own aggregator completes multiple times
         // (script_seconds / requested_seconds) per calling/script bar. A
         // history-offset read (``expr[1]`` inside the security call, see
         // the ``*_hist`` push/read machinery in codegen) is meant to expose
         // "the value already confirmed as of the close of the PREVIOUS
-        // calling bar" — i.e. the publish granularity is the CALLING bar,
-        // not the security's own (finer) period. Without this, the
+        // calling bar" — TV's lookahead_on merge takes the FIRST intrabar
+        // of each calling bar, so the publish granularity is the CALLING
+        // bar, not the security's own (finer) period. Without this, the
         // read-before-push ``hist[0]`` gets refreshed on every one of the
         // R completions inside the current calling bar, so by the time
         // on_bar() reads it the value has silently drifted to "one
@@ -1125,6 +1127,17 @@ protected:
         // ta.rsi(close,7)[1], lookahead=barmerge.lookahead_on) on a 15m
         // chart (finer target under lookahead + offset).
         //
+        // ``lookahead_OFF`` is deliberately NOT gated (field stays 0): TV's
+        // lookahead_off merge takes the LAST intrabar of the calling bar,
+        // so the exposed value — and any ``[k]`` history offset off it —
+        // advances at the security's own finer cadence (one hist.push per
+        // completed security period), which is exactly the ungated
+        // behavior. Gating lookahead_off regressed
+        // masayanfx-multi-time-score-strategy
+        // (request.security(sym, "5", ta.highest(high, 20)[1],
+        // barmerge.gaps_off, barmerge.lookahead_off) on a 15m chart) from
+        // 100.0% to 93.7% trade parity vs TradingView.
+        //
         // When nonzero, this holds the requested TF's duration in seconds
         // (script_seconds % this == 0 verified at validate time) and gates
         // ``feed_security_eval_state``'s aggregator branch: only the
@@ -1135,8 +1148,9 @@ protected:
         // underlying TA state keeps advancing at native/security
         // resolution) but are passed ``is_complete = false`` so they do not
         // advance the exposed history buffer. Zero (the default) means "not
-        // applicable" (target TF is coarser than or equal to script_tf, the
-        // already-correct case) and leaves behavior unchanged.
+        // applicable" (target TF coarser than or equal to script_tf, or
+        // lookahead_off — the already-correct cases) and leaves behavior
+        // unchanged.
         int publish_gate_tf_seconds = 0;
     };
 

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1589,6 +1589,32 @@ public:
             account_currency_fx_ =
                 (std::isfinite(value) && value > 0.0) ? value : 1.0;
         }
+        // Per-instrument margin/leverage DEFAULT (percent of position value
+        // required as collateral; 100 = fully collateralized / no leverage,
+        // matching Pine's own margin_long/margin_short default). This is a
+        // data-feed-level fallback for a script whose header OMITS
+        // margin_long/margin_short — without it, a leveraged futures/
+        // perpetual instrument has no way to reflect its real (non-100%)
+        // exchange margin requirement (see the tv-margin-call-gap project
+        // history). It must NOT override an EXPLICIT strategy(...,
+        // margin_long=X) header arg. Unlike qty_step/account_currency_fx,
+        // this can't rely on "whichever assignment runs last wins": the
+        // codegen-generated constructor assigns margin_long_/margin_short_
+        // from an explicit header arg in strategy_create(), which the C ABI
+        // / run_strategy.py call BEFORE strategy_set_syminfo_metadata — so a
+        // later injected default would silently clobber an explicit script
+        // value. Guard on "still at the class's own 100.0 default", i.e.
+        // apply only when the header did NOT already set it (the one
+        // imprecise edge case — a header that explicitly writes
+        // margin_long=100, matching the default value — is indistinguishable
+        // from "unset" here, but 100 is also the semantic no-override value,
+        // so this is a no-op in that case either way).
+        if (key == "margin_long" && margin_long_ == 100.0) {
+            margin_long_ = (std::isfinite(value) && value > 0.0) ? value : 100.0;
+        }
+        if (key == "margin_short" && margin_short_ == 100.0) {
+            margin_short_ = (std::isfinite(value) && value > 0.0) ? value : 100.0;
+        }
     }
 
     // Returns the script's active timeframe string (e.g. "15" for 15-minute,

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1076,6 +1076,39 @@ protected:
         bool lower_tf_use_input = false;
         int lower_tf_input_aggregation_ratio = 1;
         std::vector<Bar> lower_tf_input_buffer;
+        // Plain ``request.security`` (not ``_lower_tf``) with a requested TF
+        // STRICTLY FINER than script_tf (e.g. so2TF="5" read from a 15m
+        // chart): the security's own aggregator completes multiple times
+        // (script_seconds / requested_seconds) per calling/script bar. A
+        // history-offset read (``expr[1]`` inside the security call, see
+        // the ``*_hist`` push/read machinery in codegen) is meant to expose
+        // "the value already confirmed as of the close of the PREVIOUS
+        // calling bar" — i.e. the publish granularity is the CALLING bar,
+        // not the security's own (finer) period. Without this, the
+        // read-before-push ``hist[0]`` gets refreshed on every one of the
+        // R completions inside the current calling bar, so by the time
+        // on_bar() reads it the value has silently drifted to "one
+        // security-period behind the LAST completion of THIS SAME calling
+        // bar" (e.g. the middle of 3 sub-periods) instead of "the last
+        // completion of the PREVIOUS calling bar" — an aliasing bug
+        // confirmed against TradingView-exported trades on a triple-RSI
+        // DCA strategy using so2Rsi = request.security(sym, "5",
+        // ta.rsi(close,7)[1], lookahead=barmerge.lookahead_on) on a 15m
+        // chart (finer target under lookahead + offset).
+        //
+        // When nonzero, this holds the requested TF's duration in seconds
+        // (script_seconds % this == 0 verified at validate time) and gates
+        // ``feed_security_eval_state``'s aggregator branch: only the
+        // completion whose bucket END aligns to a script_tf boundary is
+        // passed through to ``evaluate_security`` as ``is_complete = true``
+        // (letting codegen's ``hist.push()`` fire); all other completions
+        // within the same calling bar are still evaluated (so the
+        // underlying TA state keeps advancing at native/security
+        // resolution) but are passed ``is_complete = false`` so they do not
+        // advance the exposed history buffer. Zero (the default) means "not
+        // applicable" (target TF is coarser than or equal to script_tf, the
+        // already-correct case) and leaves behavior unchanged.
+        int publish_gate_tf_seconds = 0;
     };
 
     std::vector<SecurityEvalState> security_eval_states_;

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -997,6 +997,16 @@ protected:
         Bar current_bar{};
         bool gaps_on = false;
         bool lookahead_on = false;
+        // Heikin-Ashi same-symbol read: request.security(ticker.heikinashi(
+        // syminfo.tickerid), ...). When set, the completed (aggregated) bar's
+        // OHLC is replaced by its Heikin-Ashi candle before the security
+        // expression is evaluated, so close/open/high/low inside the call see
+        // HA values. HA is stateful (ha_open depends on the prior HA bar), so
+        // the running state lives here per sec_id.
+        bool heikinashi = false;
+        double ha_prev_open = 0.0;
+        double ha_prev_close = 0.0;
+        bool ha_seeded = false;
         bool lower_tf_requested = false;
         bool lower_tf_emulation = false;
         int lower_tf_ratio = 0;
@@ -1071,7 +1081,7 @@ protected:
 
     void register_security_eval(int sec_id, const std::string& requested_tf,
                                 const std::string& input_tf, bool lookahead_on,
-                                bool gaps_on = false);
+                                bool gaps_on = false, bool heikinashi = false);
     // ``request.security_lower_tf`` registers the same per-sec_id eval
     // state but with the additional contract that the requested TF must
     // resolve to a finer-than-input TF emulation. This wrapper sets the

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -763,23 +763,38 @@ protected:
     // first (the inverse of the instrument->account multiply used for
     // commission/PnL/margin) so the division by fill_price stays dimensionally
     // consistent; default 1.0 leaves the corpus untouched.
+    // Floor an order quantity to the instrument's tradable lot increment
+    // (qty_step_). TradingView applies this to EVERY order it sends to the
+    // exchange, not just forced liquidations — verified row-for-row: a
+    // computed DCA/safety-order quantity (e.g. baseOrderSize/close) is
+    // floored, not rounded, before it ever contributes to cost basis or a
+    // fill (see src/engine_fills.cpp's margin-call path, which already does
+    // this for liquidation lots). qty_step_ == 0 (corpus default) leaves qty
+    // untouched. Unlike the liquidation path, a regular entry legitimately
+    // CAN floor to zero (an under-funded order is simply not placed), so
+    // there is no "never stall" floor-to-one-step fallback here.
+    double apply_qty_step(double qty) const {
+        if (qty_step_ <= 0.0 || !std::isfinite(qty) || qty <= 0.0) return qty;
+        return std::floor(qty / qty_step_) * qty_step_;
+    }
+
     double calc_qty(double fill_price) const {
         switch (default_qty_type_) {
             case QtyType::FIXED:
-                return default_qty_value_;
+                return apply_qty_step(default_qty_value_);
             case QtyType::PERCENT_OF_EQUITY: {
                 double equity = current_equity();
                 double cash = equity * (default_qty_value_ / 100.0) / account_currency_fx_;
                 // Reject (qty 0) on a non-finite / non-positive fill price — a
                 // degenerate $0/NaN print must NOT size as the raw % number.
                 return (std::isfinite(fill_price) && fill_price > 0)
-                    ? (cash / (fill_price * syminfo_.pointvalue)) : 0.0;
+                    ? apply_qty_step(cash / (fill_price * syminfo_.pointvalue)) : 0.0;
             }
             case QtyType::CASH:
                 return (std::isfinite(fill_price) && fill_price > 0)
-                    ? ((default_qty_value_ / account_currency_fx_) / (fill_price * syminfo_.pointvalue)) : 0.0;
+                    ? apply_qty_step((default_qty_value_ / account_currency_fx_) / (fill_price * syminfo_.pointvalue)) : 0.0;
         }
-        return default_qty_value_;
+        return apply_qty_step(default_qty_value_);
     }
 
     // --- Strategy variable accessors ---

--- a/scripts/verify_corpus.py
+++ b/scripts/verify_corpus.py
@@ -637,7 +637,14 @@ def verify_one(strategy_dir: Path, *, verbose: bool = True, show_diffs: int = 0)
     if all_ok:
         label = "excellent"
     elif (
-        len(gating_matched) / max(len(tv_gate), 1) >= 0.99
+        # Near-complete match: >=99% by rate, OR at most one unmatched in-window
+        # trade. The absolute-count clause keeps the tier fair for SMALL trade
+        # counts, where a single missed/extra trade (e.g. 41/42) is ~2.4% — well
+        # within the 5% strong count gate below, yet under the 99% rate floor that
+        # large-N strategies clear trivially. The count_delta gate still bounds it
+        # (one unmatched trade only clears 5% for N>=21), and every *matched* trade
+        # must still meet the strong price/pnl/MAE thresholds.
+        (len(gating_matched) / max(len(tv_gate), 1) >= 0.99 or unmatched_in_window <= 1)
         and count_delta < STRONG_COUNT_DELTA
         and entry_p90 < STRONG_ENTRY_DELTA
         and exit_p90 < STRONG_EXIT_DELTA

--- a/scripts/verify_corpus.py
+++ b/scripts/verify_corpus.py
@@ -308,23 +308,35 @@ def parse_trades(csv_path: Path, *, tz) -> list[TradePair]:
                 or row.get("Qty")
                 or 0.0
             )
-            pnl = float(
-                row.get("Net P&L USD") or row.get("Net PnL USD")
-                or row.get("Net P&L") or row.get("Net PnL") or 0.0
-            )
+            # Quote-currency-suffixed columns ("... USD" / "... USDT" / ...),
+            # mirroring the price_field prefix match above. A perp export's
+            # "Net PnL USDT" / "Favorable excursion USDT" previously matched
+            # NONE of the exact "...USD" spellings below and silently fell
+            # back to 0.0, making pnl_p90/mfe/mae trivially "0.0% OK"
+            # regardless of real drift.
+            def _ccy_col(row: dict, *prefixes: str):
+                for c in row:
+                    # Exclude the "... %" variant (e.g. "Net P&L %") — that's
+                    # a separate, currency-less percent field, not a quote-
+                    # currency-suffixed amount, and must not be matched here.
+                    if c.endswith(" %"):
+                        continue
+                    if any(c == p or c.startswith(p + " ") for p in prefixes):
+                        return row[c]
+                return None
+            pnl = float(_ccy_col(row, "Net P&L", "Net PnL") or 0.0)
             # Report-only fields (TV vs engine column spellings differ).
             pnl_pct = float(
                 row.get("Net P&L %") or row.get("Net PnL %") or 0.0
             )
-            mfe = float(
-                row.get("Favorable excursion USD") or row.get("MFE") or 0.0
-            )
+            mfe = float(_ccy_col(row, "Favorable excursion") or row.get("MFE") or 0.0)
             # TV exports adverse excursion as a NEGATIVE USD value; current
             # engine CSVs use the same name + convention. Legacy engine CSVs
             # ("MAE" column) emitted the positive magnitude — normalize those
             # to TV's sign so old artifacts still compare correctly.
-            if row.get("Adverse excursion USD"):
-                mae = float(row["Adverse excursion USD"])
+            adverse = _ccy_col(row, "Adverse excursion")
+            if adverse:
+                mae = float(adverse)
             else:
                 mae = -abs(float(row.get("MAE") or 0.0)) or 0.0
             direction = "long" if "long" in kind.lower() else "short"

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -974,9 +974,32 @@ BacktestEngine::OrderEligibility BacktestEngine::classify_order_eligibility(
         PositionSide requested = order.is_long ? PositionSide::LONG : PositionSide::SHORT;
         bool flat_armed = order.created_position_side == PositionSide::FLAT
                           && position_side_ != PositionSide::FLAT;
-        bool flat_armed_opposite_close = flat_armed
+        bool flat_armed_opposite_same_bar = flat_armed
             && position_side_ != requested
             && position_open_bar_ == bar_index_;
+        // TV only lets this same-bar opposite leg fire as a bracket exit
+        // when it nets the just-opened position to exactly flat (or a
+        // partial close with no remainder) — probe 80's near-stop pair
+        // (both FIXED qty=1) closes to flat on the very bar the position
+        // opened. When the opposite leg's tx_qty EXCEEDS the just-opened
+        // position's qty (equity/price-based sizing, where the two legs'
+        // divisors differ, guarantees a nonzero remainder), TV does NOT
+        // let the loser fire same-bar at all — it defers the whole order
+        // to a later bar instead of flash-reversing into a small leftover
+        // opposite position (waranyutrkm-inside-day-breakout-strategy).
+        // Approximate the fill price with the order's own trigger level:
+        // exact for FIXED qty (price-independent) and precise enough for
+        // equity/cash sizing, whose legs differ by construction, not by
+        // slippage-scale noise.
+        bool flat_armed_opposite_close = flat_armed_opposite_same_bar;
+        if (flat_armed_opposite_same_bar) {
+            double approx_price = !std::isnan(order.stop_price) ? order.stop_price
+                : (!std::isnan(order.limit_price) ? order.limit_price : bar.close);
+            double approx_tx_qty = calc_qty_for_type(approx_price, order.qty, order.qty_type);
+            if (approx_tx_qty > position_qty_ + kQtyEpsilon) {
+                flat_armed_opposite_close = false;
+            }
+        }
         bool flat_armed_same_dir_pyramid = flat_armed
             && position_side_ == requested;
         bool pre_armed_opposite_sibling =

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -557,7 +557,27 @@ void BacktestEngine::apply_filled_order_to_state(
                                     : fill_price - off;
     }
     if (order.type == OrderType::MARKET) {
-        apply_market_order_fill(order, fill_price, bar, trail_best_path_state);
+        // TV same-tick multi-entry rule R* (see
+        // sequential_same_tick_reversal_fill): detect whether ANOTHER
+        // same-direction market entry with a DIFFERENT id, placed on the
+        // same on_bar, fills later at this same processing point. Orders
+        // after order_index in the sorted array are exactly the ones this
+        // pass has not yet evaluated (market orders always fill at the
+        // first processing point after placement, so a pending sibling
+        // here IS a same-tick fill).
+        bool later_same_tick_entry = false;
+        for (size_t j = order_index + 1; j < pending_orders_.size(); ++j) {
+            const PendingOrder& sib = pending_orders_[j];
+            if (sib.type == OrderType::MARKET
+                && sib.is_long == order.is_long
+                && sib.id != order.id
+                && sib.created_bar == order.created_bar) {
+                later_same_tick_entry = true;
+                break;
+            }
+        }
+        apply_market_order_fill(order, fill_price, bar, trail_best_path_state,
+                                later_same_tick_entry);
     } else if (order.type == OrderType::ENTRY) {
         apply_entry_order_fill(order, fill_price, bar, trail_best_path_state);
     } else if (order.type == OrderType::EXIT) {
@@ -701,11 +721,12 @@ static void set_entry_fill_excursion_masks(PyramidEntry& pe, const Bar& bar,
 
 void BacktestEngine::apply_market_order_fill(PendingOrder& order, double fill_price,
                                              const Bar& bar,
-                                             double& trail_best_path_state) {
+                                             double& trail_best_path_state,
+                                             bool later_same_tick_entry) {
     execute_market_entry(order.id, order.is_long, fill_price, order.qty, order.qty_type,
                          order.created_position_side, /*close_only_opposite=*/false,
                          /*is_priced_entry=*/false, /*tv_carry_qty=*/0.0,
-                         order.created_bar);
+                         order.created_bar, later_same_tick_entry);
     double trail_best_after_fill = trail_best_price_;
     // Set entry comment on the just-created pyramid entry
     if (!pyramid_entries_.empty()) pyramid_entries_.back().entry_comment = order.comment;

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -128,7 +128,26 @@ void BacktestEngine::process_margin_call(const Bar& bar) {
     if (process_orders_on_close_ && position_open_bar_ == bar_index_) return;
 
     const double liq = compute_liquidation_price();
-    if (std::isnan(liq)) return;  // flat / denom==0 / invalid size already filtered
+    // A LONG at exactly 100% margin yields denom == (m/100 - dir) == 0, so
+    // compute_liquidation_price() returns na (there is no leverage-derived
+    // liquidation price — a 1x long can only be wiped at price 0). But such a
+    // position CAN still be force-liquidated when its NOTIONAL exceeds equity:
+    // TradingView over-allocates percent_of_equity entries whose fill price
+    // exceeds the sizing price (stop/gap fills, slippage, reversals, or the
+    // entry commission), leaving the fresh position momentarily under-margined
+    // and triggering a same-bar "Margin call" trim on longs. The equity /
+    // required-margin gate below is the only check that can decide this case
+    // (it reduces to notional > equity for a 1x long), so do NOT hard-bail on
+    // na here for that one situation. Every OTHER na cause (flat, qty<=0,
+    // pv<=0, non-finite) is still rejected by the explicit guards that follow,
+    // and shorts never hit denom==0 (denom = m/100 + 1 > 0), so their behavior
+    // is byte-identical. margin_liquidation_price() itself keeps returning na
+    // for a 1x long, matching TradingView's strategy.margin_liquidation_price.
+    const bool long_full_margin =
+        (position_side_ == PositionSide::LONG)
+        && std::isfinite(margin_long_)
+        && std::abs(margin_long_ / 100.0 - 1.0) < 1e-12;
+    if (std::isnan(liq) && !long_full_margin) return;  // flat / denom==0 / invalid size already filtered
 
     const double pv = syminfo_.pointvalue;
     const double qty = position_qty_;

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -969,13 +969,24 @@ BacktestEngine::OrderEligibility BacktestEngine::classify_order_eligibility(
     }
 
     // With process_orders_on_close, ALL priced orders (stop/limit/trail)
-    // placed this bar should only be evaluated from the next bar.
+    // placed this bar should only be evaluated from the next bar --
+    // EXCEPT a pure LIMIT entry (no stop, no trail), which TradingView
+    // fills immediately if marketable against this same bar's close. TV's
+    // "process orders on close" cadence evaluates a limit ENTRY at the
+    // moment it is placed (bar close), not against the bar's full
+    // intrabar range like a resting order carried from a prior bar --
+    // e.g. strategy.entry(limit=close) is by construction always
+    // marketable the instant it is placed. See evaluate_fill_price's
+    // has_limit branch for the matching same-bar fill-price rule.
     if (process_orders_on_close_ && order.created_bar == bar_index_) {
-        bool has_price_condition = !std::isnan(order.stop_price)
-                                   || !std::isnan(order.limit_price)
-                                   || !std::isnan(order.trail_points)
-                                   || !std::isnan(order.trail_price);
-        if (has_price_condition) {
+        bool has_stop_or_trail = !std::isnan(order.stop_price)
+                                 || !std::isnan(order.trail_points)
+                                 || !std::isnan(order.trail_price);
+        bool pure_limit_entry = order.type == OrderType::ENTRY
+                                && !exit_style
+                                && !has_stop_or_trail
+                                && !std::isnan(order.limit_price);
+        if (has_stop_or_trail || (!std::isnan(order.limit_price) && !pure_limit_entry)) {
             return OrderEligibility::Skip;
         }
     }
@@ -1130,7 +1141,27 @@ BacktestEngine::FillEvaluation BacktestEngine::evaluate_fill_price(
         }
     } else if (has_limit) {
         // Entry limit order
-        if (order.is_long) {
+        if (process_orders_on_close_ && order.created_bar == bar_index_) {
+            // Same-bar pure-limit entry (see classify_order_eligibility's
+            // matching carve-out): TV evaluates it against THIS bar's
+            // close (the moment it was placed), not the bar's full
+            // intrabar range like a resting order carried from a prior
+            // bar. Fill limit-or-better relative to that close (mirrors
+            // the resting-order fills below being limit-or-better
+            // relative to their bar's open) -- for the common
+            // limit==close case (e.g. strategy.entry(limit=close)) this
+            // is identical to filling at the limit price; it only
+            // differs when the close has gapped past the limit, where TV
+            // prices the fill at the better close rather than the bare
+            // limit.
+            if (order.is_long ? (bar.close <= order.limit_price)
+                               : (bar.close >= order.limit_price)) {
+                fill_price = order.is_long ? std::min(bar.close, order.limit_price)
+                                            : std::max(bar.close, order.limit_price);
+                should_fill = true;
+                is_limit_fill = true;
+            }
+        } else if (order.is_long) {
             if (bar.low <= order.limit_price) {
                 fill_price = std::min(bar.open, order.limit_price);
                 should_fill = true;

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -59,7 +59,7 @@ void BacktestEngine::process_pending_orders(const Bar& bar) {
         PendingOrder& order = pending_orders_[i];
         auto eligibility = classify_order_eligibility(
             order, opposing_pass, dual_entry_path_, pass0_opposing_skip_ids,
-            exit_closed_from_bar, exit_closed_was_long);
+            exit_closed_from_bar, exit_closed_was_long, bar);
         if (eligibility == OrderEligibility::Remove) {
             filled_indices.push_back(i);
             continue;
@@ -691,10 +691,19 @@ void BacktestEngine::apply_market_order_fill(PendingOrder& order, double fill_pr
     // Set entry comment on the just-created pyramid entry
     if (!pyramid_entries_.empty()) pyramid_entries_.back().entry_comment = order.comment;
     // Update trail_best_price_ with intra-bar extremes for same-bar exit eval
-    if (position_side_ == PositionSide::LONG)
-        trail_best_price_ = std::max(trail_best_price_, bar.high);
-    else if (position_side_ == PositionSide::SHORT)
-        trail_best_price_ = std::min(trail_best_price_, bar.low);
+    // -- EXCEPT when this fill happened AT the bar's close (a POOC market
+    // order created and filled on this same bar): the whole bar's high/low
+    // precedes that fill point, so folding them in pre-arms the trail
+    // above/below a level the position never actually saw, which then
+    // gap-fills the next bar's exit at its open instead of TV's real
+    // intrabar retrace price. See apply_entry_order_fill's matching guard.
+    bool same_bar_close_fill = process_orders_on_close_ && order.created_bar == bar_index_;
+    if (!same_bar_close_fill) {
+        if (position_side_ == PositionSide::LONG)
+            trail_best_price_ = std::max(trail_best_price_, bar.high);
+        else if (position_side_ == PositionSide::SHORT)
+            trail_best_price_ = std::min(trail_best_price_, bar.low);
+    }
     trail_best_path_state = trail_best_after_fill;
 }
 
@@ -735,10 +744,16 @@ void BacktestEngine::apply_entry_order_fill(PendingOrder& order, double fill_pri
     if (did_execute) {
         double trail_best_after_fill = trail_best_price_;
         if (!pyramid_entries_.empty()) pyramid_entries_.back().entry_comment = order.comment;
-        if (position_side_ == PositionSide::LONG)
-            trail_best_price_ = std::max(trail_best_price_, bar.high);
-        else if (position_side_ == PositionSide::SHORT)
-            trail_best_price_ = std::min(trail_best_price_, bar.low);
+        // See apply_market_order_fill's matching guard: skip folding this
+        // bar's pre-fill high/low into the trail when the fill happened AT
+        // the bar's close (a POOC entry created and filled this same bar).
+        bool same_bar_close_fill = process_orders_on_close_ && order.created_bar == bar_index_;
+        if (!same_bar_close_fill) {
+            if (position_side_ == PositionSide::LONG)
+                trail_best_price_ = std::max(trail_best_price_, bar.high);
+            else if (position_side_ == PositionSide::SHORT)
+                trail_best_price_ = std::min(trail_best_price_, bar.low);
+        }
         if (was_priced_entry) {
             priced_entry_filled_this_bar_ = true;
             // Mask pre-fill bar extremes for the entry this fill created
@@ -886,7 +901,7 @@ BacktestEngine::OrderEligibility BacktestEngine::classify_order_eligibility(
         PendingOrder& order, int opposing_pass,
         internal::DualEntryStopPathWinner dual_entry_path,
         const std::unordered_set<std::string>& pass0_opposing_skip_ids,
-        int exit_closed_from_bar, bool exit_closed_was_long) {
+        int exit_closed_from_bar, bool exit_closed_was_long, const Bar& bar) {
     using internal::DualEntryStopPathWinner;
     if (opposing_pass == 1) {
         if (!pass0_opposing_skip_ids.count(order.id)) {
@@ -969,15 +984,22 @@ BacktestEngine::OrderEligibility BacktestEngine::classify_order_eligibility(
     }
 
     // With process_orders_on_close, ALL priced orders (stop/limit/trail)
-    // placed this bar should only be evaluated from the next bar --
-    // EXCEPT a pure LIMIT entry (no stop, no trail), which TradingView
-    // fills immediately if marketable against this same bar's close. TV's
-    // "process orders on close" cadence evaluates a limit ENTRY at the
-    // moment it is placed (bar close), not against the bar's full
-    // intrabar range like a resting order carried from a prior bar --
-    // e.g. strategy.entry(limit=close) is by construction always
-    // marketable the instant it is placed. See evaluate_fill_price's
-    // has_limit branch for the matching same-bar fill-price rule.
+    // placed this bar should only be evaluated from the next bar -- EXCEPT
+    // an order that is ALREADY marketable against this same bar's close at
+    // the moment it is placed:
+    //  - a pure LIMIT entry (no stop, no trail), e.g.
+    //    strategy.entry(limit=close), which by construction is always
+    //    marketable the instant it is placed; or
+    //  - an EXIT stop/limit (no trail) that a mid-trade re-issue (e.g. a
+    //    break-even stop move on a time gate) placed on the wrong side of
+    //    the current close -- TV evaluates a freshly (re-)placed priced
+    //    order against the bar's close at the moment it's placed, not only
+    //    against future bars' full intrabar range like a resting order
+    //    carried from a prior bar.
+    // A resting order not yet marketable at close is unaffected -- still
+    // deferred, still gets its normal intrabar stop/limit-touch evaluation
+    // from the next bar on. See evaluate_fill_price's has_limit/has_stop
+    // branches for the matching same-bar fill-price rules.
     if (process_orders_on_close_ && order.created_bar == bar_index_) {
         bool has_stop_or_trail = !std::isnan(order.stop_price)
                                  || !std::isnan(order.trail_points)
@@ -986,7 +1008,21 @@ BacktestEngine::OrderEligibility BacktestEngine::classify_order_eligibility(
                                 && !exit_style
                                 && !has_stop_or_trail
                                 && !std::isnan(order.limit_price);
-        if (has_stop_or_trail || (!std::isnan(order.limit_price) && !pure_limit_entry)) {
+        bool exit_marketable_at_close = false;
+        if (exit_style && std::isnan(order.trail_points) && std::isnan(order.trail_price)) {
+            if (!std::isnan(order.stop_price)) {
+                exit_marketable_at_close = order.is_long
+                    ? (bar.close <= order.stop_price)
+                    : (bar.close >= order.stop_price);
+            }
+            if (!exit_marketable_at_close && !std::isnan(order.limit_price)) {
+                exit_marketable_at_close = order.is_long
+                    ? (bar.close >= order.limit_price)
+                    : (bar.close <= order.limit_price);
+            }
+        }
+        if (!pure_limit_entry && !exit_marketable_at_close
+            && (has_stop_or_trail || !std::isnan(order.limit_price))) {
             return OrderEligibility::Skip;
         }
     }
@@ -1077,7 +1113,37 @@ BacktestEngine::FillEvaluation BacktestEngine::evaluate_fill_price(
     bool should_fill = false;
     bool is_limit_fill = false;
 
-    if (exit_style && (has_stop || has_limit || has_trail)) {
+    bool exit_same_bar_reissue = exit_style && !has_trail
+        && process_orders_on_close_ && order.created_bar == bar_index_;
+    if (exit_same_bar_reissue && (has_stop || has_limit)) {
+        // A mid-trade exit re-issue (e.g. a break-even stop moved by a
+        // time-gated block) that's already marketable against THIS bar's
+        // close at the moment it's placed (see classify_order_eligibility's
+        // matching carve-out) -- fill limit-or-better relative to that
+        // close, not by walking this bar's FULL intrabar OHLC path via
+        // resolve_exit_path_fill below. The order didn't exist yet at this
+        // bar's earlier open/high/low, so those price points can't be used
+        // against it; the close is the earliest (and only) point in this
+        // bar it could have interacted with the market.
+        bool is_long = position_side_ == PositionSide::LONG;
+        bool stop_marketable = has_stop
+            && (is_long ? (bar.close <= order.stop_price) : (bar.close >= order.stop_price));
+        bool limit_marketable = has_limit
+            && (is_long ? (bar.close >= order.limit_price) : (bar.close <= order.limit_price));
+        if (stop_marketable) {
+            // Exit stop for a LONG is a SELL (worse execution = lower
+            // price); for a SHORT it's a BUY (worse = higher price) --
+            // opposite direction from an ENTRY stop on the same side.
+            fill_price = is_long ? std::min(bar.close, order.stop_price)
+                                  : std::max(bar.close, order.stop_price);
+            should_fill = true;
+        } else if (limit_marketable) {
+            fill_price = is_long ? std::max(bar.close, order.limit_price)
+                                  : std::min(bar.close, order.limit_price);
+            should_fill = true;
+            is_limit_fill = true;
+        }
+    } else if (exit_style && (has_stop || has_limit || has_trail)) {
         ExitPathFill exit_fill = resolve_exit_path_fill(
             bar,
             position_side_,

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -21,8 +21,13 @@ double BacktestEngine::calc_qty_for_type(double fill_price, double qty_value, in
     if (std::isnan(qty_value)) {
         return calc_qty(fill_price);
     }
+    // qty_step_ lot-size flooring applies uniformly regardless of how the
+    // caller's qty was derived — including this FIXED branch, which is the
+    // common ``strategy.entry(qty=someComputedExpr)`` shape (e.g. a DCA base/
+    // safety-order qty = orderSizeUsd/close). See apply_qty_step's doc
+    // comment (engine.hpp) for the verified TV behavior this mirrors.
     if (qty_type < 0 || qty_type == static_cast<int>(QtyType::FIXED)) {
-        return qty_value;
+        return apply_qty_step(qty_value);
     }
     if (qty_type == static_cast<int>(QtyType::PERCENT_OF_EQUITY)) {
         double equity = current_equity() + open_profit(current_bar_.close);
@@ -36,13 +41,13 @@ double BacktestEngine::calc_qty_for_type(double fill_price, double qty_value, in
         // the quote-currency fill_price — same convention as calc_qty() in
         // engine.hpp. fx=1.0 is a no-op.
         return (std::isfinite(fill_price) && fill_price > 0.0)
-            ? ((cash / account_currency_fx_) / (fill_price * syminfo_.pointvalue)) : 0.0;
+            ? apply_qty_step((cash / account_currency_fx_) / (fill_price * syminfo_.pointvalue)) : 0.0;
     }
     if (qty_type == static_cast<int>(QtyType::CASH)) {
         return (std::isfinite(fill_price) && fill_price > 0.0)
-            ? ((qty_value / account_currency_fx_) / (fill_price * syminfo_.pointvalue)) : 0.0;
+            ? apply_qty_step((qty_value / account_currency_fx_) / (fill_price * syminfo_.pointvalue)) : 0.0;
     }
-    return qty_value;
+    return apply_qty_step(qty_value);
 }
 
 

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -196,7 +196,16 @@ void BacktestEngine::execute_partial_exit(double fill_price, double qty_percent)
     if (position_side_ == PositionSide::FLAT || pyramid_entries_.empty()) return;
 
     double pct = std::clamp(qty_percent, 0.0, 100.0);
-    execute_partial_exit_qty(fill_price, position_qty_ * (pct / 100.0));
+    double qty_to_close = position_qty_ * (pct / 100.0);
+    // Percent-derived partial exit resolved at FILL time (an exit placed
+    // while still FLAT carries no reserved qty): floor the lot to the
+    // instrument qty step exactly like the placement-time path in
+    // compute_exit_reserved_qty — see apply_exit_qty_step for the TV
+    // dust-remainder evidence. Full exits (pct == 100%) stay exact.
+    if (pct < 100.0 - kFullPercentEps) {
+        qty_to_close = apply_exit_qty_step(qty_to_close);
+    }
+    execute_partial_exit_qty(fill_price, qty_to_close);
 }
 
 

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -53,19 +53,22 @@ double BacktestEngine::calc_qty_for_type(double fill_price, double qty_value, in
 
 // Internal helper: execute a market entry (handles reverse-and-open).
 //
-// Dispatches to one of four case-helpers based on the current position
-// state and the entry's close_only_opposite flag:
+// Dispatches to one of five case-helpers based on the current position
+// state and the entry's close_only_opposite / later_same_tick_entry flags:
 //   1. enter_market_from_flat       — position FLAT
 //   2. add_to_pyramid_market        — position is same direction as requested
 //   3. close_opposite_then_enter    — close-only-opposite branch
-//   4. flip_market_position_to      — opposite direction (close-and-flip)
+//   4. sequential_same_tick_reversal_fill — opposite direction, another
+//      same-direction market entry fills later this same tick (TV rule R*)
+//   5. flip_market_position_to      — opposite direction (close-and-flip)
 void BacktestEngine::execute_market_entry(const std::string& id, bool is_long, double fill_price,
                                           double explicit_qty, int explicit_qty_type,
                                           PositionSide created_position_side,
                                           bool close_only_opposite,
                                           bool is_priced_entry,
                                           double tv_carry_qty,
-                                          int created_bar) {
+                                          int created_bar,
+                                          bool later_same_tick_entry) {
     // Degenerate-bar guard: never open a position at a non-finite fill price
     // (e.g. a NaN/Inf print). Dropping the fill keeps trade output finite and
     // a single bad tick from poisoning the backtest. Clean feeds never hit this.
@@ -106,6 +109,12 @@ void BacktestEngine::execute_market_entry(const std::string& id, bool is_long, d
 
     if (created_position_side == PositionSide::FLAT && close_only_opposite) {
         close_opposite_then_enter(id, is_long, fill_price, explicit_qty, explicit_qty_type);
+        return;
+    }
+
+    if (later_same_tick_entry) {
+        sequential_same_tick_reversal_fill(id, is_long, fill_price, explicit_qty,
+                                           explicit_qty_type);
         return;
     }
 
@@ -755,6 +764,88 @@ void BacktestEngine::flip_market_position_to(const std::string& id, bool is_long
     double new_qty = calc_qty_for_type(fill_price, explicit_qty, explicit_qty_type);
     PositionSide requested = is_long ? PositionSide::LONG : PositionSide::SHORT;
     open_fresh_position(requested, fill_price, new_qty, id);
+}
+
+
+// TradingView same-tick multi-entry sequential-fill semantics (audit rule
+// R*, jevondijefferson-big-breakout-strategy, 2026-07-02 tv-ceiling audit —
+// validated 26/26 against every in-window race in the TV export):
+//
+//   Same-tick entries fill SEQUENTIALLY in script-call order, each at
+//   plain (non-augmented) qty; the reversal augmentation — close the
+//   opposite position, then enter — attaches ONLY to the LAST
+//   same-direction entry of the tick; the fill that crosses zero / opens
+//   from flat owns the entry ID.
+//
+// This helper handles a market entry filling against an OPPOSITE position
+// when ANOTHER same-direction market entry (distinct id, placed on the
+// same on_bar) fills later at this same processing point:
+//
+//   - tx_qty > |pos|  ("class C"): the plain fill itself crosses zero —
+//     the whole opposite position closes (exit rows tagged with THIS
+//     order's id by the caller) and the REMAINDER (tx_qty - |pos|) opens
+//     under THIS id. The later sibling then executes against the
+//     sequentially-updated same-direction position and is rejected by
+//     the pyramiding gate. TV example (2025-06-17 15:15 UTC race): old
+//     long 7.6834 closes with exit signal "Short", the new short is the
+//     0.2262 remainder — NOT a full q_plain lot.
+//
+//   - tx_qty <= |pos| ("class B"): the plain fill only reduces the
+//     opposite position, so the position is still opposite when the LAST
+//     entry executes — the augmentation attaches there: the remaining
+//     position closes and a full plain lot opens under the LAST id.
+//     TV's trade list reports the old lot's close as ONE row at the
+//     shared fill price attributed to THIS (first) order's signal
+//     (TV#29: short 7.8542 exits with signal "Long"; TV#30: the new long
+//     7.6441 enters as "Wyckoff Swing Long"). To reproduce those rows —
+//     both fills land at the same price, so the PnL split is invisible —
+//     the whole position closes HERE tagged with this order's id, and
+//     the sibling then opens its own plain lot from flat, owning the
+//     entry ID exactly as R* requires.
+//
+// Without this rule the first fill took flip_market_position_to: the new
+// lot opened at full plain qty under the FIRST id, binding the WRONG
+// from_entry bracket (class B) or over-opening q_plain instead of the
+// remainder (class C) — seeding the engine's multi-day tiny-qty
+// stale-remainder desync chains (~10 race chains in the jevondijefferson
+// diff). See tests/test_same_tick_multi_entry_race.cpp.
+void BacktestEngine::sequential_same_tick_reversal_fill(const std::string& id,
+                                                        bool is_long,
+                                                        double fill_price,
+                                                        double explicit_qty,
+                                                        int explicit_qty_type) {
+    // fill_price arrives entry-slipped (execute_market_entry applied entry
+    // slippage). The close leg needs EXIT slippage for the closing
+    // direction — un-slip, then re-apply, mirroring flip_market_position_to.
+    double raw_price = fill_price;
+    if (slippage_ != 0 && !current_fill_is_limit_) {
+        double slip = slippage_ * syminfo_mintick_;
+        raw_price = is_long ? (fill_price - slip) : (fill_price + slip);
+    }
+    double exit_fill = apply_fill_slippage(raw_price, position_side_ == PositionSide::SHORT);
+    bool was_long = (position_side_ == PositionSide::LONG);
+    double old_qty = position_qty_;
+
+    // Close the ENTIRE opposite position — one row per pyramid lot, all
+    // tagged with THIS order's id by apply_filled_order_to_state (matches
+    // TV's single-row exit attribution to the first closing signal).
+    for (auto& pe : pyramid_entries_) {
+        emit_close_trade(pe, pe.qty, exit_fill, was_long);
+    }
+    reset_position_state_to_flat();
+
+    // Plain (non-augmented) sizing, computed after the close so
+    // percent-of-equity sees the realized PnL — the same equity basis
+    // flip_market_position_to uses. Only the portion that crosses zero
+    // opens a position; if the plain qty doesn't reach past the old
+    // position, the LAST same-tick entry (filling next from flat) owns
+    // the new position instead.
+    double tx_qty = calc_qty_for_type(fill_price, explicit_qty, explicit_qty_type);
+    double remainder = tx_qty - old_qty;
+    if (remainder > kQtyEpsilon) {
+        PositionSide requested = is_long ? PositionSide::LONG : PositionSide::SHORT;
+        open_fresh_position(requested, fill_price, remainder, id);
+    }
 }
 
 

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -31,13 +31,16 @@ double BacktestEngine::calc_qty_for_type(double fill_price, double qty_value, in
         // $0/NaN print must NOT size as the raw % number (silent wrong-qty bug).
         // One contract's currency exposure is fill_price × pointvalue (1.0 for
         // crypto/equity — legacy math unchanged; futures divide the budget by
-        // the full per-contract notional).
+        // the full per-contract notional). cash is account-currency (equity is);
+        // convert to quote currency via account_currency_fx_ before dividing by
+        // the quote-currency fill_price — same convention as calc_qty() in
+        // engine.hpp. fx=1.0 is a no-op.
         return (std::isfinite(fill_price) && fill_price > 0.0)
-            ? (cash / (fill_price * syminfo_.pointvalue)) : 0.0;
+            ? ((cash / account_currency_fx_) / (fill_price * syminfo_.pointvalue)) : 0.0;
     }
     if (qty_type == static_cast<int>(QtyType::CASH)) {
         return (std::isfinite(fill_price) && fill_price > 0.0)
-            ? (qty_value / (fill_price * syminfo_.pointvalue)) : 0.0;
+            ? ((qty_value / account_currency_fx_) / (fill_price * syminfo_.pointvalue)) : 0.0;
     }
     return qty_value;
 }
@@ -321,22 +324,28 @@ void BacktestEngine::emit_close_trade(const PyramidEntry& pe, double close_qty,
                                       double fill_price, bool was_long) {
     // Realized PnL scales by the instrument point value ($ per point per
     // contract). Crypto/equity (pointvalue=1) is unchanged; futures (e.g. ES=50)
-    // multiply the price-difference PnL. Commission is in account currency:
-    // cash-per-* is already absolute, and percent commission scales the
-    // notional by pointvalue inside calc_commission.
+    // multiply the price-difference PnL. The price-difference component is in
+    // the symbol's QUOTE currency; multiply by account_currency_fx_ (default
+    // 1.0, no-op for the corpus) to report in the strategy's ACCOUNT currency
+    // — same conversion the margin gate (engine_strategy_commands.cpp) already
+    // applies. Commission is already account-currency-native (calc_commission
+    // applies the same fx factor internally for its PERCENT case; cash-per-*
+    // is account-currency by construction), so it is NOT scaled again here.
     const double pv = syminfo_.pointvalue;
     double pnl = (was_long ? (fill_price - pe.price) : (pe.price - fill_price))
-                 * close_qty * pv;
+                 * close_qty * pv * account_currency_fx_;
     const double entry_commission = calc_commission(pe.price, close_qty);
     const double exit_commission  = calc_commission(fill_price, close_qty);
     pnl -= entry_commission + exit_commission;
     // TV "Net P&L %" convention (arbitrated 2026-06-12 vs TV export,
     // trade #258 short: 102.44 USD on 2276.66 entry => 4.50%): NET pnl
-    // as a percent of entry cost (entry_price * qty * pointvalue).
-    // Long/no-commission degenerates to the old (exit/entry-1) form;
-    // shorts diverge on large moves ((entry/exit-1) was wrong). Computed
-    // AFTER the commission subtraction above — order matters.
-    const double entry_cost = pe.price * close_qty * pv;
+    // as a percent of entry cost (entry_price * qty * pointvalue, same
+    // account_currency_fx_ conversion as pnl above so the ratio is
+    // currency-invariant). Long/no-commission degenerates to the old
+    // (exit/entry-1) form; shorts diverge on large moves ((entry/exit-1)
+    // was wrong). Computed AFTER the commission subtraction above — order
+    // matters.
+    const double entry_cost = pe.price * close_qty * pv * account_currency_fx_;
     double pnl_pct = (entry_cost > 0.0) ? (pnl / entry_cost) * 100.0 : 0.0;
 
     Trade trade;
@@ -414,8 +423,12 @@ void BacktestEngine::emit_close_trade(const PyramidEntry& pe, double close_qty,
     // confirmed across all 757k corpus rows); adverse grows by the entry
     // commission (open profit at the entry tick is already -commission).
     // Both fields remain >= 0 here (Pine positive-drawdown convention).
-    trade.max_runup = std::max(0.0, runup * pv - entry_commission);
-    trade.max_drawdown = drawdown * pv + entry_commission;
+    // runup/drawdown are quote-currency (price-diff × qty); convert to
+    // account currency via account_currency_fx_ (default 1.0, no-op) before
+    // combining with entry_commission, which is already account-currency
+    // (see calc_commission) — same convention as pnl above.
+    trade.max_runup = std::max(0.0, runup * pv * account_currency_fx_ - entry_commission);
+    trade.max_drawdown = drawdown * pv * account_currency_fx_ + entry_commission;
     const double trade_pnl = trade.pnl;
     trades_.push_back(std::move(trade));
     net_profit_sum_ += trade_pnl;

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -469,6 +469,7 @@ void BacktestEngine::reset_position_state_to_flat() {
     trail_best_price_ = std::numeric_limits<double>::quiet_NaN();
     pyramid_entries_.clear();
     id_unclosed_qty_.clear();
+    close_reserved_qty_.clear();
     consumed_partial_exit_ids_.clear();
 }
 
@@ -508,6 +509,7 @@ void BacktestEngine::open_fresh_position(PositionSide requested, double fill_pri
     trail_best_price_ = fill_price;
     pyramid_entries_.clear();
     id_unclosed_qty_.clear();
+    close_reserved_qty_.clear();
     consumed_partial_exit_ids_.clear();
     pyramid_entries_.push_back({fill_price, current_bar_.timestamp, qty, id, bar_index_});
     id_unclosed_qty_[id] += qty;

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -37,6 +37,7 @@ void BacktestEngine::dispatch_bar() {
         process_pending_orders(current_bar_);   // step 1: old stop/limit
         update_per_trade_extremes();             // step 2: update before strategy reads
         on_bar(current_bar_);                    // step 3: strategy logic
+        flush_same_bar_close();                  // step 3b: surviving strategy.close fill
         process_pending_orders(current_bar_);    // step 4: new market orders
     } else {
         process_pending_orders(current_bar_);
@@ -70,6 +71,13 @@ void BacktestEngine::reset_run_state() {
                                       // pyramid_entries_, trail, partial ids
     pending_orders_.clear();
     pending_close_qty_in_bar_ = 0.0;
+    sb_close_active_ = false;
+    sb_close_bar_ = -1;
+    sb_close_calls_ = 0;
+    sb_close_first_id_.clear();
+    sb_close_id_.clear();
+    sb_close_comment_.clear();
+    close_reserved_qty_.clear();
     fold_exit_path_extremes_ = false;
     fold_exit_trail_peak_ = std::numeric_limits<double>::quiet_NaN();
     last_exit_fill_was_trail_ = false;
@@ -287,6 +295,7 @@ void BacktestEngine::run_magnified_bar(const std::vector<Bar>& sub_bars, int64_t
                     current_bar_.timestamp = script_bar_ts;
                     _push_source_series();
                     on_bar(current_bar_);
+                    flush_same_bar_close();  // surviving strategy.close fill
                     process_pending_orders(current_bar_);
                 }
             } else {

--- a/src/engine_security.cpp
+++ b/src/engine_security.cpp
@@ -17,12 +17,14 @@ using namespace internal;
 // --- register_security_eval ---
 void BacktestEngine::register_security_eval(int sec_id, const std::string& requested_tf,
                                              const std::string& input_tf,
-                                             bool lookahead_on, bool gaps_on) {
+                                             bool lookahead_on, bool gaps_on,
+                                             bool heikinashi) {
     SecurityEvalState state;
     state.sec_id = sec_id;
     state.tf = requested_tf;
     state.gaps_on = gaps_on;
     state.lookahead_on = lookahead_on;
+    state.heikinashi = heikinashi;
 
     if (!input_tf.empty()) {
         int lower_ratio = 0;
@@ -371,16 +373,49 @@ void BacktestEngine::feed_security_eval_state(SecurityEvalState& state, const Ba
 
     AggregatedBar ab = state.aggregator.feed(input_bar);
     state.feed_count++;
-    state.current_bar = ab.bar;
     state.current_sub_bar_count = ab.sub_bar_count;
+    // Heikin-Ashi same-symbol read: replace the completed (aggregated) bar's
+    // OHLC with its HA candle before evaluating the security expression, so
+    // close/open/high/low inside request.security see HA values (TradingView
+    // ticker.heikinashi semantics):
+    //   haClose = (O+H+L+C)/4
+    //   haOpen  = seeded ? (prevHaOpen+prevHaClose)/2 : (O+C)/2
+    //   haHigh  = max(H, haOpen, haClose);  haLow = min(L, haOpen, haClose)
+    // HA is stateful; the running open/close advance once per COMPLETED bar
+    // (committed below). A partial lookahead peek derives from prior state
+    // without advancing it. The lambda mutates ab.bar in place.
+    auto apply_ha = [&state](Bar& b, bool commit) {
+        double ha_close = (b.open + b.high + b.low + b.close) / 4.0;
+        double ha_open = state.ha_seeded
+                             ? (state.ha_prev_open + state.ha_prev_close) / 2.0
+                             : (b.open + b.close) / 2.0;
+        double ha_high = std::max(b.high, std::max(ha_open, ha_close));
+        double ha_low = std::min(b.low, std::min(ha_open, ha_close));
+        b.open = ha_open;
+        b.high = ha_high;
+        b.low = ha_low;
+        b.close = ha_close;
+        if (commit) {
+            state.ha_prev_open = ha_open;
+            state.ha_prev_close = ha_close;
+            state.ha_seeded = true;
+        }
+    };
     if (ab.is_complete) {
+        if (state.heikinashi) apply_ha(ab.bar, /*commit=*/true);
+        state.current_bar = ab.bar;
         state.eval_complete_count++;
         evaluate_security(state.sec_id, ab.bar, true);
     } else if (state.lookahead_on) {
+        if (state.heikinashi) apply_ha(ab.bar, /*commit=*/false);
+        state.current_bar = ab.bar;
         state.eval_partial_count++;
         evaluate_security(state.sec_id, ab.bar, false);
-    } else if (state.gaps_on) {
-        clear_security(state.sec_id);
+    } else {
+        state.current_bar = ab.bar;
+        if (state.gaps_on) {
+            clear_security(state.sec_id);
+        }
     }
 }
 

--- a/src/engine_security.cpp
+++ b/src/engine_security.cpp
@@ -223,18 +223,34 @@ void BacktestEngine::validate_security_timeframes(const std::string& input_tf) {
                 requested_seconds / input_seconds;
             state.lower_tf_ratio = script_seconds / requested_seconds;
             state.lower_tf_seconds = requested_seconds;
-        } else if (!is_calendar_month && script_seconds > 0
+        } else if (!is_calendar_month && state.lookahead_on
+                   && script_seconds > 0
                    && requested_seconds < script_seconds
                    && script_seconds % requested_seconds == 0) {
             // Plain request.security with a target TF finer than the
-            // script/chart TF (e.g. so2TF="5" on a 15m chart): the
-            // security's own aggregator completes multiple times per
-            // calling bar. A history-offset read (``expr[1]``) must expose
-            // the value confirmed as of the PREVIOUS calling bar, not
-            // whatever native sub-period last completed inside the
-            // CURRENT calling bar. Gate publication (see
-            // feed_security_eval_state) to only the completion whose
-            // bucket end aligns with a script_tf boundary.
+            // script/chart TF (e.g. so2TF="5" on a 15m chart) and
+            // lookahead=barmerge.lookahead_ON: TradingView merges the
+            // FIRST intrabar of each calling bar, so a history-offset
+            // read (``expr[1]``) must expose the value confirmed as of
+            // the PREVIOUS calling bar's boundary, not whatever native
+            // sub-period last completed inside the CURRENT calling bar.
+            // Gate publication (see feed_security_eval_state) to only
+            // the completion whose bucket end aligns with a script_tf
+            // boundary.
+            //
+            // lookahead_OFF is deliberately EXCLUDED: TV's lookahead_off
+            // merge takes the LAST intrabar of the calling bar, so the
+            // exposed value (and any ``[k]`` offset off it) advances at
+            // the security's own finer cadence — one push per completed
+            // security period, exactly the ungated behavior. Gating it
+            // regressed masayanfx-multi-time-score-strategy
+            // (request.security(sym, "5", ta.highest(high, 20)[1],
+            // barmerge.gaps_off, barmerge.lookahead_off) on a 15m chart)
+            // from 100.0% to 93.7% trade parity vs TradingView, while
+            // the gated lookahead_on case (3commas triple-RSI DCA,
+            // so2Rsi = request.security(sym, "5", ta.rsi(close,7)[1],
+            // lookahead=barmerge.lookahead_on)) needs the latch to hold
+            // 100.0%.
             state.publish_gate_tf_seconds = requested_seconds;
         }
     }

--- a/src/engine_security.cpp
+++ b/src/engine_security.cpp
@@ -116,6 +116,7 @@ void BacktestEngine::validate_security_timeframes(const std::string& input_tf) {
         state.lower_tf_use_input = false;
         state.lower_tf_input_aggregation_ratio = 1;
         state.lower_tf_input_buffer.clear();
+        state.publish_gate_tf_seconds = 0;
         if (state.tf.empty()) continue;
 
         int lower_ratio = 0;
@@ -222,6 +223,19 @@ void BacktestEngine::validate_security_timeframes(const std::string& input_tf) {
                 requested_seconds / input_seconds;
             state.lower_tf_ratio = script_seconds / requested_seconds;
             state.lower_tf_seconds = requested_seconds;
+        } else if (!is_calendar_month && script_seconds > 0
+                   && requested_seconds < script_seconds
+                   && script_seconds % requested_seconds == 0) {
+            // Plain request.security with a target TF finer than the
+            // script/chart TF (e.g. so2TF="5" on a 15m chart): the
+            // security's own aggregator completes multiple times per
+            // calling bar. A history-offset read (``expr[1]``) must expose
+            // the value confirmed as of the PREVIOUS calling bar, not
+            // whatever native sub-period last completed inside the
+            // CURRENT calling bar. Gate publication (see
+            // feed_security_eval_state) to only the completion whose
+            // bucket end aligns with a script_tf boundary.
+            state.publish_gate_tf_seconds = requested_seconds;
         }
     }
 }
@@ -405,7 +419,27 @@ void BacktestEngine::feed_security_eval_state(SecurityEvalState& state, const Ba
         if (state.heikinashi) apply_ha(ab.bar, /*commit=*/true);
         state.current_bar = ab.bar;
         state.eval_complete_count++;
-        evaluate_security(state.sec_id, ab.bar, true);
+        // For a plain request.security whose target TF is strictly finer
+        // than script_tf (publish_gate_tf_seconds > 0), the security's own
+        // aggregator completes multiple times per calling/script bar.
+        // Only the completion whose bucket END lands on a script_tf
+        // boundary is "the last completion of THIS calling bar" — that's
+        // the one a history-offset read (``expr[1]``) should latch as
+        // "confirmed as of the previous calling bar" the NEXT time the
+        // calling script reads it. Suppress ``is_complete`` (so codegen's
+        // gated hist.push() does not fire) for every other, intermediate
+        // completion; the underlying TA state keeps advancing regardless
+        // (compute()/recompute() dispatch is driven by
+        // current_sub_bar_count, not by this flag) — only the exposed
+        // history buffer's advance is gated. eval_complete_count/current_bar
+        // bookkeeping above stays driven by the real completion.
+        bool publish = true;
+        if (state.publish_gate_tf_seconds > 0 && script_tf_seconds_ > 0) {
+            int64_t bucket_end_sec =
+                ab.bar.timestamp / 1000 + state.publish_gate_tf_seconds;
+            publish = (bucket_end_sec % script_tf_seconds_) == 0;
+        }
+        evaluate_security(state.sec_id, ab.bar, publish);
     } else if (state.lookahead_on) {
         if (state.heikinashi) apply_ha(ab.bar, /*commit=*/false);
         state.current_bar = ab.bar;

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -229,6 +229,22 @@ void BacktestEngine::strategy_close(const std::string& id, const std::string& co
         return;
     }
 
+    // TradingView one-close-fill-per-bar rule: under process_orders_on_close,
+    // default-FIFO ``strategy.close(id)`` calls (no explicit qty/qty_percent,
+    // FIFO close-entries rule) issued on the SAME bar collapse into a single
+    // surviving market close order that fills at the bar close. Route those
+    // calls through the same-bar batch; the fill executes at the end-of-bar
+    // order-processing point (dispatch_bar step 4 / magnifier last tick) via
+    // flush_same_bar_close(). Everything else (ANY rule, explicit qty,
+    // close_all, immediately=true, non-POC deferred closes) keeps the
+    // existing paths.
+    if (process_orders_on_close_ && !immediately
+        && !close_entries_rule_any_ && !id.empty()
+        && std::isnan(qty) && std::isnan(qty_percent)) {
+        enqueue_same_bar_close(id, comment);
+        return;
+    }
+
     double matching_qty = 0.0;
     double qty_to_close = 0.0;
     bool all_entries_match = false;
@@ -271,6 +287,132 @@ void BacktestEngine::strategy_close(const std::string& id, const std::string& co
 
 void BacktestEngine::strategy_close_all() {
     strategy_close("");
+}
+
+// Sum of same-bar-close reservations held by OTHER ids. A surviving
+// multi-close fill leaves its unconsumed ledger amount reserved against
+// the position; other ids' close targets are capped by what remains.
+double BacktestEngine::close_reserved_other_qty(const std::string& id) const {
+    double sum = 0.0;
+    for (const auto& kv : close_reserved_qty_) {
+        if (kv.first != id) sum += kv.second;
+    }
+    return sum;
+}
+
+// Admit a default-FIFO strategy.close(id) call into the same-bar batch
+// (TV one-fill-per-bar rule — see the close_reserved_qty_ field block in
+// engine.hpp). Order cancels tied to a full-position close keep their
+// CALL-time timing (identical to the previous immediate path); only the
+// FILL is deferred to flush_same_bar_close().
+void BacktestEngine::enqueue_same_bar_close(const std::string& id,
+                                            const std::string& comment) {
+    const double eps = kQtyEpsilon;
+    auto it = id_unclosed_qty_.find(id);
+    double unclosed = (it != id_unclosed_qty_.end()) ? it->second : 0.0;
+    double avail = std::max(0.0, position_qty_ - close_reserved_other_qty(id));
+    double target = std::min(unclosed, avail);
+    if (target <= eps) {
+        return;  // zero-target call: no-op, cannot become the survivor
+    }
+
+    // Same-bar source-order carry (see strategy_entry's tv_carry_qty): a
+    // subsequent strategy.entry on this on_bar sees the post-close size.
+    pending_close_qty_in_bar_ += target;
+
+    bool closes_full_position = target >= position_qty_ - eps;
+    if (closes_full_position) {
+        bool closing_long = (position_side_ == PositionSide::LONG);
+        cancel_orders_for_full_close(id, closing_long);
+        purge_exit_orders();
+    }
+
+    if (!sb_close_active_ || sb_close_bar_ != bar_index_) {
+        sb_close_active_ = true;
+        sb_close_bar_ = bar_index_;
+        sb_close_calls_ = 1;
+        sb_close_first_id_ = id;
+        sb_close_id_ = id;
+        sb_close_comment_ = comment;
+        return;
+    }
+    if (id == sb_close_id_) {
+        // Re-issued close for the id already pending: replaces the same
+        // order in place (comment refresh; not a new call).
+        sb_close_comment_ = comment;
+        return;
+    }
+    sb_close_calls_ += 1;
+    if (sb_close_calls_ == 2) {
+        // The FIRST replaced call's ledger is consumed silently: no fill,
+        // no trade rows, reservation released. Intermediate replaced
+        // calls (3rd+) keep their ledgers intact.
+        id_unclosed_qty_.erase(sb_close_first_id_);
+        close_reserved_qty_.erase(sb_close_first_id_);
+    }
+    sb_close_id_ = id;
+    sb_close_comment_ = comment;
+}
+
+// Execute the surviving same-bar close at the bar's close price. Called
+// from the end-of-bar order-processing points (dispatch_bar step 4 and
+// the magnifier's last tick), i.e. the same bar and price the immediate
+// path used, after the strategy's on_bar has fully run.
+void BacktestEngine::flush_same_bar_close() {
+    if (!sb_close_active_) return;
+    const std::string id = sb_close_id_;
+    const std::string comment = sb_close_comment_;
+    const bool sole_call = (sb_close_calls_ == 1);
+    sb_close_active_ = false;
+    sb_close_bar_ = -1;
+    sb_close_calls_ = 0;
+    sb_close_first_id_.clear();
+    sb_close_id_.clear();
+    sb_close_comment_.clear();
+    if (position_side_ == PositionSide::FLAT) return;
+
+    const double eps = kQtyEpsilon;
+    auto it = id_unclosed_qty_.find(id);
+    double unclosed = (it != id_unclosed_qty_.end()) ? it->second : 0.0;
+    double avail = std::max(0.0, position_qty_ - close_reserved_other_qty(id));
+    double target = std::min(unclosed, avail);
+    if (target <= eps) return;
+
+    if (sole_call) {
+        // Single close call this bar: classic semantics — consume the
+        // ledger and release any prior reservation for this id.
+        it->second -= target;
+        if (it->second <= eps) {
+            id_unclosed_qty_.erase(it);
+        }
+        close_reserved_qty_.erase(id);
+    }
+
+    bool closes_full_position = target >= position_qty_ - eps;
+    size_t trades_before = trades_.size();
+    if (closes_full_position) {
+        // Exit-order cancel/purge already ran at CALL time in
+        // enqueue_same_bar_close — orders armed after the close call
+        // must survive exactly as they did under the immediate path.
+        execute_market_exit(current_bar_.close);
+    } else {
+        execute_partial_exit_qty(current_bar_.close, target);
+        if (position_side_ == PositionSide::FLAT) {
+            // Retain from_entry brackets whose parent entry is still a
+            // pending order (it fills right after this flush).
+            purge_exit_orders(/*retain_for_pending_entries=*/true);
+        }
+    }
+    for (size_t ti = trades_before; ti < trades_.size(); ++ti) {
+        trades_[ti].exit_comment = comment;
+        trades_[ti].exit_id = "__close__" + id;
+    }
+    if (!sole_call && position_side_ != PositionSide::FLAT) {
+        // Surviving multi-call close: ledger NOT consumed (TV leaves the
+        // id closable again later); the filled amount stays reserved
+        // against the position for other ids' close targets.
+        close_reserved_qty_[id] = target;
+    }
 }
 
 void BacktestEngine::strategy_exit(const std::string& id, const std::string& from_entry,

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -538,8 +538,43 @@ void BacktestEngine::strategy_exit(const std::string& id, const std::string& fro
         }
         is_partial = reserved_qty < live_pos_qty - kFullQtyEps;
     } else {
-        if (!compute_exit_reserved_qty(from_entry, preserved_reserved_qty,
-                                       live_pos_qty, qp, is_partial, reserved_qty)) {
+        // Default-sized (percent) bracket armed while its from_entry ENTRY is
+        // still a PENDING order in the OPPOSITE direction of the live
+        // position (the reversal-bar shape: strategy.entry(X) +
+        // strategy.exit(from_entry=X) issued together while the old opposite
+        // position is still open). TV binds the bracket to X's eventual
+        // fill — the bracket closes 100% of the lot the entry actually
+        // opens. Freezing reserved_qty at the CURRENT position size (the
+        // old, about-to-be-replaced side) under-sizes the bracket whenever
+        // the fresh percent-of-equity lot exceeds the old position, leaving
+        // a dust remainder (q_plain - |old|) open when the bracket fires —
+        // the seed of jevondijefferson's multi-day tiny-qty desync chains
+        // (2025-05-23 12:00, 2025-10-04 15:30, 2026-02-13 15:15,
+        // 2026-02-22 13:45 UTC: e.g. 10-04 bracket froze at 4.3847 against
+        // the new 4.5089 short, stranding 0.1242). Defer the reservation
+        // (qty = NaN): the fill-side path then executes a FULL exit against
+        // the live position, exactly like a bracket placed while flat.
+        // Mirrors the explicit-qty path's pending-entry capacity rule above
+        // (thulashimohanr fix); entries with an explicit qty keep the
+        // legacy reservation math.
+        bool bind_to_pending_reversal_entry = false;
+        if (!from_entry.empty() && !effectively_flat
+            && qp >= 100.0 - kFullPercentEps) {
+            for (const auto& o : pending_orders_) {
+                if (o.id != from_entry) continue;
+                if (o.type != OrderType::MARKET && o.type != OrderType::ENTRY
+                    && o.type != OrderType::RAW_ORDER) continue;
+                PositionSide entry_dir = o.is_long ? PositionSide::LONG
+                                                   : PositionSide::SHORT;
+                if (entry_dir != position_side_ && std::isnan(o.qty)) {
+                    bind_to_pending_reversal_entry = true;
+                }
+                break;  // entry ids are unique in pending_orders_
+            }
+        }
+        if (!bind_to_pending_reversal_entry
+            && !compute_exit_reserved_qty(from_entry, preserved_reserved_qty,
+                                          live_pos_qty, qp, is_partial, reserved_qty)) {
             return;
         }
     }

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -921,6 +921,18 @@ bool BacktestEngine::compute_exit_reserved_qty(const std::string& from_entry,
         reserved_qty_out = std::min(preserved_reserved_qty, live_pos_qty);
     } else {
         double requested_qty = live_pos_qty * (qp_io / 100.0);
+        // TV floors each percent-derived PARTIAL exit lot to the
+        // instrument lot step at placement (apply_exit_qty_step doc has
+        // the row-level evidence); the sub-step remainder stays open as
+        // a dust position instead of being closed by the final bracket
+        // leg. A dust-sized request that floors to zero is simply not
+        // placed (the kQtyEpsilon check below aborts), which is also
+        // TV's behaviour: dust positions carry no TP bracket and only
+        // ever close via reversal/close_all/margin call. Full-position
+        // exits (qp == 100%) are left exact so they always flatten.
+        if (qp_io < 100.0 - kFullPercentEps) {
+            requested_qty = apply_exit_qty_step(requested_qty);
+        }
         reserved_qty_out = std::min(requested_qty, available_qty);
     }
     if (reserved_qty_out <= kQtyEpsilon) {

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -289,6 +289,17 @@ void BacktestEngine::strategy_close_all() {
     strategy_close("");
 }
 
+// Qty the pending same-bar close batch will fill at flush time (0 when no
+// batch is pending). Lets same-bar order sizing (strategy.exit) see the
+// post-close position before the flush actually executes.
+double BacktestEngine::pending_same_bar_close_target() const {
+    if (!sb_close_active_) return 0.0;
+    auto it = id_unclosed_qty_.find(sb_close_id_);
+    double unclosed = (it != id_unclosed_qty_.end()) ? it->second : 0.0;
+    double avail = std::max(0.0, position_qty_ - close_reserved_other_qty(sb_close_id_));
+    return std::min(unclosed, avail);
+}
+
 // Sum of same-bar-close reservations held by OTHER ids. A surviving
 // multi-close fill leaves its unconsumed ledger amount reserved against
 // the position; other ids' close targets are capped by what remains.
@@ -424,20 +435,35 @@ void BacktestEngine::strategy_exit(const std::string& id, const std::string& fro
     if (!trading_is_active(current_bar_.timestamp, trade_start_time_, script_tf_seconds_)) return;
     bool has_explicit_qty = !std::isnan(qty);
     double qp = std::isnan(qty_percent) ? 100.0 : std::clamp(qty_percent, 0.0, 100.0);
+    // A default-FIFO strategy.close batched earlier on this SAME bar has not
+    // filled yet (it fills at the end-of-bar flush) but its qty is already
+    // committed. An exit armed after that close call must size against the
+    // post-close position — exactly what it saw when the immediate path
+    // executed the close mid-bar. Without this, a close + reversal-entry +
+    // exit sequence freezes the OLD side's size into the bracket's reserved
+    // qty (wayward-bison: the Long SL stop filled only the stale short-sized
+    // 3.9629 of an 8.0672 long, fragmenting one TV exit into two rows).
+    double sb_pending_close = (sb_close_active_ && sb_close_bar_ == bar_index_)
+                                  ? pending_same_bar_close_target()
+                                  : 0.0;
+    double live_pos_qty = (position_side_ == PositionSide::FLAT)
+                              ? 0.0
+                              : std::max(0.0, position_qty_ - sb_pending_close);
+    bool effectively_flat = live_pos_qty <= kQtyEpsilon;
     // If an explicit qty is given, derive an effective qp from the current
     // position size so downstream FIFO accounting (compute_exit_reserved_qty,
     // already-reserved tally, etc.) sees a consistent fraction. The order
     // itself stores the absolute qty so the per-fill execution path
     // honours the literal request.
-    if (has_explicit_qty && position_qty_ > kQtyEpsilon) {
-        double clamped_qty = std::min(qty, position_qty_);
-        qp = (clamped_qty / position_qty_) * 100.0;
+    if (has_explicit_qty && live_pos_qty > kQtyEpsilon) {
+        double clamped_qty = std::min(qty, live_pos_qty);
+        qp = (clamped_qty / live_pos_qty) * 100.0;
     }
     bool is_partial = qp < 100.0 - kFullPercentEps;
     bool has_trail_request = !std::isnan(trail_points) || !std::isnan(trail_price);
 
     // Re-issued explicitly partial exits with the same id are one-shot for a live position.
-    if (is_partial && position_side_ != PositionSide::FLAT
+    if (is_partial && !effectively_flat
         && consumed_partial_exit_ids_.find(id) != consumed_partial_exit_ids_.end()) {
         return;
     }
@@ -455,7 +481,7 @@ void BacktestEngine::strategy_exit(const std::string& id, const std::string& fro
         // strictly smaller than the open position size — required for
         // multi-bracket per-position exits (validation_oca/oca-three-way-
         // probe-02 has two qty=1 brackets attached to a qty=2 entry).
-        if (position_side_ == PositionSide::FLAT) {
+        if (effectively_flat) {
             // Defer placement; FIFO accounting will recompute when a
             // position eventually exists.
             reserved_qty = std::min(qty, std::numeric_limits<double>::infinity());
@@ -468,17 +494,17 @@ void BacktestEngine::strategy_exit(const std::string& id, const std::string& fro
                 } else {
                     double oqp = std::isnan(o.qty_percent) ? 100.0
                         : std::clamp(o.qty_percent, 0.0, 100.0);
-                    already_reserved += position_qty_ * (oqp / 100.0);
+                    already_reserved += live_pos_qty * (oqp / 100.0);
                 }
             }
-            double available = std::max(0.0, position_qty_ - already_reserved);
+            double available = std::max(0.0, live_pos_qty - already_reserved);
             reserved_qty = std::min(qty, available);
             if (reserved_qty <= kQtyEpsilon) return;
         }
-        is_partial = reserved_qty < position_qty_ - kFullQtyEps;
+        is_partial = reserved_qty < live_pos_qty - kFullQtyEps;
     } else {
         if (!compute_exit_reserved_qty(from_entry, preserved_reserved_qty,
-                                       qp, is_partial, reserved_qty)) {
+                                       live_pos_qty, qp, is_partial, reserved_qty)) {
             return;
         }
     }
@@ -508,10 +534,13 @@ void BacktestEngine::strategy_exit(const std::string& id, const std::string& fro
     order.oca_type = oca_name.empty() ? 0 : 1;  // strategy.exit semantics: cancel
     order.created_bar = bar_index_;
     order.created_seq = preserved_seq > 0 ? preserved_seq : next_order_seq_++;
-    order.created_position_side = position_side_;
-    order.tv_carry_qty = position_qty_;
+    // Position-derived captures use the post-batched-close view (see
+    // live_pos_qty above) so an exit armed after a same-bar strategy.close
+    // records the same state it did when the close executed mid-bar.
+    order.created_position_side = effectively_flat ? PositionSide::FLAT : position_side_;
+    order.tv_carry_qty = live_pos_qty;
     order.comment = comment;
-    order.created_while_in_position = (position_side_ != PositionSide::FLAT);
+    order.created_while_in_position = !effectively_flat;
 
     pending_orders_.push_back(std::move(order));
 }
@@ -819,11 +848,16 @@ void BacktestEngine::clear_existing_exit_order(const std::string& id,
 // full exit is queued.
 bool BacktestEngine::compute_exit_reserved_qty(const std::string& from_entry,
                                                double preserved_reserved_qty,
+                                               double live_pos_qty,
                                                double& qp_io,
                                                bool& is_partial_io,
                                                double& reserved_qty_out) {
+    // live_pos_qty: the position size this exit may size against — the raw
+    // position_qty_ minus any same-bar batched strategy.close target that is
+    // committed but not yet flushed (see strategy_exit). <= eps behaves like
+    // FLAT: defer, recompute when a position exists.
     reserved_qty_out = std::numeric_limits<double>::quiet_NaN();
-    if (position_side_ == PositionSide::FLAT) {
+    if (position_side_ == PositionSide::FLAT || live_pos_qty <= kQtyEpsilon) {
         return true;
     }
 
@@ -834,11 +868,11 @@ bool BacktestEngine::compute_exit_reserved_qty(const std::string& from_entry,
             already_reserved += o.qty;
         } else {
             double oqp = std::isnan(o.qty_percent) ? 100.0 : std::clamp(o.qty_percent, 0.0, 100.0);
-            already_reserved += position_qty_ * (oqp / 100.0);
+            already_reserved += live_pos_qty * (oqp / 100.0);
         }
     }
 
-    double available_qty = std::max(0.0, position_qty_ - already_reserved);
+    double available_qty = std::max(0.0, live_pos_qty - already_reserved);
     // Only carry the preserved (frozen) reserved qty for genuine PARTIAL
     // re-issues (qp < 100%). A full-position exit (qp == 100%) re-issued
     // every bar while the position keeps GROWING via pyramiding/DCA must
@@ -849,16 +883,16 @@ bool BacktestEngine::compute_exit_reserved_qty(const std::string& from_entry,
     // fragmenting across two bars). For partial re-issues the carry is kept
     // to avoid double-reserving against the same from_entry.
     if (!std::isnan(preserved_reserved_qty) && qp_io < 100.0 - kFullPercentEps) {
-        reserved_qty_out = std::min(preserved_reserved_qty, position_qty_);
+        reserved_qty_out = std::min(preserved_reserved_qty, live_pos_qty);
     } else {
-        double requested_qty = position_qty_ * (qp_io / 100.0);
+        double requested_qty = live_pos_qty * (qp_io / 100.0);
         reserved_qty_out = std::min(requested_qty, available_qty);
     }
     if (reserved_qty_out <= kQtyEpsilon) {
         return false;
     }
-    qp_io = (position_qty_ > kQtyEpsilon) ? (reserved_qty_out / position_qty_) * 100.0 : qp_io;
-    is_partial_io = reserved_qty_out < position_qty_ - kFullQtyEps;
+    qp_io = (live_pos_qty > kQtyEpsilon) ? (reserved_qty_out / live_pos_qty) * 100.0 : qp_io;
+    is_partial_io = reserved_qty_out < live_pos_qty - kFullQtyEps;
 
     // If there is already a full exit pending for this from_entry, ignore
     // additional partial exits until that full exit is consumed/cancelled.

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -329,7 +329,41 @@ void BacktestEngine::strategy_exit(const std::string& id, const std::string& fro
                     already_reserved += position_qty_ * (oqp / 100.0);
                 }
             }
-            double available = std::max(0.0, position_qty_ - already_reserved);
+            // Reservation capacity: by default the live position (legacy
+            // behaviour). But when a PENDING entry order with
+            // id == from_entry exists, TV binds the bracket to THAT entry's
+            // eventual fills, not to the unrelated live position: a reversal
+            // bar places qty=1 brackets for the about-to-fill opposite qty=2
+            // entry while the old position (1 lot the other way) is still
+            // open. Clamping to the live position dropped every bracket
+            // after the first (thulashimohanr-prev-day-week-levels probe:
+            // RevShortT2's stop order never existed, so the engine sailed
+            // through TV's overnight stop-out and desynced for days).
+            // Capacity then = open fills already tagged from_entry (same-id
+            // pyramiding remainder) + the pending entry's qty (unbounded
+            // when the entry's qty only resolves at fill time).
+            double capacity = position_qty_;
+            bool entry_pending = false;
+            double pending_entry_qty = 0.0;
+            for (const auto& o : pending_orders_) {
+                if (o.id != from_entry) continue;
+                if (o.type != OrderType::MARKET && o.type != OrderType::ENTRY
+                    && o.type != OrderType::RAW_ORDER) continue;
+                entry_pending = true;
+                if (std::isnan(o.qty)) {
+                    pending_entry_qty = std::numeric_limits<double>::infinity();
+                } else {
+                    pending_entry_qty += o.qty;
+                }
+            }
+            if (entry_pending) {
+                double open_from_entry = 0.0;
+                for (const auto& pe : pyramid_entries_) {
+                    if (pe.entry_id == from_entry) open_from_entry += pe.qty;
+                }
+                capacity = open_from_entry + pending_entry_qty;
+            }
+            double available = std::max(0.0, capacity - already_reserved);
             reserved_qty = std::min(qty, available);
             if (reserved_qty <= kQtyEpsilon) return;
         }

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -524,57 +524,35 @@ bool BacktestEngine::compute_close_target_qty(const std::string& id,
 
 // Wipe pending orders that should not survive a full strategy.close:
 //
-//   (1) Pending strategy.exit orders bound to the same entry id are
-//       wiped (community/IES regression: a partial TP1 limit and the
-//       queued market close were both firing on the next bar's open,
-//       producing two trade rows for the same logical close).
+//   Pending strategy.exit orders bound to the same entry id are wiped
+//   (community/IES regression: a partial TP1 limit and the queued
+//   market close were both firing on the next bar's open, producing
+//   two trade rows for the same logical close).
 //
-//   (2) Pending strategy.entry / market orders that were ADDED TO
-//       THE NOW-CLOSING POSITION are wiped (probe in
-//       tests/test_integration.cpp: a stale long-add stop placed
-//       while already long must not re-open the position after the
-//       long is closed).
-//
-// Crucially, pending entries placed FOR THE OPPOSITE DIRECTION
-// (flip preparation — e.g., a short-stop entry placed while still
-// long, intended to fire after the long closes) must NOT be
-// cancelled here. The previous predicate `o.is_long == closing_long`
-// wiped same-direction entries regardless of the position they were
-// placed in, which broke validation/93-flip-stop-pyramiding-2: the
-// 0:45 short-stop placed while in the morning long was cancelled
-// by 12:15 close_all on the still-pending leg even though the
-// engine had since flipped to a short position via the OTHER stop,
-// dropping a short the strategy intended to keep alive overnight.
-void BacktestEngine::cancel_orders_for_full_close(const std::string& id, bool closing_long) {
+// Pending strategy.entry / market orders are LEFT ALONE. Per
+// TradingView's documented broker semantics, only cancel()/cancel_all()
+// cancel pending orders; close()/close_all() only closes the open
+// position — a pending same-direction entry (e.g. a stale add-on stop
+// placed while the position was open) survives and can still fire on a
+// later bar, "ghost-refilling" into a new position. This mirrors DCA/
+// grid-bot bots (3commas-style: N independent price-level orders,
+// closing one level must not silently cancel another level's still-
+// pending order) — verified against 3commas-3commas-pullback-sniper-
+// strategy, where the previous same-direction wipe was itself the bug
+// (closed-form count-delta 2.88% -> <0.5%).
+void BacktestEngine::cancel_orders_for_full_close(const std::string& id, bool /*closing_long*/) {
     pending_orders_.erase(
         std::remove_if(
             pending_orders_.begin(),
             pending_orders_.end(),
             [&](const PendingOrder& o) {
-                if (o.type == OrderType::EXIT) {
-                    if (id.empty()) {
-                        return o.from_entry.empty();
-                    }
-                    return o.from_entry == id;
-                }
-                if (o.type != OrderType::ENTRY && o.type != OrderType::MARKET) {
+                if (o.type != OrderType::EXIT) {
                     return false;
                 }
-                if (o.created_bar >= bar_index_) {
-                    // Same-on_bar reversal entry: keep it (handles
-                    // strategy.close + strategy.entry(opposite) in the
-                    // same Pine block).
-                    return false;
+                if (id.empty()) {
+                    return o.from_entry.empty();
                 }
-                // Only wipe entries that were a same-direction ADD to
-                // the position being closed.
-                bool added_to_long = closing_long
-                    && o.created_position_side == PositionSide::LONG
-                    && o.is_long;
-                bool added_to_short = !closing_long
-                    && o.created_position_side == PositionSide::SHORT
-                    && !o.is_long;
-                return added_to_long || added_to_short;
+                return o.from_entry == id;
             }),
         pending_orders_.end());
 }

--- a/src/engine_trade_accessors.cpp
+++ b/src/engine_trade_accessors.cpp
@@ -23,10 +23,11 @@ double BacktestEngine::open_trade_profit(int idx) const {
     const PyramidEntry& pe = pyramid_entries_[(size_t)idx];
     bool is_long = (position_side_ == PositionSide::LONG);
     double px = current_bar_.close;
-    // Currency PnL: price-points × qty × pointvalue, consistent with the
-    // realized-trade path in emit_close_trade (pointvalue=1 is unchanged).
+    // Currency PnL: price-points × qty × pointvalue × account_currency_fx_,
+    // consistent with the realized-trade path in emit_close_trade
+    // (pointvalue=1, fx=1.0 leaves the corpus unchanged).
     double pnl = (is_long ? (px - pe.price) * pe.qty : (pe.price - px) * pe.qty)
-                 * syminfo_.pointvalue;
+                 * syminfo_.pointvalue * account_currency_fx_;
     pnl -= calc_commission(pe.price, pe.qty);
     return pnl;
 }
@@ -39,10 +40,11 @@ double BacktestEngine::open_trade_profit_percent(int idx) const {
     // TV net return-on-cost convention (same shape as the closed-trade
     // pnl_pct fixed 2026-06-12 in emit_close_trade): the profit value this
     // accessor pairs with — open_trade_profit, which is net of the
-    // entry-leg commission — as a percent of entry cost
-    // (entry_price * qty * pointvalue). No new commission handling is
-    // invented here; the percent just mirrors open_trade_profit.
-    const double entry_cost = pe.price * pe.qty * syminfo_.pointvalue;
+    // entry-leg commission — as a percent of entry cost (entry_price * qty
+    // * pointvalue * account_currency_fx_, matching open_trade_profit's
+    // fx-scaled pnl so the ratio is currency-invariant). No new commission
+    // handling is invented here; the percent just mirrors open_trade_profit.
+    const double entry_cost = pe.price * pe.qty * syminfo_.pointvalue * account_currency_fx_;
     if (!(entry_cost > 0.0)) return na<double>();
     return open_trade_profit(idx) / entry_cost * 100.0;
 }
@@ -92,13 +94,14 @@ double BacktestEngine::open_trade_size(int idx) const {
 
 // pe.max_drawdown / pe.max_runup are tracked in price-points × qty
 // (update_per_trade_extremes); the currency accessors scale by pointvalue
-// so they match the closed-trade fields emitted by emit_close_trade. The
-// percent accessors below intentionally use the UNSCALED excursion over the
-// unscaled entry cost — pointvalue cancels in the ratio.
+// and account_currency_fx_ (default 1.0, no-op) so they match the
+// closed-trade fields emitted by emit_close_trade. The percent accessors
+// below intentionally use the UNSCALED excursion over the unscaled entry
+// cost — pointvalue and fx both cancel in the ratio.
 double BacktestEngine::open_trade_max_drawdown(int idx) const {
     if (position_side_ == PositionSide::FLAT || idx < 0 || idx >= (int)pyramid_entries_.size())
         return 0.0;
-    return pyramid_entries_[(size_t)idx].max_drawdown * syminfo_.pointvalue;
+    return pyramid_entries_[(size_t)idx].max_drawdown * syminfo_.pointvalue * account_currency_fx_;
 }
 
 double BacktestEngine::open_trade_max_drawdown_percent(int idx) const {
@@ -112,7 +115,7 @@ double BacktestEngine::open_trade_max_drawdown_percent(int idx) const {
 double BacktestEngine::open_trade_max_runup(int idx) const {
     if (position_side_ == PositionSide::FLAT || idx < 0 || idx >= (int)pyramid_entries_.size())
         return 0.0;
-    return pyramid_entries_[(size_t)idx].max_runup * syminfo_.pointvalue;
+    return pyramid_entries_[(size_t)idx].max_runup * syminfo_.pointvalue * account_currency_fx_;
 }
 
 double BacktestEngine::open_trade_max_runup_percent(int idx) const {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ set(TEST_SOURCES
     test_limit_fill_slippage
     test_strategy_commands_extra
     test_multi_tier_exit_precedence
+    test_same_tick_multi_entry_race
     test_full_close_while_pyramiding
     test_lower_tf_parse_extra
     test_ta_ma_warmup_extra

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -704,6 +704,14 @@ static void test_blocked_entry_does_not_consume_intraday_fill_quota() {
 
 // Dual pending stop entries placed while flat: same bar, path touches both stops.
 // Second touch must flatten (bracket-style), not reverse into a new position.
+// This is the exact-zero-remainder case (both legs FIXED qty=1): confirmed by
+// real corpus probe 80 (order-dual-stop-both-touch-priority-01, Trade 1 —
+// entry long + exit long at the identical timestamp). When the opposite leg's
+// qty is NOT equal (equity/price-based sizing, e.g. equity/priceA vs
+// equity/priceB), TV instead defers the whole order to a later bar rather
+// than flattening-with-remainder — see
+// waranyutrkm-inside-day-breakout-strategy and classify_order_eligibility's
+// flat_armed_opposite_close remainder check.
 static void test_flat_bracket_dual_stop_closes_on_opposite_touch() {
     std::printf("test_flat_bracket_dual_stop_closes_on_opposite_touch\n");
 

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -2567,12 +2567,92 @@ static void test_position_reversal_state() {
     CHECK(near(strat.pos_avg[3], 110.0));
     CHECK(near(strat.net_pnl[3], 10.0));
 
-    // Bar 4: short closed at 105 (pnl=+5). strategy.close executes immediately
-    // on close, so the flat state and realized +15 are visible this bar.
-    CHECK(near(strat.pos_size[4], 0.0));
-    CHECK(near(strat.net_pnl[4], 15.0));  // 10 + 5
+    // Bar 4: short closed at 105 (pnl=+5). Like the market ENTRY on bar 0
+    // (comment above), a process_orders_on_close strategy.close fills at
+    // THIS bar's close but only AFTER the script's calc — TV's broker
+    // state updates between bars, so the script still sees the live short
+    // during bar 4; the flat state and realized +15 become visible on
+    // bar 5. (Close fills moved to the end-of-bar order-processing point
+    // by the same-bar multi-close single-fill batch — validated against
+    // the 3commas grid-bot TV exports, xau 10.8%->81.2% / xlm
+    // 22.4%->99.0% matched with pol/xrp held at 100%.)
+    CHECK(near(strat.pos_size[4], -1.0));
+    CHECK(near(strat.pos_avg[4], 110.0));
+    CHECK(near(strat.net_pnl[4], 10.0));
+
+    // Bar 5: flat + realized 15 now visible.
+    CHECK(near(strat.pos_size[5], 0.0));
+    CHECK(near(strat.net_pnl[5], 15.0));  // 10 + 5
 
     CHECK(strat.trade_count() == 2);
+}
+
+// ---- 38a2. TV one-close-fill-per-bar: multiple default-FIFO strategy.close
+// calls on the SAME bar (the grid-bot pattern) collapse into a single
+// surviving fill — the LAST nonzero-target call wins, its id-ledger is NOT
+// consumed by the fill (the remainder stays closable by a later close of the
+// same id), and the FIRST replaced call's ledger is consumed silently with
+// no fill. Empirically derived from the 3commas grid-bot TradingView exports
+// (xau/xlm/pol/xrp) — see fix/same-bar-multi-close-single-fill.
+
+class SameBarMultiCloseStrategy : public BacktestEngine {
+public:
+    double final_pos = -1.0;  // signed position size seen on the last bar
+    SameBarMultiCloseStrategy() {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+    void on_bar(const Bar&) override {
+        double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) strategy_entry("A", true, na, na, 1.0);
+        if (bar_index_ == 1) strategy_entry("B", true, na, na, 2.0);
+        if (bar_index_ == 2) {
+            strategy_close("A", "tpA");   // replaced: ledger consumed, no fill
+            strategy_close("B", "tpB");   // survivor: fills qty 2 (FIFO drain)
+        }
+        if (bar_index_ == 3) strategy_entry("B", true, na, na, 2.0);
+        if (bar_index_ == 4) strategy_close("B", "tpB2");  // old 2 + new 2, pos-clamped
+        if (bar_index_ == 5) final_pos = signed_position_size();
+    }
+};
+
+static void test_same_bar_multi_close_single_fill() {
+    std::printf("test_same_bar_multi_close_single_fill\n");
+    SameBarMultiCloseStrategy strat;
+    Bar bars[] = {
+        {100, 101, 99, 100, 50, 60000},   // bar 0: A qty1 fills @100
+        {100, 101, 99, 100, 50, 120000},  // bar 1: B qty2 fills @100 (pos 3)
+        {100, 106, 99, 105, 50, 180000},  // bar 2: both closes -> ONE fill qty2 @105
+        {105, 106, 99, 100, 50, 240000},  // bar 3: B qty2 refills @100 (pos 3)
+        {100, 111, 99, 110, 50, 300000},  // bar 4: close(B) fills min(ledger 4, pos 3) @110
+        {110, 111, 99, 110, 50, 360000},
+    };
+    strat.run(bars, 6);
+
+    // Bar 2 fills only the surviving close's qty (2): FIFO drains lot A (1)
+    // fully + half of lot B -> two trade rows @105. The old immediate path
+    // filled BOTH closes (qty 3, flat) — the one-fill rule leaves 1 open.
+    // Bar 4's close(B) then targets B's UNCONSUMED ledger (2 stale + 2 new),
+    // clamped to the live position (3): two rows @110, flat afterwards.
+    CHECK(strat.trade_count() == 4);
+    if (strat.trade_count() == 4) {
+        CHECK(near(strat.get_trade(0).qty, 1.0));       // lot A drained @105
+        CHECK(near(strat.get_trade(0).exit_price, 105.0));
+        CHECK(strat.get_trade(0).exit_comment == "tpB");  // survivor's comment
+        CHECK(near(strat.get_trade(1).qty, 1.0));       // half of lot B @105
+        CHECK(near(strat.get_trade(1).exit_price, 105.0));
+        CHECK(near(strat.get_trade(2).qty, 1.0));       // lot B remainder @110
+        CHECK(near(strat.get_trade(2).exit_price, 110.0));
+        CHECK(strat.get_trade(2).exit_comment == "tpB2");
+        CHECK(near(strat.get_trade(3).qty, 2.0));       // bar-3 refill @110
+        CHECK(near(strat.get_trade(3).exit_price, 110.0));
+    }
+    CHECK(near(strat.final_pos, 0.0));
 }
 
 // ---- 38b. process_orders_on_close: an exit gated on position visibility must
@@ -4173,6 +4253,7 @@ int main() {
     test_pyramid_avg_price();
     test_win_loss_tracking();
     test_position_reversal_state();
+    test_same_bar_multi_close_single_fill();
     test_pooc_exit_not_triggered_on_entry_bar();
     test_commission_deducted();
     test_slippage_applied();

--- a/tests/test_margin_call.cpp
+++ b/tests/test_margin_call.cpp
@@ -252,6 +252,43 @@ static void test_long_100pct_margin_no_call() {
     CHECK(std::isnan(eng.liq_price()));
 }
 
+// ---- B': OVER-ALLOCATED long at 100% margin IS force-liquidated -------------
+
+class LongOverAllocProbe : public MCEngine {
+public:
+    LongOverAllocProbe() {
+        initial_capital_ = 1000.0;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 10.0;
+        commission_value_ = 0.0;
+        margin_long_ = 100.0;             // 1x -> denominator (1 - 1) = 0 -> na
+        process_orders_on_close_ = false;  // market entry fills at NEXT bar open
+    }
+    void on_bar(const Bar& /*bar*/) override {
+        if (bar_index_ == 0) strategy_entry("L", true, kNaN, kNaN, 10.0);
+    }
+};
+
+static void test_long_100pct_margin_overalloc_call() {
+    std::printf("test_long_100pct_margin_overalloc_call\n");
+    std::vector<Bar> bars = {
+        mk_bar(1000, 100.0, 100.0,  99.0, 100.0, 1.0),  // 0: signal @ close 100
+        mk_bar(2000, 110.0, 112.0, 108.0, 109.0, 1.0),  // 1: fills @ open 110
+        mk_bar(3000, 109.0, 111.0, 107.0, 110.0, 1.0),  // 2: filler
+    };
+    LongOverAllocProbe eng;
+    eng.run(bars.data(), (int)bars.size());
+    // Signal-time affordability admits the fixed qty=10 against bar0's close
+    // (10*100 == equity 1000), but the non-POOC market entry actually fills
+    // at bar1's OPEN (110) -- notional 1100 > equity 1000, an over-allocated
+    // 1x long. TradingView force-liquidates this on the SAME bar it fired.
+    CHECK(eng.trade_count() >= 1);
+    CHECK(eng.exit_comment(0) == std::string("Margin call"));
+    CHECK(near(eng.entry_price(0), 110.0));       // notional 1100 > equity 1000
+    CHECK(near(eng.exit_price(0), 108.0));        // long adverse extreme = bar low
+    CHECK(std::isnan(eng.liq_price()));           // still na for 1x long (matches TV)
+}
+
 // ---- C: leveraged long (5x) is liquidated by a falling market --------------
 
 class LongLevLiqProbe : public MCEngine {
@@ -296,6 +333,7 @@ int main() {
     test_margin_liquidation_price_formula();
     test_short_margin_call_disabled();
     test_long_100pct_margin_no_call();
+    test_long_100pct_margin_overalloc_call();
     test_long_leveraged_margin_call();
 
     std::printf("\n%d passed, %d failed\n", tests_passed, tests_failed);

--- a/tests/test_request_security.cpp
+++ b/tests/test_request_security.cpp
@@ -555,8 +555,80 @@ void test_request_security_helper_ta_uses_security_local_state() {
     std::cout << "test_request_security_helper_ta_uses_security_local_state passed.\n";
 }
 
+// Plain request.security with a target TF strictly finer than script_tf
+// (e.g. "5" on a 15m chart, fed from 1m input bars) completes its own
+// aggregation R = script/requested times per calling bar. The publish gate
+// (SecurityEvalState::publish_gate_tf_seconds) must latch the is_complete
+// flag to calling-bar boundaries ONLY under lookahead_on (TV merges the
+// FIRST intrabar of each calling bar there); under lookahead_off TV merges
+// the LAST intrabar, so every finer-period completion must publish
+// unchanged. Regression coverage for both sides:
+//   - gated lookahead_off broke masayanfx-multi-time-score-strategy
+//     (ta.highest(high,20)[1], lookahead_off, "5" on 15m): 100.0% -> 93.7%
+//   - ungated lookahead_on broke 3commas triple-RSI DCA
+//     (ta.rsi(close,7)[1], lookahead_on, "5" on 15m): 100.0% -> 50.5%
+class FinerTfPublishGateHarness : public BacktestEngine {
+public:
+    std::vector<int64_t> published_ts;  // bucket-start ts of is_complete evals
+
+    explicit FinerTfPublishGateHarness(bool lookahead_on) {
+        register_security_eval(0, "5", "1", lookahead_on, false);
+    }
+
+    void evaluate_security(int sec_id, const Bar& bar, bool is_complete) override {
+        if (sec_id != 0 || !is_complete) {
+            return;
+        }
+        published_ts.push_back(bar.timestamp);
+    }
+
+    void on_bar(const Bar& bar) override {
+        (void)bar;
+    }
+};
+
+void test_request_security_finer_tf_publish_gate_is_lookahead_only() {
+    // 30 one-minute bars = two 15m calling bars = six 5m security buckets
+    // starting at 0, 300k, 600k, 900k, 1.2M, 1.5M ms. Bucket ends aligned
+    // to the 15m (900s) script boundary: 600k (ends 900s) and 1.5M
+    // (ends 1800s).
+    std::vector<Bar> input_bars;
+    for (int i = 0; i < 30; ++i) {
+        double px = 100.0 + i;
+        input_bars.push_back(
+            {px, px + 1.0, px - 1.0, px + 0.5, 10.0,
+             static_cast<int64_t>(i) * 60000});
+    }
+
+    FinerTfPublishGateHarness off(false);
+    off.run(input_bars.data(), static_cast<int>(input_bars.size()),
+            "1", "15", false, 4, MagnifierDistribution::ENDPOINTS);
+    require(off.last_error().empty(),
+            "lookahead_off finer-TF security run should succeed: " + off.last_error());
+    std::vector<int64_t> expected_off = {0, 300000, 600000, 900000, 1200000, 1500000};
+    require(off.published_ts == expected_off,
+            "lookahead_off finer-TF security must publish EVERY completed security "
+            "period (TV merges the LAST intrabar of the calling bar): expected one "
+            "publish per 5m bucket, got " + std::to_string(off.published_ts.size()));
+
+    FinerTfPublishGateHarness on(true);
+    on.run(input_bars.data(), static_cast<int>(input_bars.size()),
+           "1", "15", false, 4, MagnifierDistribution::ENDPOINTS);
+    require(on.last_error().empty(),
+            "lookahead_on finer-TF security run should succeed: " + on.last_error());
+    std::vector<int64_t> expected_on = {600000, 1500000};
+    require(on.published_ts == expected_on,
+            "lookahead_on finer-TF security must latch publishes to calling-bar "
+            "boundaries (TV merges the FIRST intrabar of the calling bar): expected "
+            "only script-TF-aligned bucket completions, got "
+            + std::to_string(on.published_ts.size()));
+
+    std::cout << "test_request_security_finer_tf_publish_gate_is_lookahead_only passed.\n";
+}
+
 int main() {
     test_request_security_hook_dispatches_completed_values();
+    test_request_security_finer_tf_publish_gate_is_lookahead_only();
     test_request_security_lower_tf_requires_finer_input_bars();
     test_request_security_emulates_ratio_divisible_lower_tf();
     test_request_security_lower_tf_emulation_rejects_unsupported_flags();

--- a/tests/test_same_tick_multi_entry_race.cpp
+++ b/tests/test_same_tick_multi_entry_race.cpp
@@ -1,0 +1,423 @@
+/*
+ * test_same_tick_multi_entry_race.cpp — TradingView same-tick multi-entry
+ * fill semantics (audit rule R*, jevondijefferson-big-breakout-strategy).
+ *
+ * Shape under test: TWO strategy.entry blocks with DISTINCT ids sharing one
+ * gate (3 BOS blocks entering "Long"/"Short" + a Wyckoff block entering
+ * "Wyckoff Swing Long"/"Wyckoff Swing Short"), pyramiding=0 (engine
+ * pyramiding_=1), percent-of-equity sizing, each entry paired with a
+ * strategy.exit(from_entry=<its id>) bracket. When both blocks fire on the
+ * SAME bar, both market entries fill at the SAME tick (next bar's open).
+ *
+ * TV's behaviour — validated 26/26 against every in-window race in the
+ * jevondijefferson tv_trades.csv export (qty arithmetic to 1e-4, operative
+ * bracket prices to the cent; audit artifacts scorecard.py / qtytest.py /
+ * reversals.py, 2026-07-02 tv-ceiling audit):
+ *
+ *   R*: same-tick entries fill SEQUENTIALLY in script-call order, each at
+ *   plain percent-of-equity qty; reversal augmentation (close-opposite-
+ *   then-enter extra qty) attaches ONLY to the LAST same-direction entry
+ *   of the tick; pyramiding=0 rejects an entry executing while the
+ *   position is already in that direction (evaluated at execution time,
+ *   against the sequentially-updated position); the fill that crosses
+ *   zero / opens from flat owns the entry ID; strategy.exit(from_entry=X)
+ *   brackets bind to id X even when X's paired entry call was rejected.
+ *
+ * Observable TV trade-list rows per race class (this is what the engine
+ * must reproduce — TV reports the old lot's close as ONE row at the shared
+ * fill price, attributed to the FIRST closing order's signal):
+ *
+ *   A flat at fill:      first entry opens at q_plain and owns its id;
+ *                        the later entry is pyramiding-rejected.
+ *   B opposite |pos| > q: old lot exits in ONE row with exit signal =
+ *                        FIRST entry id; the new lot opens at q_plain
+ *                        under the LAST entry id (total traded |pos|+q).
+ *   C opposite |pos| < q: the FIRST entry's single plain fill crosses
+ *                        zero: old lot exits (signal = first id), the
+ *                        REMAINDER (q - |pos|) opens under the FIRST id;
+ *                        the later entry is pyramiding-rejected.
+ *   D same direction:    no entry executes; the live lot's bracket is
+ *                        refreshed via from_entry binding.
+ *
+ * Pre-fix engine behaviour (dual-lot desync seeds): the first entry fill
+ * took flip_market_position_to — closing the whole opposite position and
+ * opening a FULL q_plain lot under the FIRST id. Class B then bound the
+ * WRONG bracket (first id instead of last id); class C opened q_plain
+ * instead of the remainder (TV: 0.2262 / engine: 7.915 at the 2025-06-17
+ * 15:15 race), seeding multi-day tiny-qty stale-remainder chains.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <pineforge/engine.hpp>
+#include <pineforge/bar.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+static bool near(double a, double b, double tol = 1e-6) {
+    return std::fabs(a - b) <= tol;
+}
+
+namespace {
+
+constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+// Mirrors the BOS+Wyckoff structure: on the race bar, TWO market entries
+// with distinct ids fire back-to-back in script-call order, each paired
+// with its own from_entry bracket. Percent-of-equity 2% default sizing,
+// pyramiding=0 (engine pyramiding_=1).
+//
+// Feed convention: o=h=l=c=100 (±0.5 wick) so market fills land at 100
+// and q_plain = 2% * 1,000,000 / 100 = 200 exactly (PnL-neutral closes
+// keep equity at 1,000,000 through the race).
+class RaceProbe : public BacktestEngine {
+public:
+    struct TradeRow {
+        std::string entry_id, exit_id;
+        double qty, entry_price, exit_price;
+    };
+
+    // Scenario knobs (set before run()).
+    int seed_bar = -1;            // bar issuing the seed entry (-1 = none)
+    bool seed_is_long = false;
+    double seed_qty = 0.0;        // explicit FIXED qty for the seed
+    int race_bar = 2;             // bar issuing both entry blocks
+    bool race_is_long = true;
+    int second_race_bar = -1;     // optional class-D repeat (-1 = none)
+
+    // Brackets (long-side values; short-side mirrors around 100).
+    // First entry's bracket fires strictly EARLIER on the path than the
+    // last entry's bracket, so the operative bracket is observable.
+    double first_limit_long = 105.0, first_stop_long = 90.0;
+    double last_limit_long = 110.0, last_stop_long = 88.0;
+
+    RaceProbe() {
+        initial_capital_ = 1'000'000.0;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 2.0;
+        pyramiding_ = 1;   // TV pyramiding=0: one entry per direction
+        slippage_ = 0;
+        commission_value_ = 0.0;
+    }
+
+    void on_bar(const Bar& bar) override {
+        if (bar_index_ == seed_bar && seed_qty > 0.0) {
+            strategy_entry("Seed", seed_is_long, kNaN, kNaN, seed_qty, "");
+        }
+        if (bar_index_ == race_bar || bar_index_ == second_race_bar) {
+            issue_race_blocks();
+        }
+        snapshot();
+    }
+
+    void issue_race_blocks() {
+        if (race_is_long) {
+            strategy_entry("Long", true, kNaN, kNaN, kNaN, "");
+            strategy_exit("Long Exit", "Long", first_limit_long,
+                          first_stop_long, kNaN, kNaN, kNaN, 100.0, "", kNaN, "");
+            strategy_entry("Wyckoff Long", true, kNaN, kNaN, kNaN, "");
+            strategy_exit("Wyckoff Long Exit", "Wyckoff Long", last_limit_long,
+                          last_stop_long, kNaN, kNaN, kNaN, 100.0, "", kNaN, "");
+        } else {
+            strategy_entry("Short", false, kNaN, kNaN, kNaN, "");
+            strategy_exit("Short Exit", "Short", 200.0 - first_limit_long,
+                          200.0 - first_stop_long, kNaN, kNaN, kNaN, 100.0, "", kNaN, "");
+            strategy_entry("Wyckoff Short", false, kNaN, kNaN, kNaN, "");
+            strategy_exit("Wyckoff Short Exit", "Wyckoff Short", 200.0 - last_limit_long,
+                          200.0 - last_stop_long, kNaN, kNaN, kNaN, 100.0, "", kNaN, "");
+        }
+    }
+
+    void snapshot() {
+        final_side = position_side_;
+        final_qty = position_qty_;
+        open_lots.clear();
+        for (const auto& pe : pyramid_entries_) {
+            open_lots.push_back({pe.entry_id, pe.qty});
+        }
+        closed.clear();
+        for (const auto& t : trades_) {
+            closed.push_back({t.entry_id, t.exit_id, t.qty, t.entry_price, t.exit_price});
+        }
+    }
+
+    PositionSide final_side = PositionSide::FLAT;
+    double final_qty = 0.0;
+    std::vector<std::pair<std::string, double>> open_lots;
+    std::vector<TradeRow> closed;
+};
+
+static std::vector<Bar> flat_feed(int n, double extra_high_bar = -1,
+                                  double extra_high = 0.0) {
+    std::vector<Bar> bars(n);
+    for (int i = 0; i < n; ++i) {
+        bars[i].open = 100.0;
+        bars[i].high = 100.5;
+        bars[i].low = 99.5;
+        bars[i].close = 100.0;
+        bars[i].volume = 1000.0;
+        bars[i].timestamp = (int64_t)(i + 1) * 900'000;
+        if (i == (int)extra_high_bar) bars[i].high = extra_high;
+    }
+    return bars;
+}
+
+}  // namespace
+
+// Class A — flat at fill: first entry opens q_plain and owns the id, the
+// later same-direction entry is pyramiding-rejected at execution time.
+static void test_flat_race_first_id_wins_plain_qty() {
+    std::printf("test_flat_race_first_id_wins_plain_qty\n");
+    RaceProbe p;
+    p.race_bar = 2;
+    p.race_is_long = true;
+    auto bars = flat_feed(6);
+    p.run(bars.data(), (int)bars.size());
+
+    CHECK(p.final_side == PositionSide::LONG);
+    CHECK(p.open_lots.size() == 1);
+    if (p.open_lots.size() == 1) {
+        CHECK(p.open_lots[0].first == "Long");
+        CHECK(near(p.open_lots[0].second, 200.0, 1e-9));
+    }
+    CHECK(p.closed.empty());
+}
+
+// Class B — opposite position larger than q_plain: the old lot exits in ONE
+// row attributed to the FIRST entry id; the new lot opens at q_plain under
+// the LAST entry id; total traded = |pos| + q_plain.
+static void test_reversal_race_last_id_owns_entry() {
+    std::printf("test_reversal_race_last_id_owns_entry\n");
+    RaceProbe p;
+    p.seed_bar = 0;
+    p.seed_is_long = false;
+    p.seed_qty = 300.0;      // seed short 300 > q_plain 200
+    p.race_bar = 2;
+    p.race_is_long = true;
+    auto bars = flat_feed(6);
+    p.run(bars.data(), (int)bars.size());
+
+    // Old short (300) closed in one row, exit signal = FIRST entry id.
+    double closed_seed = 0.0;
+    bool exit_sig_first = true;
+    for (const auto& t : p.closed) {
+        if (t.entry_id == "Seed") {
+            closed_seed += t.qty;
+            if (t.exit_id != "Long") exit_sig_first = false;
+        }
+    }
+    CHECK(near(closed_seed, 300.0, 1e-9));
+    CHECK(exit_sig_first);
+
+    // New long lot: q_plain under the LAST id (audit rule R*: the fill that
+    // crosses zero owns the entry ID; augmentation attaches to the LAST
+    // same-direction entry of the tick).
+    CHECK(p.final_side == PositionSide::LONG);
+    CHECK(p.open_lots.size() == 1);
+    if (p.open_lots.size() == 1) {
+        CHECK(p.open_lots[0].first == "Wyckoff Long");
+        CHECK(near(p.open_lots[0].second, 200.0, 1e-9));
+    }
+}
+
+// Class B bracket binding: the operative bracket must be the LAST entry's
+// from_entry bracket (limit 110), not the first's (limit 105). A bar
+// touching 106 must NOT exit; the 111 bar exits at 110 via the last id's
+// bracket.
+static void test_reversal_race_operative_bracket_is_last() {
+    std::printf("test_reversal_race_operative_bracket_is_last\n");
+    RaceProbe p;
+    p.seed_bar = 0;
+    p.seed_is_long = false;
+    p.seed_qty = 300.0;
+    p.race_bar = 2;
+    p.race_is_long = true;
+    auto bars = flat_feed(7);
+    bars[4].high = 106.0;    // would fire the WRONG bracket (limit 105)
+    bars[5].high = 111.0;    // fires the correct bracket (limit 110)
+    p.run(bars.data(), (int)bars.size());
+
+    // The long lot must survive bar 4 untouched and exit at 110 on bar 5.
+    bool found_bracket_exit = false;
+    for (const auto& t : p.closed) {
+        if (t.entry_id == "Wyckoff Long") {
+            found_bracket_exit = true;
+            CHECK(t.exit_id == "Wyckoff Long Exit");
+            CHECK(near(t.exit_price, 110.0, 1e-9));
+        }
+        // No trade may exit through the first entry's bracket at 105.
+        CHECK(!(t.exit_id == "Long Exit"));
+    }
+    CHECK(found_bracket_exit);
+    CHECK(p.final_side == PositionSide::FLAT);
+}
+
+// Class C — opposite position smaller than q_plain: the FIRST entry's plain
+// fill crosses zero; the old lot exits with the first id's signal and the
+// REMAINDER (q_plain - |pos|) opens under the FIRST id; the later entry is
+// pyramiding-rejected against the sequentially-updated position.
+static void test_reversal_race_remainder_crosses_zero_first_id() {
+    std::printf("test_reversal_race_remainder_crosses_zero_first_id\n");
+    RaceProbe p;
+    p.seed_bar = 0;
+    p.seed_is_long = true;
+    p.seed_qty = 50.0;       // seed long 50 < q_plain 200
+    p.race_bar = 2;
+    p.race_is_long = false;
+    auto bars = flat_feed(6);
+    p.run(bars.data(), (int)bars.size());
+
+    double closed_seed = 0.0;
+    bool exit_sig_first = true;
+    for (const auto& t : p.closed) {
+        if (t.entry_id == "Seed") {
+            closed_seed += t.qty;
+            if (t.exit_id != "Short") exit_sig_first = false;
+        }
+    }
+    CHECK(near(closed_seed, 50.0, 1e-9));
+    CHECK(exit_sig_first);
+
+    // Remainder short: q_plain(200) - 50 = 150 under the FIRST id, and the
+    // later entry must NOT have added a second lot (TV total traded on the
+    // tick = q_plain, not q_plain + q_plain).
+    CHECK(p.final_side == PositionSide::SHORT);
+    CHECK(p.open_lots.size() == 1);
+    if (p.open_lots.size() == 1) {
+        CHECK(p.open_lots[0].first == "Short");
+        CHECK(near(p.open_lots[0].second, 150.0, 1e-9));
+    }
+}
+
+// Class D — same-direction position: both entries are rejected at execution
+// time; the position is unchanged and the live lot's bracket is refreshed
+// via from_entry binding.
+static void test_same_direction_race_rejected() {
+    std::printf("test_same_direction_race_rejected\n");
+    RaceProbe p;
+    p.race_bar = 2;           // opens "Long" 200 from flat (class A)
+    p.second_race_bar = 4;    // fires again while long — class D
+    p.race_is_long = true;
+    auto bars = flat_feed(8);
+    p.run(bars.data(), (int)bars.size());
+
+    CHECK(p.final_side == PositionSide::LONG);
+    CHECK(p.open_lots.size() == 1);
+    if (p.open_lots.size() == 1) {
+        CHECK(p.open_lots[0].first == "Long");
+        CHECK(near(p.open_lots[0].second, 200.0, 1e-9));
+    }
+    CHECK(p.closed.empty());
+}
+
+// Composition guard — same-bar strategy.close batch (672c59b) + sequential
+// same-tick entries under process_orders_on_close: the surviving batched
+// close fills at the bar close BEFORE the entry orders fill (dispatch step
+// 3b before step 4), so the entries execute from FLAT: first id opens
+// q_plain, later id is pyramiding-rejected.
+static void test_poc_close_batch_then_sequential_entries() {
+    std::printf("test_poc_close_batch_then_sequential_entries\n");
+    class PocProbe : public RaceProbe {
+    public:
+        PocProbe() { process_orders_on_close_ = true; }
+        void on_bar(const Bar& bar) override {
+            if (bar_index_ == 0) {
+                strategy_entry("Seed", true, kNaN, kNaN, 50.0, "");
+            }
+            if (bar_index_ == 2) {
+                strategy_close("Seed", "flip", kNaN, kNaN, false);
+                race_is_long = false;
+                issue_race_blocks();
+            }
+            snapshot();
+        }
+    };
+    PocProbe p;
+    auto bars = flat_feed(6);
+    p.run(bars.data(), (int)bars.size());
+
+    // Seed long closed by the batched close (not by the entry fills).
+    double closed_seed = 0.0;
+    bool closed_by_close = true;
+    for (const auto& t : p.closed) {
+        if (t.entry_id == "Seed") {
+            closed_seed += t.qty;
+            if (t.exit_id.rfind("__close__", 0) != 0) closed_by_close = false;
+        }
+    }
+    CHECK(near(closed_seed, 50.0, 1e-9));
+    CHECK(closed_by_close);
+
+    // Entries then fill from flat at the same bar's close: first id owns
+    // the position at q_plain; the later entry is pyramiding-rejected.
+    CHECK(p.final_side == PositionSide::SHORT);
+    CHECK(p.open_lots.size() == 1);
+    if (p.open_lots.size() == 1) {
+        CHECK(p.open_lots[0].first == "Short");
+        CHECK(near(p.open_lots[0].second, 200.0, 1e-9));
+    }
+}
+
+// Single-entry reversal (no same-tick sibling) keeps the classic augmented
+// flip: whole opposite position closes and a FULL q_plain lot opens under
+// the single entry's id — the fix must not disturb the everyday path.
+static void test_single_entry_reversal_unchanged() {
+    std::printf("test_single_entry_reversal_unchanged\n");
+    class SingleProbe : public RaceProbe {
+    public:
+        void on_bar(const Bar& bar) override {
+            if (bar_index_ == 0) {
+                strategy_entry("Seed", false, kNaN, kNaN, 300.0, "");
+            }
+            if (bar_index_ == 2) {
+                strategy_entry("Long", true, kNaN, kNaN, kNaN, "");
+            }
+            snapshot();
+        }
+    };
+    SingleProbe p;
+    auto bars = flat_feed(6);
+    p.run(bars.data(), (int)bars.size());
+
+    double closed_seed = 0.0;
+    for (const auto& t : p.closed) {
+        if (t.entry_id == "Seed") closed_seed += t.qty;
+    }
+    CHECK(near(closed_seed, 300.0, 1e-9));
+    CHECK(p.final_side == PositionSide::LONG);
+    CHECK(p.open_lots.size() == 1);
+    if (p.open_lots.size() == 1) {
+        CHECK(p.open_lots[0].first == "Long");
+        CHECK(near(p.open_lots[0].second, 200.0, 1e-9));
+    }
+}
+
+int main() {
+    test_flat_race_first_id_wins_plain_qty();
+    test_reversal_race_last_id_owns_entry();
+    test_reversal_race_operative_bracket_is_last();
+    test_reversal_race_remainder_crosses_zero_first_id();
+    test_same_direction_race_rejected();
+    test_poc_close_batch_then_sequential_entries();
+    test_single_entry_reversal_unchanged();
+
+    std::printf("%d passed, %d failed\n", tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Integration branch for the 2026-07-01/02 TV-parity fix campaign: 13 engine fixes (each on its own retained `fix/*` branch, merged here after gating), driven by trade-for-trade validation against real TradingView deep-backtest exports across the 82-strategy scraped corpus.

Standard-corpus result: **excellent+strong 54 → 72 / 82**; five residuals proof-grade classified as TV-parity ceilings (adversarially audited); reference corpus held **252/252 ok, excellent=251 / anomaly=1** tier-for-tier through every merge.

### Key fixes
- `672c59b` same-bar default-FIFO `strategy.close` batching — TV fills ONE per bar (replace/reserve rule reverse-engineered from 1150/1150 + 584/584 fill streams): xau-grid 10.8→81.2%, xlm-grid 22.4→99.0%
- `75d07f6` same-tick multi-entry sequential fills (rule R*) + percent-100 bracket binding to pending reversal entry: jevondijefferson 88.0→100.0% (+ new discriminating ctest probe; corpus was proven byte-insensitive to this fill class)
- `e654888` + `eb79f53` finer-than-chart `request.security` history latch, restricted to `lookahead_on`: triple-rsi-dca 50.5→100.0%, masayanfx regression caught and restored to 100.0%
- `e82714e` exit-bracket reservation against pending `from_entry` reversal entry: thulashimohanr 92.8→96.4%
- `513e8fa` percent-derived `strategy.exit` legs floored to instrument lot step (TV dust semantics): stockhunter2025 92.3→93.6%
- `8d5bad8` same-bar flat-armed opposite-close deferral; `ac61d0c` over-allocated 1x-long liquidation; `4e82016`/`96d9fbb` same-bar limit-entry/exit-reissue fills; `bdad9a4` margin syminfo wiring; `3ec0484` qty-step on entries; `19b7236` account-currency FX; `cfa8c89` close() keeps pending entries

### Verification
- ctest 78/78 (855+ assertions, incl. 2 new discriminating probes)
- `run_corpus.sh`: 252 strategies, ok=252 fail=0
- `verify_corpus.py --all`: excellent=251, anomaly=1 (the anomaly is the pre-existing deliberate `anomaly-equity-mirror` TV-nondeterminism probe)
- `check_c_abi_runtime.py` exit 0 (no PF_API surface changes)
- Full 82-slug standard sweep after every merge: no unexplained artifact drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnvqmHPmgUpeu2fz6A1mMU