### PR TITLE
Compose historical HTF projection with range-start warmup

### DIFF
--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1687,8 +1687,10 @@ protected:
         // One entry per projected HTF bucket, populated only for an explicitly
         // opted-in finite historical batch. Empty for every default/streaming
         // run and for sites outside the narrow HTF lookahead_on+gaps_off
-        // contract. The feed index advances once per input bar; the projection
-        // cursor advances only at the next bucket's first child.
+        // contract. The feed index advances once per retained input bar (bars
+        // before an opt-in security range start are dropped by both producer
+        // and consumer); the projection cursor advances only at the next
+        // bucket's first child.
         std::vector<HistoricalSecurityProjection> historical_projections;
         std::size_t historical_projection_cursor = 0;
         std::size_t historical_projection_feed_index = 0;

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -750,6 +750,13 @@ protected:
     // byte-identical behavior; touched only through feed_security_eval_state.
     bool security_range_start_na_warmup_ = false;
     int64_t security_range_start_ms_ = 0;
+    // Opt-in historical-only request.security lookahead projection. TradingView
+    // can merge a completed higher-timeframe bar onto the first chart child
+    // when a finite historical batch is already known. The normal engine path
+    // remains progressive, and stream warmup/realtime deliberately ignore this
+    // selector so future data can never leak into a live continuation.
+    bool historical_security_lookahead_projection_ = false;
+    bool historical_security_lookahead_projection_active_ = false;
     int64_t next_order_seq_ = 1;
     // TV: at most one priced ENTRY "open" event per bar; persists across
     // multiple process_pending_orders calls (bar magnifier) and dual-pass
@@ -1570,6 +1577,12 @@ protected:
     bool stream_script_tick_seen_ = false;
 
     // --- request.security state ---
+    struct HistoricalSecurityProjection {
+        Bar bar{};
+        std::size_t first_child_index = 0;
+        bool is_complete = false;
+    };
+
     struct SecurityEvalState {
         int sec_id = 0;
         std::string tf;
@@ -1671,6 +1684,14 @@ protected:
         // lookahead_off — the already-correct cases) and leaves behavior
         // unchanged.
         int publish_gate_tf_seconds = 0;
+        // One entry per projected HTF bucket, populated only for an explicitly
+        // opted-in finite historical batch. Empty for every default/streaming
+        // run and for sites outside the narrow HTF lookahead_on+gaps_off
+        // contract. The feed index advances once per input bar; the projection
+        // cursor advances only at the next bucket's first child.
+        std::vector<HistoricalSecurityProjection> historical_projections;
+        std::size_t historical_projection_cursor = 0;
+        std::size_t historical_projection_feed_index = 0;
     };
 
     std::vector<SecurityEvalState> security_eval_states_;
@@ -2125,6 +2146,10 @@ private:
     int  count_expected_script_bars(const Bar* input_bars, int n_input,
                                     bool needs_aggregation) const;
     void init_security_eval_states_for_run(const std::string& effective_input_tf);
+    void prepare_historical_security_lookahead_projections(
+        const Bar* input_bars, int n_input,
+        const std::string& effective_input_tf);
+    void clear_historical_security_lookahead_projections();
     // Runs the standard per-script-bar order/strategy sequence on current_bar_:
     //   process_pending_orders -> update_per_trade_extremes -> on_bar,
     // plus a second process_pending_orders when process_orders_on_close_ is set
@@ -2321,6 +2346,14 @@ public:
                 security_range_start_na_warmup_ = false;
                 security_range_start_ms_ = 0;
             }
+        }
+        // Historical batch-only lookahead projection. This is intentionally a
+        // default-off verifier candidate: regular execution and every stream
+        // path keep progressive HTF aggregation unless a caller explicitly
+        // supplies a positive finite metadata value.
+        if (key == "historical_security_lookahead_projection") {
+            historical_security_lookahead_projection_ =
+                std::isfinite(value) && value > 0.0;
         }
         // "qty_step" is the per-instrument lot increment used by the forced-
         // liquidation quantizer. Route it onto the dedicated member so the

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -1028,6 +1028,8 @@ void BacktestEngine::run(const Bar* input_bars, int n_input,
     validate_security_timeframes(effective_input_tf);
 
     init_security_eval_states_for_run(effective_input_tf);
+    prepare_historical_security_lookahead_projections(
+        input_bars, n_input, effective_input_tf);
 
     if (!needs_aggregation && !bar_magnifier) {
         run_simple_bar_loop(input_bars, n_input);
@@ -1035,9 +1037,12 @@ void BacktestEngine::run(const Bar* input_bars, int n_input,
         run_aggregation_bar_loop(input_bars, n_input, bar_magnifier,
                                  expected_script_bars);
     }
+    clear_historical_security_lookahead_projections();
     } catch (const std::exception& e) {
+        clear_historical_security_lookahead_projections();
         last_error_ = e.what();
     } catch (...) {
+        clear_historical_security_lookahead_projections();
         last_error_ = "unknown error during BacktestEngine::run";
     }
 }
