### PR TITLE
fix(session_time): stop double-normalizing tz for fixed offsets (KI-35 follow-up)

### DIFF
--- a/src/session_time.cpp
+++ b/src/session_time.cpp
@@ -35,11 +35,16 @@ int hhmm_to_minutes(const std::string& hhmm) {
 // consults the tz database exactly as the old inline lambda did.
 static void decompose_ms_local(int64_t bar_ms, const std::string& tz, struct tm& out) {
     time_t secs = static_cast<time_t>(bar_ms / 1000);
+    // Detect UTC on the NORMALIZED string, but hand the RAW tz to
+    // ScopedTimezone — it normalizes internally (timezone.cpp), so passing an
+    // already-normalized string double-normalizes and flips the sign of fixed
+    // offsets ("UTC+2" -> "UTC-2" -> "UTC+2" => wrong hour). IANA/UTC zones are
+    // idempotent under normalize so this only bit offset-string tz inputs.
     const std::string t = normalize_timezone_for_posix(tz);
     if (t.empty() || t == "UTC" || t == "Etc/UTC") {
         gmtime_r(&secs, &out);
     } else {
-        pine_tz::ScopedTimezone guard(t);
+        pine_tz::ScopedTimezone guard(tz);
         localtime_r(&secs, &out);
     }
 }


### PR DESCRIPTION
## Bug (introduced by #70)

The KI-35 helper `decompose_ms_local` passed an **already-normalized** tz string into `pine_tz::ScopedTimezone`, which normalizes **again** internally. For fixed-offset tz inputs the normalizer flips the POSIX sign (`"UTC+2"` → `"UTC-2"`), so normalizing twice flips it back and `localtime_r` decodes the **wrong hour**. IANA names and `"UTC"` are idempotent under normalize, so the bug was invisible to the corpus gate (0 offset-tz strategies), the lukeborgerding trade diff, and the NY/Phoenix/Kolkata DST unit test — every #70 probe used UTC or an IANA zone.

Surfaced by the post-merge sweep flagging `mylivingedge-gold-asian-range` excellent→minimal: its `tz = "UTC+2"` Asian-session window (`hour(time, tz)`) was mis-shifted by the double-flip.

## Fix

Detect UTC on the normalized string (as before) but hand the **raw** `tz` to `ScopedTimezone` so it normalizes exactly once — matching the old inline `setenv+tzset+localtime_r` lambda.

## Verification (fresh-context R7, GO)

- **Value-identity 48/48**: `pine_hour`/`pine_minute`/`pine_dayofweek` == old lambda across {UTC, UTC+2, UTC+3, UTC+5, GMT+2, America/New_York, Asia/Kolkata, America/Phoenix} × 6 timestamps. DST anchors correct (NY 8 EDT / 7 EST, Phoenix 5/5, Kolkata 17:30).
- **Corpus**: full `run_corpus.sh` rebuild → corpus submodule **byte-identical**, 0 changed outputs; NEW tiers == baseline (239 exc / 12 strong / 1 anomaly). Zero downward moves.
- **ctest 79/79**.
- **Sentinels**: lukeborgerding exc, stockhunter strong, 3commas-pol-grid exc — unchanged.
- **Blast radius = 5 data/draft offset-tz strategies, 0 corpus**: mylivingedge minimal→**excellent**, ananthanvelmurugan/evrinb7716/ltony excellent (held), andrewwieiw moderate (unchanged). Score 323→324, 0 minimal.

Follow-up to #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)