### PR TITLE
Roll the daily boundary at chart/UTC for a 2-arg time() timezone-in-session-slot

### DIFF
--- a/src/session_time.cpp
+++ b/src/session_time.cpp
@@ -420,12 +420,15 @@ bool pine_session_ispostmarket(const std::string& session,
 
 // A 2-argument time()/time_close() call binds its second string to the
 // `session` parameter, but scripts commonly pass a TIMEZONE there — e.g.
-// `time("D", "America/New_York")` to detect a day-change in that zone.
-// TradingView honors this idiom. When no explicit timezone was supplied and
-// the session slot instead holds an unambiguous timezone (IANA "Area/Location"
-// or a GMT/UTC specifier), reinterpret it as the timezone with no session
-// filter. A real session window ("0930-1600") never contains '/' nor starts
-// with GMT/UTC, and a 3-arg call supplies tz_in, so neither is affected.
+// `time("D", "America/New_York")`. TradingView does NOT reinterpret that
+// string as the timezone: a value that is not a valid session spec (IANA
+// "Area/Location" or a GMT/UTC specifier) is an invalid session that TV
+// ignores entirely, rolling the daily boundary at the chart/exchange
+// (UTC in the engine's model) timezone — NOT at the string's tz. We detect
+// such a string here only so we can drop it (no session filter, tz left at
+// the chart/UTC default). A real session window ("0930-1600") never contains
+// '/' nor starts with GMT/UTC, and a 3-arg call supplies tz_in, so neither is
+// affected.
 static bool session_arg_is_timezone(const std::string& s) {
     if (s.empty())
         return false;
@@ -436,8 +439,12 @@ static bool session_arg_is_timezone(const std::string& s) {
     return false;
 }
 
-// Resolve the (session, tz) pair for a time()/time_close() call, applying the
-// 2-arg timezone-in-session-slot reinterpretation above.
+// Resolve the (session, tz) pair for a time()/time_close() call. When a 2-arg
+// call passes a timezone-looking string in the session slot (and no explicit
+// tz), TV treats it as an invalid session and ignores it: drop the session
+// (no filter) but leave tz at the chart/UTC default — do NOT adopt the string
+// as the timezone. The daily boundary then rolls at the chart/exchange (UTC)
+// timezone, matching TradingView.
 static void resolve_session_tz(const std::string& session,
                                const std::string& tz_in,
                                std::string& sess_out,
@@ -445,7 +452,6 @@ static void resolve_session_tz(const std::string& session,
     sess_out = session;
     tz_out = tz_in;
     if (tz_out.empty() && session_arg_is_timezone(sess_out)) {
-        tz_out = sess_out;
         sess_out.clear();
     }
     if (tz_out.empty())

--- a/tests/test_session_time.cpp
+++ b/tests/test_session_time.cpp
@@ -63,23 +63,28 @@ static void test_time_close_hourly() {
 
 static void test_time_tz_in_session_slot_equiv() {
     std::printf("test_time_tz_in_session_slot_equiv\n");
-    // time("D", "America/New_York") binds the tz into the session slot. The
-    // engine must reinterpret it as the timezone (not a session) — previously
-    // it treated it as a session, matched no HHMM window, and returned na.
+    // time("D", "America/New_York") binds the tz into the session slot. That is
+    // an invalid session, which TV ignores entirely — it does NOT adopt the
+    // string as the timezone. The daily boundary rolls at the chart/exchange
+    // (UTC) timezone, exactly as a plain time("D") does. It must not be na, and
+    // must NOT match the 3-arg explicit-tz form (which still rolls at NY).
     int64_t bar = 1775572200000LL;  // 2026-04-07 14:30 UTC = 10:30 NY (EDT)
     int64_t two_arg = pine_time(bar, "D", "America/New_York", "", "15");
-    int64_t three_arg = pine_time(bar, "D", "", "America/New_York", "15");
-    CHECK(!is_na(two_arg));          // was na for every bar (the bug)
-    CHECK(two_arg == three_arg);     // reinterpreted identically to the 3-arg form
+    int64_t plain   = pine_time(bar, "D", "", "", "15");                // time("D") → UTC/chart
+    int64_t three_arg = pine_time(bar, "D", "", "America/New_York", "15");  // explicit tz → NY
+    CHECK(!is_na(two_arg));          // was na before PR#66; still not na
+    CHECK(two_arg == plain);         // invalid session tz-string ignored → rolls at UTC/chart
+    CHECK(two_arg != three_arg);     // explicit-tz 3-arg form still uses the given tz
 }
 
 static void test_time_tz_in_session_daily_change() {
     std::printf("test_time_tz_in_session_daily_change\n");
-    // Bars in the same NY-day share the daily time; the next NY-day differs —
+    // The tz-string session is ignored, so the daily boundary rolls at UTC.
+    // Bars in the same UTC-day share the daily time; the next UTC-day differs —
     // this is what makes ta.change(time("D", tz)) fire once per day.
-    int64_t bar_a = 1775572200000LL;               // 2026-04-07 10:30 NY
-    int64_t bar_b = bar_a + 3600000LL;             // +1h, same NY-day
-    int64_t bar_next = bar_a + 24LL * 3600000LL;   // +24h, next NY-day
+    int64_t bar_a = 1775572200000LL;               // 2026-04-07 14:30 UTC
+    int64_t bar_b = bar_a + 3600000LL;             // +1h → 15:30 UTC, same UTC-day
+    int64_t bar_next = bar_a + 24LL * 3600000LL;   // +24h, next UTC-day
     int64_t ta = pine_time(bar_a, "D", "America/New_York", "", "15");
     int64_t tb = pine_time(bar_b, "D", "America/New_York", "", "15");
     int64_t tn = pine_time(bar_next, "D", "America/New_York", "", "15");


### PR DESCRIPTION
## Correction to PR #66
PR #66 made a 2-arg `time("D", tz)` (a timezone string bound to the `session` slot) return a valid daily time — but it **adopted the string as the timezone**, rolling the daily boundary at that zone's midnight. That is wrong: TradingView treats an invalid session string as a **no-op** and rolls the daily boundary at the **chart/exchange timezone** (for BINANCE:ETHUSDT.P = 00:00 UTC).

Evidence (gb2wgkrtxs-liquidity-sweep, `time("D","Europe/Prague")`): TV's session cascades' last entry = 00:00 UTC on 49 summer + 21 winter nights; PR#66's Prague-tz build rolled at 22:00/23:00 UTC → cascades ended at the wrong hour.

## Fix
In `resolve_session_tz` (`src/session_time.cpp`): when the session slot holds a timezone string with no explicit tz, **ignore** the string (drop the session filter) but leave the tz at the chart/UTC default — do not adopt the string as the tz. `session_arg_is_timezone()` is retained (still detects the string to ignore).

## Tests
`tests/test_session_time.cpp` updated: 2-arg `time("D","America/New_York")` now == plain `time("D")` (both roll at UTC) and != the 3-arg explicit-tz form (which still uses the given tz); daily-change reframed to UTC-day. Real-session and GMT cases unchanged.

## Gate (R7, fresh context)
- Anti-cheat: exactly 2 files.
- ctest: 79/79.
- Corpus gate: `239/12/0/0/0/1` — **identical to baseline** (no corpus strategy uses this pattern; neutral).
- Scraper: gb2wgkrtxs **60.2%→90.6%** coverage; drop-trades-orb unchanged (ORB day-reset insensitive to UTC-vs-NY); nils123456-orb (3-arg) unchanged 104/104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)