@@ -1076,6 +1081,9 @@ void BacktestEngine::init_security_eval_states_for_run(
         state.current_sub_bar_count = 0;
         state.lower_tf_sub_bar_index = 0;
         state.lower_tf_input_buffer.clear();
+        state.historical_projections.clear();
+        state.historical_projection_cursor = 0;
+        state.historical_projection_feed_index = 0;
         state.aggregator = TimeframeAggregator();
         if (state.lower_tf_emulation || state.lower_tf_use_input) {
             continue;
@@ -1086,6 +1094,124 @@ void BacktestEngine::init_security_eval_states_for_run(
         } else if (req_ratio == -1) {
             state.aggregator = TimeframeAggregator(state.tf, effective_input_tf);
         }
+    }
+}
+
+
+// Build the finite-batch oracle used by the opt-in historical lookahead
+// candidate. Each eligible HTF bucket is aggregated from all input bars that
+// are available in the batch and stored once with its first-child index. The
+// evaluator is dispatched only at that index (engine_security.cpp), so the
+// value is projected there and held for the rest of the bucket. A trailing
+// bucket that has not reached its natural boundary is still projected from the
+// available bars, but remains an incomplete evaluation so committed security
+// history does not advance prematurely.
+void BacktestEngine::prepare_historical_security_lookahead_projections(
+        const Bar* input_bars, int n_input,
+        const std::string& effective_input_tf) {
+    clear_historical_security_lookahead_projections();
+
+    const int input_seconds = tf_to_seconds(effective_input_tf);
+    const int script_seconds = script_tf_seconds_;
+    if (!historical_security_lookahead_projection_
+            || stream_warmup_mode_
+            // The finite-batch oracle is built from raw input bars. Until it
+            // can consume script-TF aggregates, activating it across a
+            // separate input->script aggregation stage would project the
+            // wrong child indexes and values.
+            || effective_input_tf != script_tf_
+            // Range-start warmup deliberately drops pre-range bars inside
+            // feed_security_eval_state(). Precomputing them here would leave
+            // the projection cursor out of sync with that trimmed feed.
+            || security_range_start_na_warmup_
+            || input_bars == nullptr || n_input <= 0
+            || input_seconds <= 0 || script_seconds <= 0) {
+        return;
+    }
+
+    historical_security_lookahead_projection_active_ = true;
+    const int64_t input_ms = static_cast<int64_t>(input_seconds) * 1000;
+
+    for (auto& state : security_eval_states_) {
+        const int requested_seconds = tf_to_seconds(state.tf);
+        const bool eligible = !state.lower_tf_requested
+            && !state.lower_tf_emulation
+            && !state.lower_tf_use_input
+            && state.lookahead_on
+            && !state.gaps_on
+            && !state.heikinashi
+            && requested_seconds > script_seconds;
+        if (!eligible) {
+            continue;
+        }
+
+        const int expected_children = std::max(
+            1, requested_seconds / input_seconds);
+        state.historical_projections.reserve(static_cast<std::size_t>(
+            n_input / expected_children + 1));
+        state.historical_projection_cursor = 0;
+        state.historical_projection_feed_index = 0;
+
+        auto crosses_requested_boundary = [&](int64_t from_ms,
+                                               int64_t to_ms) {
+            // tf_change treats epoch zero as an uninitialized sentinel. Keep
+            // tests/synthetic feeds beginning at zero correct via the fixed-TF
+            // bucket fallback; real feeds take the calendar-aware path.
+            if (from_ms != 0 && to_ms != 0) {
+                return tf_change(from_ms, to_ms, state.tf);
+            }
+            const int64_t requested_ms =
+                static_cast<int64_t>(requested_seconds) * 1000;
+            return requested_ms > 0
+                && from_ms / requested_ms != to_ms / requested_ms;
+        };
+
+        auto merge = [](Bar& aggregate, const Bar& child) {
+            aggregate.high = std::max(aggregate.high, child.high);
+            aggregate.low = std::min(aggregate.low, child.low);
+            aggregate.close = child.close;
+            aggregate.volume += child.volume;
+        };
+
+        auto publish_group = [&](int begin, const Bar& aggregate,
+                                 bool is_complete) {
+            state.historical_projections.push_back(
+                HistoricalSecurityProjection{
+                    aggregate, static_cast<std::size_t>(begin), is_complete});
+        };
+
+        int group_begin = 0;
+        Bar aggregate = input_bars[0];
+        for (int i = 1; i < n_input; ++i) {
+            if (crosses_requested_boundary(aggregate.timestamp,
+                                           input_bars[i].timestamp)) {
+                // A later bucket proves this group is historical/confirmed,
+                // even when sparse input omitted its natural final child.
+                publish_group(group_begin, aggregate, true);
+                group_begin = i;
+                aggregate = input_bars[i];
+            } else {
+                merge(aggregate, input_bars[i]);
+            }
+        }
+
+        bool final_complete = false;
+        const int64_t last_timestamp = input_bars[n_input - 1].timestamp;
+        if (last_timestamp <= std::numeric_limits<int64_t>::max() - input_ms) {
+            final_complete = crosses_requested_boundary(
+                last_timestamp, last_timestamp + input_ms);
+        }
+        publish_group(group_begin, aggregate, final_complete);
+    }
+}
+
+
+void BacktestEngine::clear_historical_security_lookahead_projections() {
+    historical_security_lookahead_projection_active_ = false;
+    for (auto& state : security_eval_states_) {
+        state.historical_projections.clear();
+        state.historical_projection_cursor = 0;
+        state.historical_projection_feed_index = 0;
     }
 }
 

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -1120,17 +1120,33 @@ void BacktestEngine::prepare_historical_security_lookahead_projections(
             // separate input->script aggregation stage would project the
             // wrong child indexes and values.
             || effective_input_tf != script_tf_
-            // Range-start warmup deliberately drops pre-range bars inside
-            // feed_security_eval_state(). Precomputing them here would leave
-            // the projection cursor out of sync with that trimmed feed.
-            || security_range_start_na_warmup_
             || input_bars == nullptr || n_input <= 0
             || input_seconds <= 0 || script_seconds <= 0) {
         return;
     }
 
