### PR TITLE
fix(fills): normalize qty_percent when freezing a deferred layered exit qty

### DIFF
--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -934,6 +934,14 @@ void BacktestEngine::reconcile_deferred_layered_exits(const std::string& entry_i
         double res = std::min(requested, avail);
         if (res <= kQtyEpsilon) continue;  // nothing left to reserve; leave deferred
         o.qty = res;
+        // Keep qty_percent consistent with the qty we just froze. A deferred
+        // 100% sibling capped here to the remaining slice must not keep
+        // qty_percent=100, or a later same-bar/next-bar re-arm of a partial
+        // sibling reads it as a still-pending FULL exit (compute_exit_reserved_
+        // qty guard), drops the re-issued partial, and the 100% leg re-expands
+        // to flatten the whole position. Mirrors the live-armed normalization
+        // at engine_strategy_commands.cpp (reserved_qty_out / live_pos * 100).
+        if (live_pos > kQtyEpsilon) o.qty_percent = (res / live_pos) * 100.0;
         o.requested_partial = res < live_pos - kFullQtyEps;
         reserved += res;
     }


### PR DESCRIPTION
## Summary

A layered `strategy.exit` group (a partial `qty_percent` leg + a 100% sibling) **armed while the position is FLAT** goes through the deferred-reconcile path `reconcile_deferred_layered_exits` (`src/engine_fills.cpp:922-939`). That path froze each leg's `o.qty` to its reserved slice but **left the 100% sibling's `o.qty_percent` at 100**.

On a later per-bar re-arm of the partial sibling, the `compute_exit_reserved_qty` guard (`src/engine_strategy_commands.cpp:1023-1033`) read that stale `qty_percent=100` as a still-pending **full** exit, dropped the re-issued partial, and the 100% leg re-expanded to flatten the whole position at its stop — over-closing a `TP1(50%) + TP2(100%)` bracket (100% single close instead of two 50% legs).

## Fix

Set `o.qty_percent` consistent with the `o.qty` reconcile already froze (one line, mirrors the live-armed normalization at `engine_strategy_commands.cpp:1020`):

```cpp
if (live_pos > kQtyEpsilon) o.qty_percent = (res / live_pos) * 100.0;
```

Gated by reconcile's existing `leg_count >= 2 && has_partial` condition. **Live-armed** layered exits (armed inside `if position_size > 0`) never enter reconcile — they normalize at arm time — so they are untouched, as are non-layered brackets.

## Gate (fresh-context R7)

- `cmake --build build --target pineforge` clean
- `ctest`: **79/79** passing
- `run_corpus.sh`: **239 excellent / 12 strong / 1 anomaly**, `fail=0` — corpus artifacts **byte-identical** (the deferred-layered path has no corpus coverage; golden `bracket-partial-exit-qty-percent-01` is live-armed)
- scraper data sweep across 8 `qty_percent` sentinels + 2 3commas DCA/grid: **0 up / 0 down**, `run_err=0`

The originating strategy is coverage-capped by an unrelated HTF-warmup ceiling, so this is a correctness/fidelity fix rather than a scoreboard move; ~15 data/ layered-exit strategies exercise the construct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)