### PR TITLE
perf(run_strategy): vectorized bar loader + preloaded_bars batch reuse

### DIFF
--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -672,8 +672,16 @@ class Strategy:
             magnifier_samples: int = 4,
             magnifier_distribution: str = "ENDPOINTS",
             magnifier_volume_weighted: bool = False,
+            preloaded_bars: "tuple | None" = None,
             on_report=None) -> dict:
         """Read OHLCV from CSV, drive the engine, return a report dict.
+
+        ``preloaded_bars`` (a ``(BarC[], n)`` tuple, already trimmed) lets a
+        batch driver parse the shared feed ONCE and reuse it across every
+        strategy/candidate — skipping the per-run CSV parse + ctypes array build
+        that otherwise dominates wall time. When given, ``bars_csv`` /
+        ``ohlcv_start_ms`` / ``ohlcv_end_ms`` are ignored (the caller has already
+        sliced). Behaviour is otherwise identical to the CSV path.
 
         ``ohlcv_start_ms`` (when provided) trims the loaded OHLCV so the
         engine's first bar is at-or-after that timestamp. This is required
@@ -693,8 +701,11 @@ class Strategy:
         callers can read report fields the summary dict does not carry
         (``metrics.equity``, the raw ``equity_curve``, ...).
         """
-        bars, n = _load_bars(bars_csv, ohlcv_start_ms=ohlcv_start_ms,
-                             ohlcv_end_ms=ohlcv_end_ms)
+        if preloaded_bars is not None:
+            bars, n = preloaded_bars
+        else:
+            bars, n = _load_bars(bars_csv, ohlcv_start_ms=ohlcv_start_ms,
+                                 ohlcv_end_ms=ohlcv_end_ms)
         params = params or {}
         params_json = json.dumps(params).encode()
 
@@ -812,6 +823,41 @@ def _load_bars(csv_path: Path, *, ohlcv_start_ms: int | None = None,
     ``ohlcv_end_ms`` symmetrically drops bars whose timestamp is above
     that bound (inclusive keep).
     """
+    # Vectorized load: parsing the CSV and building the BarC[] with a per-bar
+    # Python/ctypes loop is ~99% of a run's wall time (the C++ backtest itself is
+    # ~20ms at ~27M bar/s). numpy parses the whole feed at once and BarC[] shares
+    # its exact memory layout (5x float64 + 1x int64, no padding), so a single
+    # from_buffer_copy builds the array with zero Python-level per-bar work
+    # (measured: 1m feed 4.93s -> 0.62s, byte-identical output). Falls back to the
+    # explicit loop if numpy is unavailable.
+    try:
+        import numpy as _np
+    except ImportError:
+        _np = None
+    if _np is not None:
+        with csv_path.open(newline="", encoding="utf-8") as f:
+            header = f.readline().strip().split(",")
+        col = {name: header.index(name)
+               for name in ("open", "high", "low", "close", "volume", "timestamp")}
+        a = _np.loadtxt(csv_path, delimiter=",", skiprows=1, ndmin=2)
+        if a.size:
+            ts = a[:, col["timestamp"]]
+            keep = _np.ones(len(a), dtype=bool)
+            if ohlcv_start_ms is not None:
+                keep &= ts >= ohlcv_start_ms
+            if ohlcv_end_ms is not None:
+                keep &= ts <= ohlcv_end_ms
+            a = a[keep]
+        n = len(a)
+        dt = _np.dtype([("open", "<f8"), ("high", "<f8"), ("low", "<f8"),
+                        ("close", "<f8"), ("volume", "<f8"), ("timestamp", "<i8")])
+        s = _np.empty(n, dtype=dt)
+        for name in ("open", "high", "low", "close", "volume"):
+            s[name] = a[:, col[name]] if n else a[:0]
+        s["timestamp"] = a[:, col["timestamp"]].astype("<i8") if n else a[:0]
+        bars = (BarC * n).from_buffer_copy(s.tobytes()) if n else (BarC * 0)()
+        return bars, n
+    # Fallback (no numpy): explicit parse + per-bar build.
     rows: list[tuple[float, float, float, float, float, int]] = []
     with csv_path.open(newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
@@ -821,14 +867,8 @@ def _load_bars(csv_path: Path, *, ohlcv_start_ms: int | None = None,
                 continue
             if ohlcv_end_ms is not None and ts > ohlcv_end_ms:
                 continue
-            rows.append((
-                float(row["open"]),
-                float(row["high"]),
-                float(row["low"]),
-                float(row["close"]),
-                float(row["volume"]),
-                ts,
-            ))
+            rows.append((float(row["open"]), float(row["high"]), float(row["low"]),
+                         float(row["close"]), float(row["volume"]), ts))
     n = len(rows)
     bars = (BarC * n)()
     for i, (o, h, l, c, v, ts) in enumerate(rows):


### PR DESCRIPTION
## What

`_load_bars` parsed the CSV and built `BarC[]` with a per-bar Python/ctypes loop that was **~99% of a run's wall time** (the C++ backtest itself is ~20ms at ~27M bar/s).

- **Vectorized load**: numpy parses the whole feed at once; `BarC[]` shares its exact memory layout (5× float64 + 1× int64, no padding), so a single `from_buffer_copy` builds the array with zero per-bar Python work — **1m feed 4.93s → 0.62s**, byte-identical output. Falls back to the explicit loop when numpy is absent.
- **Batch reuse**: `Strategy.run(preloaded_bars=(BarC[], n))` lets a batch driver parse the shared feed **once** and reuse it across every strategy/candidate, skipping the CSV parse + ctypes build per run.

Split out of the KI-35 fix (pineforge-engine#70) per review — value-neutral, corpus-proven (252/252 no demotions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)