+    // Range-start warmup drops every earlier input in
+    // feed_security_eval_state(). Build the projection from that exact same
+    // retained suffix and store child indexes relative to it: the per-state
+    // feed cursor likewise starts at zero on the first retained child because
+    // the early-return path never increments it. This composes the two
+    // independently opt-in historical semantics without exposing a pre-range
+    // aggregate or shifting the first projected bucket.
+    int projection_begin = 0;
+    if (security_range_start_na_warmup_) {
+        while (projection_begin < n_input
+                && input_bars[projection_begin].timestamp
+                    < security_range_start_ms_) {
+            ++projection_begin;
+        }
+        if (projection_begin >= n_input) {
+            return;
+        }
+    }
+
     historical_security_lookahead_projection_active_ = true;
     const int64_t input_ms = static_cast<int64_t>(input_seconds) * 1000;
+    const int projection_count = n_input - projection_begin;
 
     for (auto& state : security_eval_states_) {
         const int requested_seconds = tf_to_seconds(state.tf);
@@ -1148,7 +1164,7 @@ void BacktestEngine::prepare_historical_security_lookahead_projections(
         const int expected_children = std::max(
             1, requested_seconds / input_seconds);
         state.historical_projections.reserve(static_cast<std::size_t>(
-            n_input / expected_children + 1));
+            projection_count / expected_children + 1));
         state.historical_projection_cursor = 0;
         state.historical_projection_feed_index = 0;
 
@@ -1181,14 +1197,15 @@ void BacktestEngine::prepare_historical_security_lookahead_projections(
         };
 
         int group_begin = 0;
