### PR TITLE
fix(time): intraday time_close is the exact bar-close boundary

### DIFF
--- a/src/session_time.cpp
+++ b/src/session_time.cpp
@@ -174,7 +174,16 @@ static int64_t compute_tf_close_ms(int64_t open_ms,
     int sec = tf_to_seconds(tf);
 
     if (sec > 0 && sec < kSecPerDay) {
-        return open_ms + static_cast<int64_t>(sec) * 1000 - 1;
+        // Intraday time_close is the EXACT bar-close boundary (== next bar's
+        // open = open_ms + duration), NOT the last millisecond of the bar. TV's
+        // time_close for a 15:15 15m bar is 15:30:00.000, so minute(time_close)
+        // == 30 (verified against vasudevshenoy-manoj-betrayed-me, whose
+        // `minute(time_close) >= 30` intraday session-close flatten fires 222
+        // times in TV; the prior `- 1` gave 15:29:59.999 -> minute 29 -> the
+        // flatten never fired). The calendar DAY/WEEK/MONTH branches below keep
+        // their `- 1` (period-END = last ms of the period, per their TV-boundary
+        // tests) because those are distinct semantics from an intraday close.
+        return open_ms + static_cast<int64_t>(sec) * 1000;
     }
 
     pine_tz::ScopedTimezone guard(tz);

--- a/tests/test_session_time.cpp
+++ b/tests/test_session_time.cpp
@@ -56,7 +56,10 @@ static void test_time_close_hourly() {
     int64_t tc = pine_time_close(bar, "60", "", "UTC", "60");
     CHECK(!is_na(tc));
     int64_t to = pine_time(bar, "60", "", "UTC", "60");
-    CHECK(tc == to + 3600000 - 1);
+    // Intraday time_close is the EXACT bar-close boundary (open + duration),
+    // == the next bar's open — NOT the last ms of the bar. So minute()/hour()
+    // of a boundary-aligned bar match TV (see session_time.cpp compute_tf_close_ms).
+    CHECK(tc == to + 3600000);
 }
 
 // --- 2-arg time(tf, tz): a timezone passed in the session slot ---


### PR DESCRIPTION
## Problem
`compute_tf_close_ms` returned `open + duration - 1ms` for **intraday** timeframes, so `minute(time_close)`/`hour(time_close)` of a boundary-aligned bar were off by one: a 15:15 15m bar gave 15:29:59.999 → minute 29 instead of TradingView's 15:30:00.000 → minute 30. Strategies that detect the intraday session-close bar via `minute(time_close) >= N` never fired their `strategy.close_all` and held positions past the intended session close.

## Fix
Drop the `-1` for the **intraday branch only**: intraday `time_close` == `open + duration` == the next bar's open, matching TV. Calendar DAY/WEEK/MONTH branches keep their period-END `-1` (distinct TV semantics, covered by `test_session_calendar_extra`).

## Validation
- `test_session_time.cpp::test_time_close_hourly` updated to assert `tc == to + 3600000` (exact boundary).
- **ctest 79/79.**
- **Corpus neutral: 239 excellent / 12 strong / 0 moderate / 1 anomaly** (unchanged; no corpus strategy uses `time_close`, verified by grep).
- Standard sentinels unchanged (3commas DCA/grid 100%, stockhunter 93.9%).
- Gated by a fresh-context R7 review (build + full corpus rebuild-and-run + sentinels + ctest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)