### PR TITLE
fix(margin): floor restore-qty to lot step BEFORE the 4x over-liquidation (KI-31)

### DIFF
--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -182,22 +182,36 @@ void BacktestEngine::process_margin_call(const Bar& bar) {
     // q units leaves the bar-equity unchanged (realized + open P/L just
     // reclassify) while the required margin shrinks: need
     // (qty - q) * adverse * pv * m <= equity_adv  =>  q >= qty - equity_adv/(adverse*pv*m).
-    const double q_min = qty - equity_adv / (adverse * pv * m);
+    double q_min = qty - equity_adv / (adverse * pv * m);
     if (!std::isfinite(q_min) || q_min <= kQtyEpsilon) return;
-    double qty_liq = 4.0 * q_min;
-    // Per-instrument lot quantization. TradingView floors each forced-
-    // liquidation lot to the instrument's quantity step (verified row-for-row
-    // against the p2 ETHUSDT.P export: every margin-call qty is an exact
-    // multiple of 0.0004). Without this the engine's nibbles are slightly
-    // larger and drain the position in fewer calls, drifting the per-call exit
-    // prices. qty_step_ == 0 (corpus default) leaves qty_liq untouched.
+    // Per-instrument lot quantization. TradingView floors the minimum-restore
+    // qty to the instrument's quantity step BEFORE applying the 4x over-
+    // liquidation — not after. Flooring the 4x PRODUCT instead injects a
+    // ~qty_step/4 error into the first nibble that compounds ~3x per step
+    // through the margin-call cascade (row-diff vs the ETHUSDT.P export,
+    // alpha-wizard-channel percent_of_equity=100: floor-BEFORE reproduces the
+    // first 14 cascade nibbles bit-exact — 7.7232 / 30.3796 / 35.716 / 19.1516
+    // / 53.0532 / 59.69 / … ; floor-AFTER matched 0/19 and desynced by step 7).
+    // qty_step_ == 0 (corpus default; the explicit-leverage p2/5x margin probes
+    // never set it) leaves both q_min and qty_liq untouched -> byte-identical.
     if (qty_step_ > 0.0) {
-        double floored = std::floor(qty_liq / qty_step_) * qty_step_;
+        q_min = std::floor(q_min / qty_step_) * qty_step_;
+    }
+    double qty_liq = 4.0 * q_min;
+    if (qty_step_ > 0.0) {
+        // q_min is already a multiple of qty_step_, so 4*q_min is mathematically
+        // a multiple too — but binary float makes e.g. 4*5.7089 = 22.83559999…,
+        // which a bare std::floor drops a whole lot (→ 22.8355 vs TV's 22.8356).
+        // The +1e-6 epsilon (same guard as quantize_qty in engine.hpp) pins it to
+        // the intended lot. Without it the tail nibbles desync from ~step 14 on;
+        // with it alpha-wizard-channel cascade-1 matches TV 19/19 bit-exact.
+        double floored = std::floor(qty_liq / qty_step_ + 1e-6) * qty_step_;
         if (floored <= kQtyEpsilon) {
             // A liquidation IS required (we passed the margin-shortfall gate)
-            // but the floored lot rounds to zero. Take the smallest step that
-            // still makes progress — one qty_step_, or the full residual if it
-            // is smaller — so the per-bar call loop cannot stall forever.
+            // but the floored lot rounds to zero (sub-lot shortfall). Take the
+            // smallest step that still makes progress — one qty_step_, or the
+            // full residual if it is smaller — so the per-bar call loop cannot
+            // stall forever.
             floored = std::min(qty_step_, qty);
         }
         qty_liq = floored;


### PR DESCRIPTION
## Bug

`process_margin_call` computed the forced-liquidation lot as `floor(4 * q_min / step) * step` — it applied the 4× over-liquidation to the **raw** minimum-restore qty and floored only the product. TradingView floors the restore-qty to the instrument lot step **first**, then multiplies by 4. Flooring after injects a ~step/4 error into the first margin-call nibble that compounds ~3×/step through the cascade.

## Fix (two coupled corrections)

1. Floor `q_min` to `qty_step_` **before** `qty_liq = 4 * q_min`.
2. Epsilon (`+1e-6`) the now-redundant second floor of `4*q_min` (same guard as `quantize_qty`): `4 × (a lot multiple)` is mathematically a lot multiple, but binary float makes e.g. `4*5.7089 = 22.83559999…` which a bare `std::floor` drops a whole lot — desyncing the tail nibbles from ~step 14.

## Verification (fresh-context R7 = GO)

- **Nibble fidelity**: alpha-wizard-channel `percent_of_equity=100` cascade-1 now **19/19 bit-exact** (7.7232 / 30.3796 / 35.716 / … / 22.8356 / …) vs the ETHUSDT.P export; old floor-after matched **0/19** and desynced by step 7.
- **Corpus BYTE-IDENTICAL**: full `run_corpus.sh` → submodule completely clean, 0 changed outputs, tiers 239 exc / 12 strong / 1 anomaly unchanged. `qty_step_ == 0` for the entire corpus + the explicit-leverage p2/5x margin probes (only `verify-engine-local` passes 0.0001), so both floor branches are guarded no-ops there.
- **ctest 79/79**.

## Scope note (honest)

This is a **correctness/fidelity fix, score-neutral**. It does **not** change any scraper strategy's tier: the margin nibbles are exit rows while the grader matches on entries, and the ~40 margin-cascade members fail on entry coverage / are KI-28 indicator-rewrite (provenance-gapped) — not on margin-exit fidelity. It sharpens the ETHUSDT.P `percent_of_equity` margin model to bit-exact TV parity for its own sake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)