-        Bar aggregate = input_bars[0];
-        for (int i = 1; i < n_input; ++i) {
+        Bar aggregate = input_bars[projection_begin];
+        for (int i = projection_begin + 1; i < n_input; ++i) {
+            const int retained_child_index = i - projection_begin;
             if (crosses_requested_boundary(aggregate.timestamp,
                                            input_bars[i].timestamp)) {
                 // A later bucket proves this group is historical/confirmed,
                 // even when sparse input omitted its natural final child.
                 publish_group(group_begin, aggregate, true);
-                group_begin = i;
+                group_begin = retained_child_index;
                 aggregate = input_bars[i];
             } else {
                 merge(aggregate, input_bars[i]);

--- a/src/engine_security.cpp
+++ b/src/engine_security.cpp
@@ -295,6 +295,28 @@ void BacktestEngine::feed_security_eval_state(SecurityEvalState& state, const Ba
         ~SecurityNaWarmupScope() { ta::ema_na_warmup_flag() = prev_; }
     } _na_warmup_scope(security_range_start_na_warmup_);
 
+    // Heikin-Ashi same-symbol read: replace an aggregated bar's OHLC with its
+    // HA candle before evaluating the security expression. The completed
+    // state advances once per committed HTF bucket; a partial/projection peek
+    // derives from the prior state without committing it.
+    auto apply_ha = [&state](Bar& b, bool commit) {
+        double ha_close = (b.open + b.high + b.low + b.close) / 4.0;
+        double ha_open = state.ha_seeded
+                             ? (state.ha_prev_open + state.ha_prev_close) / 2.0
+                             : (b.open + b.close) / 2.0;
+        double ha_high = std::max(b.high, std::max(ha_open, ha_close));
+        double ha_low = std::min(b.low, std::min(ha_open, ha_close));
+        b.open = ha_open;
+        b.high = ha_high;
+        b.low = ha_low;
+        b.close = ha_close;
+        if (commit) {
+            state.ha_prev_open = ha_open;
+            state.ha_prev_close = ha_close;
+            state.ha_seeded = true;
+        }
+    };
+
     if (state.lower_tf_use_input) {
         // Buffer raw input bars until we accumulate one full script-TF
         // chunk, then aggregate (if req > input) and dispatch each
@@ -427,36 +449,49 @@ void BacktestEngine::feed_security_eval_state(SecurityEvalState& state, const Ba
         return;
     }
 
+    if (historical_security_lookahead_projection_active_
+            && !state.historical_projections.empty()) {
+        const std::size_t feed_index =
+            state.historical_projection_feed_index++;
+        while (state.historical_projection_cursor + 1
+                    < state.historical_projections.size()
+                && state.historical_projections[
+                       state.historical_projection_cursor + 1]
+                       .first_child_index <= feed_index) {
+            ++state.historical_projection_cursor;
+        }
+        const auto& projection = state.historical_projections[
+            state.historical_projection_cursor];
+        state.feed_count++;
+        if (projection.first_child_index != feed_index) {
+            // gaps_off holds the first-child projection unchanged until the
+            // next HTF bucket. No evaluator call means TA/security histories
+            // also advance exactly once per projected bucket.
+            return;
+        }
+
+        Bar projected_bar = projection.bar;
+        if (state.heikinashi) {
+            apply_ha(projected_bar, projection.is_complete);
+        }
+        state.current_bar = projected_bar;
+        // The projected HTF bucket is introduced on its first chart child, so
+        // generated security series must allocate a fresh history/TA slot even
+        // though projected_bar itself already contains every available child.
+        state.current_sub_bar_count = 1;
+        if (projection.is_complete) {
+            state.eval_complete_count++;
+        } else {
+            state.eval_partial_count++;
+        }
+        evaluate_security(state.sec_id, projected_bar,
+                          projection.is_complete);
+        return;
+    }
+
     AggregatedBar ab = state.aggregator.feed(input_bar);
     state.feed_count++;
     state.current_sub_bar_count = ab.sub_bar_count;
-    // Heikin-Ashi same-symbol read: replace the completed (aggregated) bar's
-    // OHLC with its HA candle before evaluating the security expression, so
-    // close/open/high/low inside request.security see HA values (TradingView
-    // ticker.heikinashi semantics):
-    //   haClose = (O+H+L+C)/4
-    //   haOpen  = seeded ? (prevHaOpen+prevHaClose)/2 : (O+C)/2
-    //   haHigh  = max(H, haOpen, haClose);  haLow = min(L, haOpen, haClose)
-    // HA is stateful; the running open/close advance once per COMPLETED bar
-    // (committed below). A partial lookahead peek derives from prior state
-    // without advancing it. The lambda mutates ab.bar in place.
-    auto apply_ha = [&state](Bar& b, bool commit) {
-        double ha_close = (b.open + b.high + b.low + b.close) / 4.0;
-        double ha_open = state.ha_seeded
-                             ? (state.ha_prev_open + state.ha_prev_close) / 2.0
-                             : (b.open + b.close) / 2.0;
-        double ha_high = std::max(b.high, std::max(ha_open, ha_close));
-        double ha_low = std::min(b.low, std::min(ha_open, ha_close));
-        b.open = ha_open;
-        b.high = ha_high;
-        b.low = ha_low;
-        b.close = ha_close;
-        if (commit) {
-            state.ha_prev_open = ha_open;
-            state.ha_prev_close = ha_close;
-            state.ha_seeded = true;
-        }
-    };
     if (ab.is_complete) {
         if (state.heikinashi) apply_ha(ab.bar, /*commit=*/true);
         state.current_bar = ab.bar;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_SOURCES
     test_dmi_parity
     test_integration
     test_request_security
+    test_historical_security_lookahead_projection
     test_security_range_start_na_warmup
     test_security_tf_validation
     test_security_lower_tf_input_passthrough

--- a/tests/test_historical_security_lookahead_projection.cpp
+++ b/tests/test_historical_security_lookahead_projection.cpp
@@ -1,0 +1,330 @@
+// Pins the default-off historical batch projection for regular HTF
+// request.security(..., gaps_off, lookahead_on) sites.
+
+#include <pineforge/engine.hpp>
+#include <pineforge/na.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace pineforge;
+
+namespace {
+
+int failures = 0;
+
+#define CHECK(cond, tag) do { \
+    if (!(cond)) { \
+        std::printf("FAIL: %s (line %d)\n", (tag), __LINE__); \
+        ++failures; \
+    } \
+} while (0)
+
+bool same(double lhs, double rhs) {
+    if (is_na(lhs) && is_na(rhs)) return true;
+    if (is_na(lhs) || is_na(rhs)) return false;
+    return lhs == rhs;
+}
+
+struct Dispatch {
+    Bar bar;
+    bool complete;
+};
+
+class ProjectionHarness final : public BacktestEngine {
+public:
+    explicit ProjectionHarness(bool lookahead_on = true, bool gaps_on = false,
+                               const char* requested_tf = "60",
+                               bool heikinashi = false) {
+        register_security_eval(0, requested_tf, "15", lookahead_on, gaps_on,
+                               heikinashi);
+    }
+
+    void evaluate_security(int sec_id, const Bar& bar,
+                           bool is_complete) override {
+        CHECK(sec_id == 0, "security id");
+        dispatches.push_back(Dispatch{bar, is_complete});
+        visible_close = bar.close;
+    }
+
+    void on_bar(const Bar&) override {
+        chart_values.push_back(visible_close);
+    }
+
+    std::vector<Dispatch> dispatches;
+    std::vector<double> chart_values;
+    double visible_close = na<double>();
+};
+
+std::vector<Bar> make_feed() {
+    // One complete 60m bucket (01:00..01:45) and one incomplete tail
+    // (02:00..02:15), both composed from 15m chart bars.
+    return {
+        Bar{10.0, 11.0,  9.0, 10.0, 1.0,  3'600'000},
+        Bar{10.0, 22.0,  8.0, 20.0, 2.0,  4'500'000},
+        Bar{20.0, 33.0,  7.0, 30.0, 3.0,  5'400'000},
+        Bar{30.0, 44.0,  6.0, 40.0, 4.0,  6'300'000},
+        Bar{40.0, 55.0, 35.0, 50.0, 5.0,  7'200'000},
+        Bar{50.0, 66.0, 34.0, 60.0, 6.0,  8'100'000},
+    };
+}
+
+std::vector<Bar> make_5m_feed() {
+    std::vector<Bar> bars;
+    bars.reserve(12);
+    for (int i = 0; i < 12; ++i) {
+        const double close = static_cast<double>(i + 1);
+        const int64_t timestamp = 3'600'000
+            + static_cast<int64_t>(i) * 300'000;
+        bars.push_back(Bar{close, close, close, close, 1.0, timestamp});
+    }
+    return bars;
+}
+
+void test_default_remains_progressive() {
+    ProjectionHarness harness;
+    const auto bars = make_feed();
+    harness.run(bars.data(), static_cast<int>(bars.size()), "15", "15");
+
+    CHECK(harness.last_error().empty(), "default run succeeds");
+    CHECK(harness.dispatches.size() == 6,
+          "default lookahead dispatches every progressive child");
+    const double expected[] = {10, 20, 30, 40, 50, 60};
+    for (std::size_t i = 0; i < harness.dispatches.size() && i < 6; ++i) {
+        CHECK(same(harness.dispatches[i].bar.close, expected[i]),
+              "default progressive close sequence");
+        CHECK(harness.dispatches[i].complete == (i == 3),
+              "default completion cadence");
+        CHECK(same(harness.chart_values[i], expected[i]),
+              "default chart sees progressive value");
+    }
+}
+
+void test_flag_projects_full_bucket_then_holds() {
+    ProjectionHarness harness;
+    harness.set_syminfo_metadata(
+        "historical_security_lookahead_projection", 1.0);
+    const auto bars = make_feed();
+    harness.run(bars.data(), static_cast<int>(bars.size()), "15", "15");
+
+    CHECK(harness.last_error().empty(), "projected run succeeds");
+    CHECK(harness.dispatches.size() == 2,
+          "one projected dispatch per HTF bucket");
+    CHECK(harness.dispatches[0].complete,
+          "full historical bucket is committed");
+    CHECK(same(harness.dispatches[0].bar.open, 10.0), "projected full open");
+    CHECK(same(harness.dispatches[0].bar.high, 44.0), "projected full high");
+    CHECK(same(harness.dispatches[0].bar.low, 6.0), "projected full low");
+    CHECK(same(harness.dispatches[0].bar.close, 40.0), "projected full close");
+    CHECK(same(harness.dispatches[0].bar.volume, 10.0), "projected full volume");
+
+    const double expected_chart[] = {40, 40, 40, 40, 60, 60};
+    CHECK(harness.chart_values.size() == 6, "all chart children dispatched");
+    for (std::size_t i = 0; i < harness.chart_values.size() && i < 6; ++i) {
+        CHECK(same(harness.chart_values[i], expected_chart[i]),
+              "projection is visible on first child and held");
+    }
+}
+
+void test_incomplete_tail_projects_available_aggregate() {
+    ProjectionHarness harness;
+    harness.set_syminfo_metadata(
+        "historical_security_lookahead_projection", 1.0);
+    const auto bars = make_feed();
+    harness.run(bars.data(), static_cast<int>(bars.size()), "15", "15");
+
+    CHECK(harness.dispatches.size() == 2, "tail projection exists");
+    if (harness.dispatches.size() == 2) {
+        const Dispatch& tail = harness.dispatches[1];
+        CHECK(!tail.complete, "incomplete tail does not commit history");
+        CHECK(same(tail.bar.open, 40.0), "tail available open");
+        CHECK(same(tail.bar.high, 66.0), "tail available high");
+        CHECK(same(tail.bar.low, 34.0), "tail available low");
+        CHECK(same(tail.bar.close, 60.0), "tail available close");
+        CHECK(same(tail.bar.volume, 11.0), "tail available volume");
+    }
+}
+
+void test_lookahead_off_ignores_projection_flag() {
+    ProjectionHarness harness(/*lookahead_on=*/false, /*gaps_on=*/false);
+    harness.set_syminfo_metadata(
+        "historical_security_lookahead_projection", 1.0);
+    const auto bars = make_feed();
+    harness.run(bars.data(), static_cast<int>(bars.size()), "15", "15");
+
+    CHECK(harness.dispatches.size() == 1,
+          "lookahead_off keeps completion-only behavior");
+    CHECK(harness.dispatches.empty() || harness.dispatches[0].complete,
+          "lookahead_off dispatch is committed");
+    CHECK(harness.dispatches.empty()
+              || same(harness.dispatches[0].bar.close, 40.0),
+          "lookahead_off completed close unchanged");
+    const double expected_chart[] = {
+        na<double>(), na<double>(), na<double>(), 40.0, 40.0, 40.0,
+    };
+    for (std::size_t i = 0; i < harness.chart_values.size() && i < 6; ++i) {
+        CHECK(same(harness.chart_values[i], expected_chart[i]),
+              "lookahead_off chart sequence unchanged");
+    }
+}
+
+void test_gaps_on_ignores_projection_flag() {
+    ProjectionHarness harness(/*lookahead_on=*/true, /*gaps_on=*/true);
+    harness.set_syminfo_metadata(
+        "historical_security_lookahead_projection", 1.0);
+    const auto bars = make_feed();
+    harness.run(bars.data(), static_cast<int>(bars.size()), "15", "15");
+
+    CHECK(harness.dispatches.size() == 6,
+          "gaps_on keeps progressive lookahead behavior");
+    const double expected[] = {10, 20, 30, 40, 50, 60};
+    for (std::size_t i = 0; i < harness.dispatches.size() && i < 6; ++i) {
+        CHECK(same(harness.dispatches[i].bar.close, expected[i]),
+              "gaps_on progressive close sequence unchanged");
+    }
+}
+
+void test_equal_timeframe_ignores_projection_flag() {
+    ProjectionHarness harness(/*lookahead_on=*/true, /*gaps_on=*/false,
+                              /*requested_tf=*/"15");
+    harness.set_syminfo_metadata(
+        "historical_security_lookahead_projection", 1.0);
+    const auto bars = make_feed();
+    harness.run(bars.data(), static_cast<int>(bars.size()), "15", "15");
+
+    CHECK(harness.dispatches.size() == 6,
+          "equal timeframe remains passthrough");
+    for (std::size_t i = 0; i < harness.dispatches.size() && i < bars.size(); ++i) {
+        CHECK(same(harness.dispatches[i].bar.close, bars[i].close),
+              "equal timeframe close unchanged");
+        CHECK(harness.dispatches[i].complete,
+              "equal timeframe dispatch stays complete");
+    }
+}
+
+void test_heikinashi_ignores_projection_flag() {
+    ProjectionHarness harness(/*lookahead_on=*/true, /*gaps_on=*/false,
+                              /*requested_tf=*/"60", /*heikinashi=*/true);
+    harness.set_syminfo_metadata(
+        "historical_security_lookahead_projection", 1.0);
+    const auto bars = make_feed();
+    harness.run(bars.data(), static_cast<int>(bars.size()), "15", "15");
+
+    CHECK(harness.dispatches.size() == 6,
+          "Heikin-Ashi security remains on its established progressive path");
+}
+
+void test_input_tf_below_script_tf_ignores_projection_flag() {
+    ProjectionHarness harness;
+    harness.set_syminfo_metadata(
+        "historical_security_lookahead_projection", 1.0);
+    const auto bars = make_5m_feed();
+    harness.run(bars.data(), static_cast<int>(bars.size()), "5", "15");
+
+    CHECK(harness.last_error().empty(), "5m-to-15m run succeeds");
+    CHECK(harness.dispatches.size() == 12,
+          "input-to-script aggregation keeps security progressive");
+    for (std::size_t i = 0;
+         i < harness.dispatches.size() && i < bars.size(); ++i) {
+        CHECK(same(harness.dispatches[i].bar.close, bars[i].close),
+              "raw input security close remains progressive");
+    }
+
+    const double expected_chart[] = {3.0, 6.0, 9.0, 12.0};
+    CHECK(harness.chart_values.size() == 4,
+          "5m input produces four 15m script bars");
+    for (std::size_t i = 0;
+         i < harness.chart_values.size() && i < 4; ++i) {
+        CHECK(same(harness.chart_values[i], expected_chart[i]),
+              "15m script sees latest progressive security close");
+    }
+}
+
+void test_range_start_warmup_ignores_projection_flag() {
+    ProjectionHarness harness;
+    harness.set_syminfo_metadata(
+        "historical_security_lookahead_projection", 1.0);
+    // Drop the first 15m input bar. The established warmup path then builds a
+    // three-child partial 60m bucket before committing it at the next hour.
+    harness.set_syminfo_metadata(
+        "security_range_start_na_warmup", 4'500'000.0);
+    const auto bars = make_feed();
+    harness.run(bars.data(), static_cast<int>(bars.size()), "15", "15");
+
+    CHECK(harness.last_error().empty(), "range-start composition run succeeds");
+    CHECK(harness.dispatches.size() == 5,
+          "range-start warmup keeps trimmed security feed progressive");
+    const double expected_close[] = {20.0, 30.0, 40.0, 40.0, 60.0};
+    const bool expected_complete[] = {false, false, false, true, false};
+    for (std::size_t i = 0;
+         i < harness.dispatches.size() && i < 5; ++i) {
+        CHECK(same(harness.dispatches[i].bar.close, expected_close[i]),
+              "range-start progressive close sequence");
+        CHECK(harness.dispatches[i].complete == expected_complete[i],
+              "range-start completion cadence");
+    }
+}
+
+void test_stream_warmup_and_continuation_stay_progressive() {
+    ProjectionHarness harness;
+    harness.set_syminfo_metadata(
+        "historical_security_lookahead_projection", 1.0);
+    const auto bars = make_feed();
+
+    CHECK(harness.stream_begin(bars.data(), 4, "15", "15"),
+          "stream begin succeeds");
+    CHECK(harness.dispatches.size() == 4,
+          "stream warmup ignores historical projection");
+    const double warmup_expected[] = {10, 20, 30, 40};
+    for (std::size_t i = 0; i < harness.dispatches.size() && i < 4; ++i) {
+        CHECK(same(harness.dispatches[i].bar.close, warmup_expected[i]),
+              "stream warmup stays progressive");
+    }
+
+    CHECK(harness.stream_push_tick(
+              TradeTick{7'200'000, 1, 50.0, 5.0}),
+          "first realtime tick accepted");
+    CHECK(harness.stream_advance_time(8'100'000),
+          "first realtime input bar finalized");
+    CHECK(harness.dispatches.size() == 5,
+          "realtime continuation dispatches next partial");
+    CHECK(same(harness.dispatches.back().bar.close, 50.0),
+          "realtime continuation exposes available close");
+    CHECK(!harness.dispatches.back().complete,
+          "realtime continuation remains partial");
+
+    CHECK(harness.stream_push_tick(
+              TradeTick{8'100'000, 2, 60.0, 6.0}),
+          "second realtime tick accepted");
+    CHECK(harness.stream_advance_time(9'000'000),
+          "second realtime input bar finalized");
+    CHECK(harness.dispatches.size() == 6,
+          "second realtime partial dispatched");
+    CHECK(same(harness.dispatches.back().bar.close, 60.0),
+          "realtime aggregation advances progressively");
+    CHECK(!harness.dispatches.back().complete,
+          "second realtime bar is still partial");
+    CHECK(harness.stream_end(), "stream ends cleanly");
+}
+
+}  // namespace
+
+int main() {
+    test_default_remains_progressive();
+    test_flag_projects_full_bucket_then_holds();
+    test_incomplete_tail_projects_available_aggregate();
+    test_lookahead_off_ignores_projection_flag();
+    test_gaps_on_ignores_projection_flag();
+    test_equal_timeframe_ignores_projection_flag();
+    test_heikinashi_ignores_projection_flag();
+    test_input_tf_below_script_tf_ignores_projection_flag();
+    test_range_start_warmup_ignores_projection_flag();
+    test_stream_warmup_and_continuation_stay_progressive();
+    if (failures != 0) {
+        std::printf("%d check(s) FAILED\n", failures);
+        return 1;
+    }
+    std::printf("test_historical_security_lookahead_projection passed.\n");
+    return 0;
+}

--- a/tests/test_historical_security_lookahead_projection.cpp
+++ b/tests/test_historical_security_lookahead_projection.cpp
@@ -241,28 +241,45 @@ void test_input_tf_below_script_tf_ignores_projection_flag() {
     }
 }
 
-void test_range_start_warmup_ignores_projection_flag() {
+void test_range_start_warmup_composes_with_projection() {
     ProjectionHarness harness;
     harness.set_syminfo_metadata(
         "historical_security_lookahead_projection", 1.0);
-    // Drop the first 15m input bar. The established warmup path then builds a
-    // three-child partial 60m bucket before committing it at the next hour.
+    // Drop the first 15m input bar. The finite projection must aggregate only
+    // the retained range-start feed: a three-child historical 60m bucket,
+    // followed by the available two-child tail. The skipped chart child stays
+    // na because neither the range-start evaluator nor the projection has run.
     harness.set_syminfo_metadata(
         "security_range_start_na_warmup", 4'500'000.0);
     const auto bars = make_feed();
     harness.run(bars.data(), static_cast<int>(bars.size()), "15", "15");
 
     CHECK(harness.last_error().empty(), "range-start composition run succeeds");
-    CHECK(harness.dispatches.size() == 5,
-          "range-start warmup keeps trimmed security feed progressive");
-    const double expected_close[] = {20.0, 30.0, 40.0, 40.0, 60.0};
-    const bool expected_complete[] = {false, false, false, true, false};
+    CHECK(harness.dispatches.size() == 2,
+          "range-start feed projects once per retained HTF bucket");
+    if (harness.dispatches.size() == 2) {
+        const Dispatch& historical = harness.dispatches[0];
+        CHECK(historical.complete, "trimmed historical bucket is complete");
+        CHECK(same(historical.bar.open, 10.0), "trimmed projection open");
+        CHECK(same(historical.bar.high, 44.0), "trimmed projection high");
+        CHECK(same(historical.bar.low, 6.0), "trimmed projection low");
+        CHECK(same(historical.bar.close, 40.0), "trimmed projection close");
+        CHECK(same(historical.bar.volume, 9.0), "trimmed projection volume");
+
+        const Dispatch& tail = harness.dispatches[1];
+        CHECK(!tail.complete, "trimmed tail remains incomplete");
+        CHECK(same(tail.bar.close, 60.0), "trimmed tail available close");
+    }
+
+    const double expected_chart[] = {
+        na<double>(), 40.0, 40.0, 40.0, 60.0, 60.0,
+    };
+    CHECK(harness.chart_values.size() == 6,
+          "range-start composition preserves every chart child");
     for (std::size_t i = 0;
-         i < harness.dispatches.size() && i < 5; ++i) {
-        CHECK(same(harness.dispatches[i].bar.close, expected_close[i]),
-              "range-start progressive close sequence");
-        CHECK(harness.dispatches[i].complete == expected_complete[i],
-              "range-start completion cadence");
+         i < harness.chart_values.size() && i < 6; ++i) {
+        CHECK(same(harness.chart_values[i], expected_chart[i]),
+              "range-start projected chart sequence");
     }
 }
 
@@ -319,7 +336,7 @@ int main() {
     test_equal_timeframe_ignores_projection_flag();
     test_heikinashi_ignores_projection_flag();
     test_input_tf_below_script_tf_ignores_projection_flag();
-    test_range_start_warmup_ignores_projection_flag();
+    test_range_start_warmup_composes_with_projection();
     test_stream_warmup_and_continuation_stay_progressive();
     if (failures != 0) {
         std::printf("%d check(s) FAILED\n", failures);


### PR DESCRIPTION
## What changed

- Add an opt-in finite historical `request.security(..., gaps_off, lookahead_on)` projection path.
- Compose historical projection with the existing range-start NA warmup instead of making the two semantics mutually exclusive.
- Project only the retained input suffix and keep child/evaluator indexes aligned.
- Add focused coverage for default behavior, eligibility guards, tail projection, range composition, and streaming continuation.

## Why

Deep Backtesting can publish finite HTF values from the first chart child while resetting requested-series state at the configured range boundary. The engine already supported both behaviors independently, but enabling historical projection disabled range-start warmup. That left the composition unavailable and suppressed valid early signals for affected strategies.

## Impact

The behavior remains default-off and metadata-gated. It applies only to finite historical batches for eligible same-symbol higher-timeframe `lookahead_on + gaps_off` requests. Default execution and streaming behavior remain unchanged, and an incomplete trailing HTF bucket remains incomplete.

No codegen change is required: the accepted generator already emits the runtime metadata used by this path.

## Validation

- Fresh Release all-target build, including 252 corpus strategy targets
- CTest: 99/99 passed
- Corpus: 252/252 executed; 240 Excellent, 11 Strong, 1 known Anomaly
- C ABI runtime smoke check passed
- Existing codegen against this engine: 1537 passed, 2 skipped
- No-cache Waranyu oracle: 110/110 matched, 100% coverage and price exactness, zero count delta, and zero entry/exit/PnL P90
