### PR TITLE
fix(session_time): kill per-call tzset()->notifyd storm on macOS (KI-35)

### DIFF
--- a/include/pineforge/session_time.hpp
+++ b/include/pineforge/session_time.hpp
@@ -36,6 +36,21 @@ int64_t pine_time_close(int64_t bar_ms,
 // Convert "HHMM" string to minutes-since-midnight.  Returns -1 on parse error.
 int hhmm_to_minutes(const std::string& hhmm);
 
+// Pine time/date extraction from a Unix-ms bar timestamp in timezone `tz`.
+// Value-identical to Pine hour()/minute()/dayofweek()/... (dayofweek 1=Sun..7=Sat,
+// month 1..12, year full). Codegen routes hour()/minute()/... through these
+// instead of an inline setenv+tzset lambda, which stops the per-call macOS
+// tzset()->notifyd IPC storm (KI-35): UTC uses tzset-free gmtime_r, other zones
+// use the cached ScopedTimezone. DST-correct (localtime_r via the tz database).
+int pine_hour(int64_t bar_ms, const std::string& tz);
+int pine_minute(int64_t bar_ms, const std::string& tz);
+int pine_second(int64_t bar_ms, const std::string& tz);
+int pine_dayofmonth(int64_t bar_ms, const std::string& tz);
+int pine_dayofweek(int64_t bar_ms, const std::string& tz);
+int pine_month(int64_t bar_ms, const std::string& tz);
+int pine_year(int64_t bar_ms, const std::string& tz);
+int pine_weekofyear(int64_t bar_ms, const std::string& tz);
+
 // True when local_tm falls within any of the comma-separated HHMM-HHMM
 // windows in windows_body.  "24x7" or empty always returns true.
 bool local_time_in_session_windows(const std::string& windows_body,

--- a/src/session_time.cpp
+++ b/src/session_time.cpp
@@ -25,7 +25,54 @@ int hhmm_to_minutes(const std::string& hhmm) {
     return h * 60 + m;
 }
 
+// Decompose a Unix-ms timestamp into local calendar fields for `tz` WITHOUT the
+// per-call setenv/tzset churn that made hour()/minute()/... pathologically slow
+// on macOS (each changed-TZ tzset() does a notifyd Mach-IPC round-trip ~173us;
+// ~888k/run over the full feed -> minutes of apparent "hang", KI-35). UTC needs
+// no tz -> tzset-free gmtime_r; other zones use the CACHED pine_tz::ScopedTimezone
+// (skips tzset when the active zone is unchanged, and never restores), so a run
+// that stays on one zone pays a single tzset. DST stays exact: localtime_r
+// consults the tz database exactly as the old inline lambda did.
+static void decompose_ms_local(int64_t bar_ms, const std::string& tz, struct tm& out) {
+    time_t secs = static_cast<time_t>(bar_ms / 1000);
+    const std::string t = normalize_timezone_for_posix(tz);
+    if (t.empty() || t == "UTC" || t == "Etc/UTC") {
+        gmtime_r(&secs, &out);
+    } else {
+        pine_tz::ScopedTimezone guard(t);
+        localtime_r(&secs, &out);
+    }
+}
+
+// Pine time/date extraction — value-identical to the codegen's former inline
+// setenv+tzset lambda (pineforge-codegen tables.py TIME_FIELD_EXPRS) but
+// churn-free. hour()/minute()/... route through these instead of open-coding it.
+int pine_hour(int64_t bar_ms, const std::string& tz)       { struct tm t; decompose_ms_local(bar_ms, tz, t); return t.tm_hour; }
+int pine_minute(int64_t bar_ms, const std::string& tz)     { struct tm t; decompose_ms_local(bar_ms, tz, t); return t.tm_min; }
+int pine_second(int64_t bar_ms, const std::string& tz)     { struct tm t; decompose_ms_local(bar_ms, tz, t); return t.tm_sec; }
+int pine_dayofmonth(int64_t bar_ms, const std::string& tz) { struct tm t; decompose_ms_local(bar_ms, tz, t); return t.tm_mday; }
+int pine_dayofweek(int64_t bar_ms, const std::string& tz)  { struct tm t; decompose_ms_local(bar_ms, tz, t); return t.tm_wday + 1; }
+int pine_month(int64_t bar_ms, const std::string& tz)      { struct tm t; decompose_ms_local(bar_ms, tz, t); return t.tm_mon + 1; }
+int pine_year(int64_t bar_ms, const std::string& tz)       { struct tm t; decompose_ms_local(bar_ms, tz, t); return t.tm_year + 1900; }
+int pine_weekofyear(int64_t bar_ms, const std::string& tz) { struct tm t; decompose_ms_local(bar_ms, tz, t); return (t.tm_yday + 7 - ((t.tm_wday + 6) % 7)) / 7; }
+
+static int64_t calendar_day_open_local_ms_tz(int64_t bar_ms, const std::string& tz);
+
 int64_t calendar_day_open_local_ms(int64_t bar_ms, const std::string& tz) {
+    // UTC needs no tzset: local midnight is exact integer floor. Avoiding
+    // ScopedTimezone(UTC) here keeps the process TZ from flipping to UTC every
+    // bar (which would re-slow the strategy's hour()/minute() zone) — see KI-35.
+    {
+        const std::string t = normalize_timezone_for_posix(tz);
+        if (t.empty() || t == "UTC" || t == "Etc/UTC") {
+            time_t secs = static_cast<time_t>(bar_ms / 1000);
+            return static_cast<int64_t>((secs / 86400) * 86400) * 1000;
+        }
+    }
+    return calendar_day_open_local_ms_tz(bar_ms, tz);
+}
+
+static int64_t calendar_day_open_local_ms_tz(int64_t bar_ms, const std::string& tz) {
     pine_tz::ScopedTimezone guard(tz);
     time_t secs = static_cast<time_t>(bar_ms / 1000);
     struct tm local_tm {};
@@ -534,10 +581,8 @@ int64_t pine_time_tradingday(int64_t bar_ms,
     std::string eff_tz = tz.empty() ? "UTC" : tz;
     int bar_local_min;
     {
-        pine_tz::ScopedTimezone guard(eff_tz);
-        time_t secs = static_cast<time_t>(bar_ms / 1000);
         struct tm local_tm {};
-        localtime_r(&secs, &local_tm);
+        decompose_ms_local(bar_ms, eff_tz, local_tm);  // gmtime_r for UTC (no TZ flip)
         bar_local_min = local_tm.tm_hour * 60 + local_tm.tm_min;
     }
 


### PR DESCRIPTION
## Problem (KI-35)

`hour()`/`minute()`/`second()`/`dayof*`/`month()`/`year()`/`weekofyear()` were emitted by codegen as an inline `setenv(\"TZ\")`+`tzset()`+`localtime_r` lambda evaluated **once per bar**. On macOS every changed-TZ `tzset()` performs a notifyd Mach-IPC round-trip (~173µs). Across a full ETH 1m feed (~888k evals per field) this is minutes of wall time that presents as an engine **hang** — algotorma ran 154s+ and never finished.

## Fix

- Add churn-free `pine_hour()`/`pine_minute()`/... helpers backed by `decompose_ms_local()`:
  - **UTC** → tzset-free `gmtime_r` (integer path, no `tzset` at all).
  - **other zones** → cached `pine_tz::ScopedTimezone` (skips `tzset` when the active zone is unchanged, never restores) → a single-zone run pays **one** `tzset` total.
- Short-circuit `calendar_day_open_local_ms()` for UTC (integer midnight floor) so the per-bar tradingday path stops flipping the process TZ to UTC and back each bar (which would re-slow the strategy's own zone).

## Value-identity (proven)

Same Pine offsets as the old lambda (`dayofweek=tm_wday+1`, `month=tm_mon+1`, `year=tm_year+1900`, weekofyear ISO-ish), DST-exact via `localtime_r` over the tz database.

- **DST unit test**: NY summer h=8 (EDT-4), NY winter h=7 (EST-5), Phoenix unshifted, Kolkata +5:30, UTC/empty→12.
- **Trade diff**: lukeborgerding (uses hour/minute/second) byte-for-byte identical to baseline.
- **Corpus gate**: 252/252 ran, 0 fail, excellent=239 strong=12 — byte-exactly the baseline, no demotions.
- **ctest**: 79/79.
- **Formerly-"hung"**: 16 strategies now finish in seconds (algotorma 154s+ → 1.5s, 282/282 100%).

## Pairing

Codegen emits calls to these helpers in a paired `pineforge-codegen-oss` change (merge this first — codegen depends on the `pine_*` symbols).

🤖 Generated with [Claude Code](https://claude.com/claude-code)