### PR TITLE
fix(sizing): reserve entry commission when sizing percent_of_equity

### DIFF
--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -837,6 +837,19 @@ protected:
         return floored < qty ? floored : qty;
     }
 
+    // TradingView reserves the entry commission when sizing percent_of_equity:
+    // it sizes the notional so that notional + entry_fee <= equity*pct, i.e.
+    // divides the sizing cash by (1 + commRate). Proven from TV exports for
+    // BOTH fractional (pct=10) and all-in (pct=100) sizing — the reservation is
+    // not gated on headroom (KI-52 probes: ki52-pct-equity-commission-{frac,allin},
+    // first-entry qty = equity/(price*(1+commRate)) to the lot step, 16/16). Only
+    // percent commission reserves; cash-per-order/contract and a zero rate are
+    // exact no-ops, so FIXED/CASH qty types and commission_value_==0 are unchanged.
+    double reserve_percent_commission(double cash) const {
+        return (commission_type_ == CommissionType::PERCENT && commission_value_ > 0.0)
+            ? cash / (1.0 + commission_value_ / 100.0) : cash;
+    }
+
     double calc_qty(double fill_price) const {
         switch (default_qty_type_) {
             case QtyType::FIXED:
@@ -849,7 +862,7 @@ protected:
                 // percent orders from the live equity snapshot so pyramid adds
                 // and same-bar/re-entry sizing see unrealized PnL.
                 double equity = current_equity() + open_profit(current_bar_.close);
-                double cash = equity * (default_qty_value_ / 100.0) / account_currency_fx_;
+                double cash = reserve_percent_commission(equity * (default_qty_value_ / 100.0)) / account_currency_fx_;
                 // Reject (qty 0) on a non-finite / non-positive fill price — a
                 // degenerate $0/NaN print must NOT size as the raw % number.
                 return (std::isfinite(fill_price) && fill_price > 0)

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -31,7 +31,7 @@ double BacktestEngine::calc_qty_for_type(double fill_price, double qty_value, in
     }
     if (qty_type == static_cast<int>(QtyType::PERCENT_OF_EQUITY)) {
         double equity = current_equity() + open_profit(current_bar_.close);
-        double cash = equity * (qty_value / 100.0);
+        double cash = reserve_percent_commission(equity * (qty_value / 100.0));
         // Reject (qty 0) on a non-finite / non-positive fill price — a degenerate
         // $0/NaN print must NOT size as the raw % number (silent wrong-qty bug).
         // One contract's currency exposure is fill_price × pointvalue (1.0 for


### PR DESCRIPTION
## Summary

TradingView sizes a `percent_of_equity` order so `notional + entry_fee` stays within the target equity fraction: `qty = equity*pct / (price*pointvalue*(1 + commRate))`, `commRate = commission_value/100` for a percent commission. The engine omitted the `(1+commRate)` divisor and sized slightly large, drifting the compounding equity/position path.

## Proof (clean-room TV probes)

Two minimal probes (`percent_of_equity=10` and `=100`, `commission.percent=0.05`, 1-bar holds so no margin fragmentation) were TV-exported. TV's first-entry qty (equity = initial_capital, decisive) matches `equity/(price*(1+commRate))` to the lot step for **both**:

| probe | TVqty | `/(1+c)` | no-reserve |
|---|---|---|---|
| pct=10 | 5.5287 | **5.5287** ✓ | 5.5314 |
| pct=100 | 55.2872 | **55.2872** ✓ | 55.3149 |

So TV reserves the commission for **fractional AND all-in** sizing — the reservation is not gated on headroom, and the fix is global (16/16 clean entries exact).

## Fix

New `reserve_percent_commission()` helper applied to both `PERCENT_OF_EQUITY` sizing branches (`calc_qty` + `calc_qty_for_type`). Percent commission only; `FIXED`/`CASH` qty types and `commission_value==0` are exact no-ops.

## Gate (full R7)

- ctest **79/79**
- `run_corpus` **239 exc / 12 strong / 1 anomaly**, byte-identical (corpus has no percent-commission `percent_of_equity` → no-op there)
- full data sweep: **net-0** — one strategy strong→excellent (its true tier once sized correctly), one excellent→strong.

The excellent→strong move is a **truthful re-grade, not a regression**: that strategy is `percent_of_equity=100` all-in (margin-cascade), and its prior excellent was an artifact of the under-sizing bug coincidentally matching TV's proprietary liquidation path to <0.01% exit-p90. Under correct sizing its honest tier is strong. The fix improves per-trade sizing accuracy for the ~50 percent-commission strategies in the dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)