### PR TITLE
fix: enforce paired market affordability

### DIFF
--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -267,6 +267,37 @@ struct PendingOrder {
     // collapsing to close-only-flat. Scoped to created-FLAT so the deferred-flip
     // carry (created OPPOSITE) is untouched.
     bool reverses_same_bar_market_from_flat = false;
+    // KI-65 MARKET/MARKET follow-up candidate. Every own-affordable explicit
+    // MARKET call in the pinned broker scope carries this snapshot until the
+    // next broker-processing boundary, where the complete source-bar set is
+    // known. Only a set of exactly two distinct-id opposite calls is finalized
+    // as a pair; larger sets remain ordinary source-ordered entries.
+    bool paired_flat_market_candidate = false;
+    double paired_flat_market_own_qty =
+        std::numeric_limits<double>::quiet_NaN();
+    double paired_flat_market_signal_close =
+        std::numeric_limits<double>::quiet_NaN();
+    double paired_flat_market_signal_equity =
+        std::numeric_limits<double>::quiet_NaN();
+    double paired_flat_market_signal_margin_pct =
+        std::numeric_limits<double>::quiet_NaN();
+    double paired_flat_market_signal_pointvalue =
+        std::numeric_limits<double>::quiet_NaN();
+    double paired_flat_market_signal_fx =
+        std::numeric_limits<double>::quiet_NaN();
+    // Finalized exact peer relation. Each side stores the other order's
+    // created_seq; zero means unpaired. The mutual relation lets fill sorting
+    // swap only this exact pair into TV's
+    // buy-before-sell broker priority without reordering unrelated MARKET calls.
+    int64_t paired_flat_market_peer_seq = 0;
+    // Finalization-frozen broker transaction quantity for the paired order. The
+    // earlier call carries its own qty; the later call carries
+    // own + earlier-pending-own. This is deliberately separate from ``qty``:
+    // ``qty`` remains the Pine call's own/target quantity and continues to drive
+    // explicit-qty provenance, exit reservations, and every unpaired path.
+    // NaN means ordinary strategy.entry reversal semantics.
+    double paired_flat_market_transaction_qty =
+        std::numeric_limits<double>::quiet_NaN();
     // Snapshot of the position's quantity at the moment this order was
     // PLACED (0 if placed from flat). Used by execute_market_entry's
     // flat branch to apply TradingView's deferred-flip growth rule:
@@ -791,6 +822,11 @@ protected:
 
     std::vector<Trade> trades_;
     std::vector<PendingOrder> pending_orders_;
+    // Source bars whose otherwise eligible flat MARKET candidate set was
+    // mutated (same-id replacement/cancel). Even if two orders survive, the
+    // original bar contained more/different calls and is outside the exact
+    // two-call oracle, so finalization must leave it ordinary.
+    std::unordered_set<int> pending_flat_market_pair_disqualified_bars_;
 
     // strategy.exit partial orders are one-shot per open position for a given id
     std::unordered_set<std::string> consumed_partial_exit_ids_;
@@ -1947,7 +1983,8 @@ private:
                               bool is_priced_entry = false,
                               double tv_carry_qty = 0.0,
                               int created_bar = -1,
-                              bool later_same_tick_entry = false);
+                              bool later_same_tick_entry = false,
+                              bool paired_flat_market_transaction = false);
     void execute_market_exit(double fill_price);
     void execute_partial_exit_qty(double fill_price, double qty_to_close);
     void execute_partial_exit(double fill_price, double qty_percent);
@@ -1971,7 +2008,11 @@ private:
     // bar-pump fill loop is reviewable rather than a 600-line monolith.
     void update_trail_best_for_bar_open(const Bar& bar);
     void sort_exit_siblings_by_path_fill(const Bar& bar);
+    bool pending_flat_market_pair_scope_is_live() const;
+    void finalize_pending_flat_market_pairs(const Bar& bar);
     void sort_orders_by_fill_phase(const Bar& bar);
+    bool pending_flat_market_pair_is_live(const PendingOrder& order) const;
+    void invalidate_pending_flat_market_pair(int64_t created_seq);
     void compact_filled_pending_orders(const std::vector<size_t>& filled_indices,
                                        int exit_closed_from_bar,
                                        bool exit_closed_was_long);
@@ -2122,7 +2163,8 @@ private:
                                 int explicit_qty_type,
                                 PositionSide created_position_side,
                                 bool is_priced_entry, double tv_carry_qty,
-                                int created_bar);
+                                int created_bar,
+                                bool explicit_qty_prequantized = false);
     void add_to_pyramid_market(const std::string& id, bool is_long,
                                double fill_price, double explicit_qty,
                                int explicit_qty_type,
@@ -2130,7 +2172,9 @@ private:
                                bool is_priced_entry);
     void close_opposite_then_enter(const std::string& id, bool is_long,
                                    double fill_price, double explicit_qty,
-                                   int explicit_qty_type);
+                                   int explicit_qty_type,
+                                   bool purge_pending_exits = true,
+                                   bool explicit_qty_prequantized = false);
     void flip_market_position_to(const std::string& id, bool is_long,
                                  double fill_price, double explicit_qty,
                                  int explicit_qty_type,

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -19,6 +19,7 @@ using namespace internal;
 void BacktestEngine::process_pending_orders(const Bar& bar) {
     // Update risk state
     update_risk_state();
+    finalize_pending_flat_market_pairs(bar);
 
     double trail_best_path_state = trail_best_price_;
     update_trail_best_for_bar_open(bar);
@@ -63,6 +64,7 @@ void BacktestEngine::process_pending_orders(const Bar& bar) {
             order, opposing_pass, dual_entry_path_, pass0_opposing_skip_ids,
             exit_closed_from_bar, exit_closed_was_long, bar);
         if (eligibility == OrderEligibility::Remove) {
+            invalidate_pending_flat_market_pair(order.created_seq);
             filled_indices.push_back(i);
             continue;
         }
@@ -177,6 +179,7 @@ BacktestEngine::CoofFillResult BacktestEngine::process_next_pending_order(
                 order, opposing_pass, dual_entry_path, pass0_opposing_skip_ids,
                 exit_closed_from_bar, exit_closed_was_long, bar);
             if (eligibility == OrderEligibility::Remove) {
+                invalidate_pending_flat_market_pair(order.created_seq);
                 filled_indices.push_back(i);
                 continue;
             }
@@ -623,12 +626,194 @@ void BacktestEngine::sort_exit_siblings_by_path_fill(const Bar& bar) {
         });
 }
 
+bool BacktestEngine::pending_flat_market_pair_scope_is_live() const {
+    return !process_orders_on_close_
+        && !calc_on_order_fills_
+        && slippage_ == 0
+        && pyramiding_ == 2
+        && std::abs(margin_long_ - 100.0) < 1e-12
+        && std::abs(margin_short_ - 100.0) < 1e-12
+        && risk_direction_ == RiskDirection::BOTH
+        && risk_max_cons_loss_days_ == 0
+        && risk_max_drawdown_ <= 0.0
+        && risk_max_intraday_loss_ <= 0.0
+        && risk_max_position_size_ <= 0.0
+        && max_intraday_filled_orders_ <= 0
+        && !risk_halted_;
+}
+
+// Finalize the deferred KI-65 MARKET/MARKET candidate set only after on_bar
+// has completed and the broker sees every call from that source bar. Each call
+// has already passed the ordinary own-qty placement gate. Exactly two eligible
+// opposite calls form a pair; larger/other sets are deliberately ordinary.
+// The later call alone receives the pending-aware GROSS admission check.
+void BacktestEngine::finalize_pending_flat_market_pairs(const Bar& bar) {
+    std::vector<int64_t> rejected_seqs;
+    std::unordered_set<int> finalized_bars;
+
+    for (size_t seed = 0; seed < pending_orders_.size(); ++seed) {
+        PendingOrder& seed_order = pending_orders_[seed];
+        if (!seed_order.paired_flat_market_candidate) continue;
+        const int source_bar = seed_order.created_bar;
+        if (!finalized_bars.insert(source_bar).second) continue;
+
+        std::vector<size_t> group;
+        int pending_entry_like_orders = 0;
+        for (size_t i = 0; i < pending_orders_.size(); ++i) {
+            const PendingOrder& order = pending_orders_[i];
+            const bool entry_like =
+                order.type == OrderType::MARKET
+                || order.type == OrderType::ENTRY
+                || order.type == OrderType::RAW_ORDER;
+            if (entry_like) ++pending_entry_like_orders;
+            if (order.paired_flat_market_candidate
+                && order.created_bar == source_bar) {
+                group.push_back(i);
+            }
+        }
+        for (size_t i : group) {
+            pending_orders_[i].paired_flat_market_candidate = false;
+        }
+
+        const bool source_bar_disqualified =
+            pending_flat_market_pair_disqualified_bars_.erase(source_bar) > 0;
+        if (group.size() != 2
+            || pending_entry_like_orders != 2
+            || source_bar_disqualified
+            || !pending_flat_market_pair_scope_is_live()) {
+            continue;
+        }
+        PendingOrder* first = &pending_orders_[group[0]];
+        PendingOrder* second = &pending_orders_[group[1]];
+        if (second->created_seq < first->created_seq) std::swap(first, second);
+        if (first->type != OrderType::MARKET
+            || second->type != OrderType::MARKET
+            || first->id == second->id
+            || first->is_long == second->is_long
+            || first->created_position_side != PositionSide::FLAT
+            || second->created_position_side != PositionSide::FLAT
+            || !std::isfinite(first->paired_flat_market_own_qty)
+            || !std::isfinite(second->paired_flat_market_own_qty)
+            || first->paired_flat_market_own_qty <= kQtyEpsilon
+            || second->paired_flat_market_own_qty <= kQtyEpsilon) {
+            continue;
+        }
+
+        const double gross_qty = first->paired_flat_market_own_qty
+            + second->paired_flat_market_own_qty;
+        const bool valid_snapshot =
+            std::isfinite(second->paired_flat_market_signal_close)
+            && second->paired_flat_market_signal_close > 0.0
+            && std::isfinite(second->paired_flat_market_signal_equity)
+            && std::isfinite(second->paired_flat_market_signal_margin_pct)
+            && second->paired_flat_market_signal_margin_pct > 0.0
+            && std::isfinite(second->paired_flat_market_signal_pointvalue)
+            && second->paired_flat_market_signal_pointvalue > 0.0
+            && std::isfinite(second->paired_flat_market_signal_fx)
+            && second->paired_flat_market_signal_fx > 0.0;
+        if (!valid_snapshot) continue;
+
+        const double required_margin =
+            gross_qty * second->paired_flat_market_signal_close
+            * second->paired_flat_market_signal_pointvalue
+            * second->paired_flat_market_signal_fx
+            * (second->paired_flat_market_signal_margin_pct / 100.0);
+        const double epsilon = std::max(
+            1e-9, std::abs(second->paired_flat_market_signal_equity) * 1e-12);
+        if (required_margin
+            > second->paired_flat_market_signal_equity + epsilon) {
+            rejected_seqs.push_back(second->created_seq);
+            continue;
+        }
+
+        // Defensive explicit-qty adverse-gap admission runs here BEFORE links
+        // can swap the pair around interleaved brackets. The buy is the first
+        // broker fill. When it is also the later source call (HSF), cost its
+        // GROSS transaction; otherwise cost the earlier buy's own quantity.
+        PendingOrder* buy = first->is_long ? first : second;
+        const double buy_transaction_qty = (buy == second)
+            ? gross_qty
+            : first->paired_flat_market_own_qty;
+        const bool valid_buy_snapshot =
+            std::isfinite(buy->paired_flat_market_signal_close)
+            && buy->paired_flat_market_signal_close > 0.0
+            && std::isfinite(buy->paired_flat_market_signal_equity)
+            && std::isfinite(buy->paired_flat_market_signal_margin_pct)
+            && buy->paired_flat_market_signal_margin_pct > 0.0
+            && std::isfinite(buy->paired_flat_market_signal_pointvalue)
+            && buy->paired_flat_market_signal_pointvalue > 0.0
+            && std::isfinite(buy->paired_flat_market_signal_fx)
+            && buy->paired_flat_market_signal_fx > 0.0;
+        if (valid_buy_snapshot && std::isfinite(bar.open) && bar.open > 0.0) {
+            const double buy_fill = apply_slippage(
+                bar.open, /*is_buy=*/buy->is_long);
+            const double notional_k =
+                buy->paired_flat_market_signal_pointvalue
+                * buy->paired_flat_market_signal_fx
+                * (buy->paired_flat_market_signal_margin_pct / 100.0);
+            const double fill_notional =
+                buy_transaction_qty * buy_fill * notional_k;
+            const double signal_notional =
+                buy_transaction_qty * buy->paired_flat_market_signal_close
+                * notional_k;
+            const double threshold = std::max(
+                buy->paired_flat_market_signal_equity, signal_notional);
+            const double gap_epsilon = std::max(
+                1e-9,
+                std::abs(buy->paired_flat_market_signal_equity) * 1e-12);
+            if (fill_notional > threshold + gap_epsilon) {
+                rejected_seqs.push_back(buy->created_seq);
+                continue;
+            }
+        }
+
+        first->paired_flat_market_peer_seq = second->created_seq;
+        first->paired_flat_market_transaction_qty =
+            first->paired_flat_market_own_qty;
+        second->paired_flat_market_peer_seq = first->created_seq;
+        second->paired_flat_market_transaction_qty = gross_qty;
+    }
+
+    if (!rejected_seqs.empty()) {
+        pending_orders_.erase(
+            std::remove_if(
+                pending_orders_.begin(), pending_orders_.end(),
+                [&](const PendingOrder& order) {
+                    return std::find(rejected_seqs.begin(), rejected_seqs.end(),
+                                     order.created_seq) != rejected_seqs.end();
+                }),
+            pending_orders_.end());
+    }
+    // A bar whose candidates were all canceled has no seed above to consume
+    // its tombstone. Once broker processing advances beyond that source bar it
+    // can no longer form a MARKET pair, so prune the stale taint cheaply.
+    for (auto it = pending_flat_market_pair_disqualified_bars_.begin();
+         it != pending_flat_market_pair_disqualified_bars_.end();) {
+        if (*it < bar_index_) {
+            it = pending_flat_market_pair_disqualified_bars_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
 // Sort by the first possible fill point, then by PineScript source order.
 // Market orders fill at bar open. Priced orders that gap through at open
 // share that same fill point; other priced orders evaluate later on the
 // synthetic OHLC path. This avoids broad type-based reordering.
 void BacktestEngine::sort_orders_by_fill_phase(const Bar& bar) {
     if (pending_orders_.size() < 2) return;  // nothing to order; skips stable_sort's temp-buffer alloc
+
+    // Validate pair links before stable_sort starts moving elements. Scanning
+    // pending_orders_ from inside the comparator would make its result depend
+    // on the sort algorithm's transient moves. The immutable sequence set
+    // below instead gives the comparator a stable, transitive key.
+    std::unordered_set<int64_t> live_flat_market_pair_seqs;
+    for (const PendingOrder& order : pending_orders_) {
+        if (pending_flat_market_pair_is_live(order)) {
+            live_flat_market_pair_seqs.insert(order.created_seq);
+        }
+    }
     std::stable_sort(pending_orders_.begin(), pending_orders_.end(),
         [&](const PendingOrder& a, const PendingOrder& b) {
             auto fill_phase = [&](const PendingOrder& o) {
@@ -761,8 +946,61 @@ void BacktestEngine::sort_orders_by_fill_phase(const Bar& bar) {
             bool b_opp_priced = is_opposite_priced_entry(b);
             if (a_full_close && b_opp_priced) return true;
             if (b_full_close && a_opp_priced) return false;
+
+            // The confirmed flat MARKET pair is buy-before-sell even when the
+            // short call appeared first in source. Map the pair onto its two
+            // existing sequence slots (buy=min, sell=max), rather than adding a
+            // pair-only comparator edge that could cycle around interleaved
+            // orders such as strategy.exit brackets.
+            auto effective_seq = [&](const PendingOrder& order) {
+                if (live_flat_market_pair_seqs.count(order.created_seq) == 0) {
+                    return order.created_seq;
+                }
+                return order.is_long
+                    ? std::min(order.created_seq,
+                               order.paired_flat_market_peer_seq)
+                    : std::max(order.created_seq,
+                               order.paired_flat_market_peer_seq);
+            };
+            const int64_t a_seq = effective_seq(a);
+            const int64_t b_seq = effective_seq(b);
+            if (a_seq != b_seq) return a_seq < b_seq;
             return a.created_seq < b.created_seq;
         });
+}
+
+bool BacktestEngine::pending_flat_market_pair_is_live(
+        const PendingOrder& order) const {
+    if (!pending_flat_market_pair_scope_is_live()
+        || order.type != OrderType::MARKET
+        || order.paired_flat_market_peer_seq <= 0
+        || !std::isfinite(order.paired_flat_market_transaction_qty)) {
+        return false;
+    }
+    for (const PendingOrder& peer : pending_orders_) {
+        if (peer.created_seq != order.paired_flat_market_peer_seq) continue;
+        return peer.type == OrderType::MARKET
+            && peer.paired_flat_market_peer_seq == order.created_seq
+            && std::isfinite(peer.paired_flat_market_transaction_qty)
+            && peer.id != order.id
+            && peer.is_long != order.is_long
+            && peer.created_bar == order.created_bar
+            && peer.created_position_side == PositionSide::FLAT
+            && order.created_position_side == PositionSide::FLAT;
+    }
+    return false;
+}
+
+void BacktestEngine::invalidate_pending_flat_market_pair(int64_t created_seq) {
+    if (created_seq <= 0) return;
+    for (PendingOrder& order : pending_orders_) {
+        if (order.created_seq == created_seq
+            || order.paired_flat_market_peer_seq == created_seq) {
+            order.paired_flat_market_peer_seq = 0;
+            order.paired_flat_market_transaction_qty =
+                std::numeric_limits<double>::quiet_NaN();
+        }
+    }
 }
 
 // Remove filled orders in O(n) single pass and mirror the in-loop wipe
@@ -838,6 +1076,10 @@ void BacktestEngine::apply_filled_order_to_state(
         int& exit_closed_from_bar,
         bool& exit_closed_was_long,
         std::vector<size_t>& filled_indices) {
+    auto decline_and_cancel = [&]() {
+        invalidate_pending_flat_market_pair(order.created_seq);
+        filled_indices.push_back(order_index);
+    };
     // design-declined-reversal-close-leg: a close flagged by the reversal
     // decline is Removed by classify_order_eligibility in the ordinary kernel,
     // so this order never reaches apply there. The KI-60 COOF kernel, however,
@@ -846,7 +1088,7 @@ void BacktestEngine::apply_filled_order_to_state(
     // by classify — catch it here (no-op the fill, mark for compaction). Shared
     // by both kernels; must precede every state mutation below.
     if (order.suppress_as_declined_reversal_close) {
-        filled_indices.push_back(order_index);
+        decline_and_cancel();
         return;
     }
     // Fill-local proof that KI-54 admitted this order as a flat open on its
@@ -860,7 +1102,7 @@ void BacktestEngine::apply_filled_order_to_state(
         bool is_opposite_entry =
             position_side_ != PositionSide::FLAT && position_side_ != requested;
         if (!is_opposite_entry && !check_risk_allow_entry(order.is_long)) {
-            filled_indices.push_back(order_index);
+            decline_and_cancel();
             return;
         }
     }
@@ -901,7 +1143,7 @@ void BacktestEngine::apply_filled_order_to_state(
             const double available = current_equity();
             const double eps = std::max(1e-9, std::abs(available) * 1e-12);
             if (fill_qty > 0.0 && required > available + eps) {
-                filled_indices.push_back(order_index);   // decline + cancel
+                decline_and_cancel();
                 return;
             }
         }
@@ -961,7 +1203,7 @@ void BacktestEngine::apply_filled_order_to_state(
             const double epsilon =
                 std::max(1e-9, std::abs(equity_at_fill) * 1e-12);
             if (required_margin > free_funds + epsilon) {
-                filled_indices.push_back(order_index);
+                decline_and_cancel();
                 return;
             }
         }
@@ -1063,7 +1305,7 @@ void BacktestEngine::apply_filled_order_to_state(
         if (reversal && order.type == OrderType::MARKET) {
             suppress_declined_reversal_close_legs(order);
         }
-        filled_indices.push_back(order_index);
+        decline_and_cancel();
         return;
     }
     // sizing_equity > 0 and frozen_default_qty > 0 are part of the invariant,
@@ -1151,7 +1393,7 @@ void BacktestEngine::apply_filled_order_to_state(
                     std::max(1e-9, std::abs(order.sizing_equity) * 1e-12);
                 if (gap_notional
                     > order.sizing_equity + one_lot_slack + float_guard) {
-                    filled_indices.push_back(order_index);
+                    decline_and_cancel();
                     return;
                 }
             }
@@ -1235,7 +1477,7 @@ void BacktestEngine::apply_filled_order_to_state(
                 if (reversal && order.type == OrderType::MARKET) {
                     suppress_declined_reversal_close_legs(order);
                 }
-                filled_indices.push_back(order_index);
+                decline_and_cancel();
                 return;
             }
             admitted_flat_on_frozen_sizing_price =
@@ -1287,19 +1529,28 @@ void BacktestEngine::apply_filled_order_to_state(
                 apply_fill_slippage(fill_price, order.is_long);
             const double notional_k = syminfo_.pointvalue * account_currency_fx_
                                       * (margin_pct / 100.0);
+            // A finalized pair's first broker fill may be the later source
+            // call and moves the frozen GROSS transaction. Cost that exact
+            // transaction here; using order.qty would admit an adverse gap on
+            // half the notional the fill is about to open.
+            const bool paired_flat_market =
+                pending_flat_market_pair_is_live(order);
+            const double admission_qty = paired_flat_market
+                ? order.paired_flat_market_transaction_qty
+                : std::abs(order.qty);
             const double fill_notional =
-                std::abs(order.qty) * slipped_fill * notional_k;
+                admission_qty * slipped_fill * notional_k;
             // POOC / no-gap admission floor: a fill at the slipped signal close
             // was already admitted at signal time.
             const double signal_notional =
-                std::abs(order.qty) * order.explicit_slipped_signal_close
+                admission_qty * order.explicit_slipped_signal_close
                 * notional_k;
             const double threshold =
                 std::max(order.explicit_placement_equity, signal_notional);
             const double float_guard =
                 std::max(1e-9, std::abs(order.explicit_placement_equity) * 1e-12);
             if (fill_notional > threshold + float_guard) {
-                filled_indices.push_back(order_index);
+                decline_and_cancel();
                 return;
             }
         }
@@ -1344,7 +1595,7 @@ void BacktestEngine::apply_filled_order_to_state(
             // Latched: drop this pending order and skip dispatch.
             // Removing from pending_orders_ matches TV's behaviour of
             // silently consuming/rejecting fills past the daily cap.
-            filled_indices.push_back(order_index);
+            decline_and_cancel();
             return;
         }
         intraday_fill_count_++;
@@ -1522,12 +1773,34 @@ void BacktestEngine::apply_filled_order_to_state(
     double signed_pos_after = signed_pos();
     double filled_qty = std::abs(signed_pos_after - signed_pos_before);
 
+    const bool paired_flat_market_fill =
+        order.type == OrderType::MARKET
+        && pending_flat_market_pair_is_live(order);
+
+    // A paired first fill opens the transient broker GROSS quantity. Do not
+    // reconcile deferred/layered exits against that temporary size. After the
+    // second transaction nets the pair to its own surviving exposure, rebuild
+    // the logical close ledger from the physical lots and reconcile once.
+    if (paired_flat_market_fill
+        && std::abs(signed_pos_before) >= kQtyEpsilon
+        && position_side_ != PositionSide::FLAT) {
+        id_unclosed_qty_.clear();
+        for (const PyramidEntry& entry : pyramid_entries_) {
+            id_unclosed_qty_[entry.entry_id] += entry.qty;
+        }
+        if (!pyramid_entries_.empty()) {
+            reconcile_deferred_layered_exits(
+                pyramid_entries_.back().entry_id);
+        }
+    }
+
     // This fill just opened a position from FLAT via an entry order. Freeze
     // any LAYERED strategy.exit legs bound to that entry that were armed while
     // flat (qty=NaN, reservation deferred): bind each to a fixed slice of the
     // opened lot so a percent partial + its sibling 100% leg no longer
     // over-close the whole position depending on which leg fills first.
-    if (std::abs(signed_pos_before) < kQtyEpsilon
+    if (!paired_flat_market_fill
+        && std::abs(signed_pos_before) < kQtyEpsilon
         && position_side_ != PositionSide::FLAT
         && (order.type == OrderType::MARKET
             || order.type == OrderType::ENTRY
@@ -1677,15 +1950,28 @@ void BacktestEngine::apply_market_order_fill(PendingOrder& order, double fill_pr
     // fill does not re-derive it from the fill price. Explicit-qty and
     // FIXED-default orders keep their own (qty, qty_type) pair unchanged.
     const bool frozen = !std::isnan(order.frozen_default_qty);
+    const bool paired_flat_market =
+        pending_flat_market_pair_is_live(order);
+    const double dispatch_qty = paired_flat_market
+        ? order.paired_flat_market_transaction_qty
+        : (frozen ? order.frozen_default_qty : order.qty);
+    const int dispatch_qty_type = paired_flat_market
+        ? -1
+        : (frozen ? -1 : order.qty_type);
     execute_market_entry(order.id, order.is_long, fill_price,
-                         frozen ? order.frozen_default_qty : order.qty,
-                         frozen ? -1 : order.qty_type,
-                         order.created_position_side, /*close_only_opposite=*/false,
+                         dispatch_qty, dispatch_qty_type,
+                         order.created_position_side,
+                         /*close_only_opposite=*/paired_flat_market,
                          /*is_priced_entry=*/false, /*tv_carry_qty=*/0.0,
-                         order.created_bar, later_same_tick_entry);
+                         order.created_bar, later_same_tick_entry,
+                         paired_flat_market);
     double trail_best_after_fill = trail_best_price_;
     // Set entry comment on the just-created pyramid entry
-    if (!pyramid_entries_.empty()) pyramid_entries_.back().entry_comment = order.comment;
+    if (!pyramid_entries_.empty()
+        && (!paired_flat_market
+            || pyramid_entries_.back().entry_id == order.id)) {
+        pyramid_entries_.back().entry_comment = order.comment;
+    }
     // Update trail_best_price_ with intra-bar extremes for same-bar exit eval
     // -- EXCEPT when this fill happened AT the bar's close (a POOC market
     // order created and filled on this same bar): the whole bar's high/low

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -68,7 +68,8 @@ void BacktestEngine::execute_market_entry(const std::string& id, bool is_long, d
                                           bool is_priced_entry,
                                           double tv_carry_qty,
                                           int created_bar,
-                                          bool later_same_tick_entry) {
+                                          bool later_same_tick_entry,
+                                          bool paired_flat_market_transaction) {
     // Degenerate-bar guard: never open a position at a non-finite fill price
     // (e.g. a NaN/Inf print). Dropping the fill keeps trade output finite and
     // a single bad tick from poisoning the backtest. Clean feeds never hit this.
@@ -82,7 +83,7 @@ void BacktestEngine::execute_market_entry(const std::string& id, bool is_long, d
     if (is_opposite_entry && direction_blocked) {
         double exit_fill = apply_slippage(fill_price, position_side_ == PositionSide::SHORT);
         execute_market_exit(exit_fill);
-        purge_exit_orders();
+        if (!paired_flat_market_transaction) purge_exit_orders();
         return;
     }
 
@@ -97,7 +98,9 @@ void BacktestEngine::execute_market_entry(const std::string& id, bool is_long, d
     if (position_side_ == PositionSide::FLAT) {
         enter_market_from_flat(id, is_long, fill_price, explicit_qty, explicit_qty_type,
                                created_position_side, is_priced_entry, tv_carry_qty,
-                               created_bar);
+                               created_bar,
+                               /*explicit_qty_prequantized=*/
+                                   paired_flat_market_transaction);
         return;
     }
 
@@ -108,7 +111,10 @@ void BacktestEngine::execute_market_entry(const std::string& id, bool is_long, d
     }
 
     if (created_position_side == PositionSide::FLAT && close_only_opposite) {
-        close_opposite_then_enter(id, is_long, fill_price, explicit_qty, explicit_qty_type);
+        close_opposite_then_enter(
+            id, is_long, fill_price, explicit_qty, explicit_qty_type,
+            /*purge_pending_exits=*/!paired_flat_market_transaction,
+            /*explicit_qty_prequantized=*/paired_flat_market_transaction);
         return;
     }
 
@@ -688,14 +694,17 @@ void BacktestEngine::enter_market_from_flat(const std::string& id, bool is_long,
                                             int explicit_qty_type,
                                             PositionSide created_position_side,
                                             bool is_priced_entry, double tv_carry_qty,
-                                            int created_bar) {
+                                            int created_bar,
+                                            bool explicit_qty_prequantized) {
     bool carry_was_long = (created_position_side == PositionSide::LONG);
     bool tv_deferred_flip =
         script_has_strategy_close_
         && is_priced_entry
         && tv_carry_qty > 0.0
         && (carry_was_long ? !is_long : is_long);
-    double base_qty = calc_qty_for_type(fill_price, explicit_qty, explicit_qty_type);
+    double base_qty = explicit_qty_prequantized
+        ? explicit_qty
+        : calc_qty_for_type(fill_price, explicit_qty, explicit_qty_type);
     double qty = tv_deferred_flip ? (tv_carry_qty + base_qty) : base_qty;
     if (tv_deferred_flip) {
         consume_tv_carry_from_siblings(id, created_position_side, created_bar);
@@ -767,14 +776,23 @@ void BacktestEngine::add_to_pyramid_market(const std::string& id, bool is_long,
 // requested-direction remainder if any.
 void BacktestEngine::close_opposite_then_enter(const std::string& id, bool is_long,
                                                double fill_price, double explicit_qty,
-                                               int explicit_qty_type) {
-    double tx_qty = calc_qty_for_type(fill_price, explicit_qty, explicit_qty_type);
+                                               int explicit_qty_type,
+                                               bool purge_pending_exits,
+                                               bool explicit_qty_prequantized) {
+    double tx_qty = explicit_qty_prequantized
+        ? explicit_qty
+        : calc_qty_for_type(fill_price, explicit_qty, explicit_qty_type);
     double close_qty = std::min(tx_qty, position_qty_);
     // execute_partial_exit_qty applies slippage internally (mirrors its other
     // callers, e.g. execute_partial_exit_by_percent). Pass the RAW fill_price —
     // pre-slipping here would double-slip the close leg (issue #27).
     execute_partial_exit_qty(fill_price, close_qty);
-    purge_exit_orders();
+    // The ordinary close-only-opposite path historically purges stale exits.
+    // A confirmed same-source flat MARKET pair is different: both transaction
+    // legs execute inside process_pending_orders, where erasing the vector
+    // would invalidate the active order reference and filled-index ledger.
+    // Its stale exits follow flip_market_position_to's safe next-pass cleanup.
+    if (purge_pending_exits) purge_exit_orders();
     double remainder = tx_qty - close_qty;
     if (remainder <= kQtyEpsilon) {
         return;

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -437,6 +437,7 @@ void BacktestEngine::reset_run_state() {
     reset_position_state_to_flat();   // position_side_/qty/price/time/count,
                                       // pyramid_entries_, trail, partial ids
     pending_orders_.clear();
+    pending_flat_market_pair_disqualified_bars_.clear();
     pending_close_qty_in_bar_ = 0.0;
     pos_view_freeze_bar_ = -1;   // KI-64: fresh run starts with no frozen view
     sb_close_active_ = false;

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -105,6 +105,26 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
     // day before the script's else-branch could cancel it).
     if (_intraday_cap_currently_latched()) return;
 
+    // KI-65 MARKET/MARKET follow-up. Every explicit MARKET call first receives
+    // the established OWN-qty admission below. Eligible own-admitted calls are
+    // merely snapshotted here; the broker pair is finalized at the next fill
+    // boundary, after the complete same-source-bar call set is known. Deferring
+    // prevents an alternating three-call set from prematurely gross-rejecting
+    // call 2 before call 3 exists.
+    const bool explicit_fixed_market_call =
+        std::isfinite(qty) && qty > kQtyEpsilon
+        && std::isnan(limit_price) && std::isnan(stop_price)
+        && oca_name.empty()
+        && (qty_type < 0 || qty_type == static_cast<int>(QtyType::FIXED));
+    const double paired_flat_market_own_qty = explicit_fixed_market_call
+        ? std::abs(apply_qty_step(qty))
+        : std::numeric_limits<double>::quiet_NaN();
+    const bool paired_flat_market_candidate =
+        explicit_fixed_market_call
+        && paired_flat_market_own_qty > kQtyEpsilon
+        && pending_flat_market_pair_scope_is_live()
+        && position_side_ == PositionSide::FLAT;
+
     // TradingView broker rule: market-entry orders are admitted only
     // when ``qty * <signal-bar close> * margin_pct/100 <= equity``.
     // The check happens HERE (at signal time, with current_bar_.close
@@ -165,6 +185,27 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
     }
 
     // Remove existing pending order with same id
+    for (const PendingOrder& pending : pending_orders_) {
+        if (pending.id == id) {
+            const bool entry_like =
+                pending.type == OrderType::MARKET
+                || pending.type == OrderType::ENTRY
+                || pending.type == OrderType::RAW_ORDER;
+            // A candidate call that replaces any resting entry-like order is
+            // not an exact two-call source-bar set, even when the replaced
+            // order came from an earlier bar. Taint this call's bar as well as
+            // preserving the old-bar tombstone below.
+            if (paired_flat_market_candidate && entry_like) {
+                pending_flat_market_pair_disqualified_bars_.insert(bar_index_);
+            }
+            if (entry_like
+                && pending.created_position_side == PositionSide::FLAT) {
+                pending_flat_market_pair_disqualified_bars_.insert(
+                    pending.created_bar);
+            }
+            invalidate_pending_flat_market_pair(pending.created_seq);
+        }
+    }
     pending_orders_.erase(
         std::remove_if(pending_orders_.begin(), pending_orders_.end(),
             [&](const PendingOrder& o) { return o.id == id; }),
@@ -249,6 +290,16 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
         order.type = OrderType::MARKET;
         order.limit_price = std::numeric_limits<double>::quiet_NaN();
         order.stop_price = std::numeric_limits<double>::quiet_NaN();
+        if (paired_flat_market_candidate) {
+            order.paired_flat_market_candidate = true;
+            order.paired_flat_market_own_qty = paired_flat_market_own_qty;
+            order.paired_flat_market_signal_close = current_bar_.close;
+            order.paired_flat_market_signal_equity = current_equity();
+            order.paired_flat_market_signal_margin_pct =
+                is_long ? margin_long_ : margin_short_;
+            order.paired_flat_market_signal_pointvalue = syminfo_.pointvalue;
+            order.paired_flat_market_signal_fx = account_currency_fx_;
+        }
         // TradingView freezes DEFAULT (qty=na) percent_of_equity / cash
         // market-order sizing at THIS (signal) bar's close — see
         // frozen_default_market_qty (engine.hpp) for the rule and the
@@ -880,6 +931,18 @@ void BacktestEngine::strategy_exit(const std::string& id, const std::string& fro
 }
 
 void BacktestEngine::strategy_cancel(const std::string& id) {
+    for (const PendingOrder& order : pending_orders_) {
+        if (order.id == id) {
+            if ((order.type == OrderType::MARKET
+                 || order.type == OrderType::ENTRY
+                 || order.type == OrderType::RAW_ORDER)
+                && order.created_position_side == PositionSide::FLAT) {
+                pending_flat_market_pair_disqualified_bars_.insert(
+                    order.created_bar);
+            }
+            invalidate_pending_flat_market_pair(order.created_seq);
+        }
+    }
     pending_orders_.erase(
         std::remove_if(pending_orders_.begin(), pending_orders_.end(),
             [&](const PendingOrder& o) { return o.id == id; }),
@@ -887,6 +950,15 @@ void BacktestEngine::strategy_cancel(const std::string& id) {
 }
 
 void BacktestEngine::strategy_cancel_all() {
+    for (const PendingOrder& order : pending_orders_) {
+        if ((order.type == OrderType::MARKET
+             || order.type == OrderType::ENTRY
+             || order.type == OrderType::RAW_ORDER)
+            && order.created_position_side == PositionSide::FLAT) {
+            pending_flat_market_pair_disqualified_bars_.insert(
+                order.created_bar);
+        }
+    }
     pending_orders_.clear();
 }
 
@@ -903,6 +975,18 @@ void BacktestEngine::strategy_order(const std::string& id, bool is_long, double 
     }
 
     // Remove existing pending order with same id
+    for (const PendingOrder& pending : pending_orders_) {
+        if (pending.id == id) {
+            if ((pending.type == OrderType::MARKET
+                 || pending.type == OrderType::ENTRY
+                 || pending.type == OrderType::RAW_ORDER)
+                && pending.created_position_side == PositionSide::FLAT) {
+                pending_flat_market_pair_disqualified_bars_.insert(
+                    pending.created_bar);
+            }
+            invalidate_pending_flat_market_pair(pending.created_seq);
+        }
+    }
     pending_orders_.erase(
         std::remove_if(pending_orders_.begin(), pending_orders_.end(),
             [&](const PendingOrder& o) { return o.id == id; }),

--- a/tests/test_dual_entry_placement_sizing.cpp
+++ b/tests/test_dual_entry_placement_sizing.cpp
@@ -22,10 +22,10 @@
  * (reverses_same_bar_market_from_flat) so the fill takes the ordinary
  * full-reversal path (flip_market_position_to, close_only=false).
  *
- * R1/R2/R3 are RED vs worktree HEAD (eaf5e97): today the second leg is
- * dropped (pos ends FLAT). G1–G3 are byte-stable characterization — the fix
- * MUST NOT change them (they pin the discriminator: STOP-first and
- * placement-rejected still close-only; MM-both-market unchanged path).
+ * R1/R2/R3 are the priced-second-leg KI-65 cases. G1/G3 pin the STOP-first and
+ * placement-rejected controls. The MARKET/MARKET follow-up cases below pin the
+ * remaining broker contract: gross placement admission, buy-before-sell fill
+ * priority, and transaction-net execution for an admitted pair.
  *
  * Cell map (probe hours, TRUE combo under the probe's v6 float-div coverage):
  *   MS-LF-A (hh=04, 391 ev): E1 long MARKET, E2 short STOP → TV: long dur0,
@@ -34,7 +34,7 @@
  *                            HELD.  Engine HEAD: close-only-flat.        [R2]
  *   SS-LF-A (hh=08, 391 ev): E1 long STOP, E2 short STOP → single close,
  *                            net FLAT (BOTH match — must stay).          [G1]
- *   MM-*-A  (hh=00/02):      both MARKET, net already matches (diff path).[G2]
+ *   MM-*-A  (hh=00/02):      both MARKET, net can match through wrong rows. [G2]
  *   -U cells / placement-reject: E1 over-notional → dropped, contributes 0. [G3]
  * Out of scope (frozen characterization): SS-SF (never ran in the probe),
  * pyramiding>0 multi-bar pyramids, deferred_flip carry (own suite).
@@ -93,6 +93,41 @@ struct DualProbeBase : public BacktestEngine {
         syminfo_mintick_ = 0.01;
     }
     double pos() const { return signed_position_size(); }
+};
+
+// The new MARKET/MARKET oracle was exported with pyramiding=2. Keep the legacy
+// KI-65 cells above on their pinned pyramiding=0 fixture and use this subclass
+// only for the follow-up cases.
+struct PendingMarketProbeBase : public DualProbeBase {
+    explicit PendingMarketProbeBase(double capital = 1000.0)
+        : DualProbeBase(capital) {
+        pyramiding_ = 2;
+        process_orders_on_close_ = false;
+        calc_on_order_fills_ = false;
+    }
+    size_t pending_count() const { return pending_orders_.size(); }
+    bool pending_pair_metadata_clean() const {
+        for (const PendingOrder& order : pending_orders_) {
+            if (order.paired_flat_market_peer_seq != 0
+                || std::isfinite(order.paired_flat_market_transaction_qty)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    bool pending_has(const char* id, bool is_long, double qty) const {
+        for (const PendingOrder& order : pending_orders_) {
+            if (order.id == id && order.is_long == is_long
+                && near(order.qty, qty)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    double logical_open_qty(const char* id) const {
+        auto it = id_unclosed_qty_.find(id);
+        return it == id_unclosed_qty_.end() ? 0.0 : it->second;
+    }
 };
 
 // ─────────────────────────────────────────────────────────────────────
@@ -220,10 +255,9 @@ static void test_G1_ss_lf_a_single_close_flat() {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// G2 — MM-*-A: both legs MARKET (E1 long, E2 short), from flat. Net already
-// matches TV via the market fill path (flip_market_position_to); the fix
-// touches only the PRICED-entry gate, so this stays byte-identical: net -1
-// short held, one dur-0 long round trip.
+// G2 — legacy long-first MM control: E1 long, E2 short, from flat. Buy-first
+// already agrees with source order, so the pending-market follow-up retains
+// the established net -1 short and one dur-0 long round trip.
 // ─────────────────────────────────────────────────────────────────────
 static void test_G2_mm_both_market_unchanged() {
     std::printf("test_G2_mm_both_market_unchanged\n");
@@ -267,6 +301,793 @@ static void test_G3_placement_rejected_contributes_zero() {
     CHECK(p.trade_count() == 0);                 // nothing closed (E1 never opened)
 }
 
+// ──────────────────────────────────────────────────────────────────────
+// MARKET/MARKET follow-up oracle (pf-probe-ki65-pending-market-affordability):
+// both calls are explicit-qty, distinct-id, opposite MARKET strategy.entry
+// calls placed from flat on the same ordinary (POOC=false, COOF=false) on_bar.
+// The later call freezes a broker transaction of own + pending-opposite own.
+// Admission costs that GROSS transaction at the signal close. If admitted,
+// buys fill before sells and each fill nets its frozen transaction against the
+// live position. The order's own qty remains the eventual target exposure.
+// ─────────────────────────────────────────────────────────────────────
+
+// HSF: short 25% first, long 25% second. The later buy's gross transaction is
+// 50%, so both calls are admitted. TV fills the buy first: long 50%, then the
+// earlier sell closes 25%, leaving long 25%. The trade list is therefore TWO
+// long slices carrying E2's entry id, not a dur-0 short followed by a long.
+static void test_MM_HSF_buy_first_exact_trade_decomposition() {
+    std::printf("test_MM_HSF_buy_first_exact_trade_decomposition\n");
+    struct P : PendingMarketProbeBase {
+        size_t queued_after_signal = 0;
+        bool own_qty_preserved = false;
+        double ledger_after_pair = 0.0;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("HSF-E1-S", false, kNaN, kNaN, 2.5, "HSF-E1-S");
+                strategy_entry("HSF-E2-L", true,  kNaN, kNaN, 2.5, "HSF-E2-L");
+                queued_after_signal = pending_orders_.size();
+                own_qty_preserved = pending_orders_.size() == 2
+                    && near(pending_orders_[0].qty, 2.5)
+                    && near(pending_orders_[1].qty, 2.5);
+            } else if (bar_index_ == 1) {
+                ledger_after_pair = logical_open_qty("HSF-E2-L");
+                strategy_close_all();
+            }
+        }
+    } p;
+    Bar bars[3] = { mk(100, 600'000), mk(100, 1'200'000), mk(100, 1'800'000) };
+    p.run(bars, 3);
+
+    CHECK(p.queued_after_signal == 2);
+    CHECK(p.own_qty_preserved);
+    CHECK(near(p.ledger_after_pair, 2.5));
+    CHECK(near(p.pos(), 0.0));
+    CHECK(p.trade_count() == 2);
+    if (p.trade_count() == 2) {
+        const Trade& scratch = p.get_trade(0);
+        const Trade& cleanup = p.get_trade(1);
+        CHECK(scratch.is_long);
+        CHECK(scratch.entry_id == "HSF-E2-L");
+        CHECK(scratch.exit_id == "HSF-E1-S");
+        CHECK(near(scratch.qty, 2.5));
+        CHECK(scratch.entry_bar_index == 1);
+        CHECK(scratch.exit_bar_index == 1);
+        CHECK(cleanup.is_long);
+        CHECK(cleanup.entry_id == "HSF-E2-L");
+        CHECK(near(cleanup.qty, 2.5));
+        CHECK(cleanup.entry_bar_index == 1);
+        CHECK(cleanup.exit_bar_index == 2);
+    }
+}
+
+// HLF mirror: the buy is already first. The later sell's admitted gross 50%
+// transaction closes long 25% and opens short 25%.
+static void test_MM_HLF_gross_sell_transaction_mirror() {
+    std::printf("test_MM_HLF_gross_sell_transaction_mirror\n");
+    struct P : PendingMarketProbeBase {
+        size_t queued_after_signal = 0;
+        bool own_qty_preserved = false;
+        double ledger_after_pair = 0.0;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("HLF-E1-L", true,  kNaN, kNaN, 2.5, "HLF-E1-L");
+                strategy_entry("HLF-E2-S", false, kNaN, kNaN, 2.5, "HLF-E2-S");
+                queued_after_signal = pending_orders_.size();
+                own_qty_preserved = pending_orders_.size() == 2
+                    && near(pending_orders_[0].qty, 2.5)
+                    && near(pending_orders_[1].qty, 2.5);
+            } else if (bar_index_ == 1) {
+                ledger_after_pair = logical_open_qty("HLF-E2-S");
+                strategy_close_all();
+            }
+        }
+    } p;
+    Bar bars[3] = { mk(100, 600'000), mk(100, 1'200'000), mk(100, 1'800'000) };
+    p.run(bars, 3);
+
+    CHECK(p.queued_after_signal == 2);
+    CHECK(p.own_qty_preserved);
+    CHECK(near(p.ledger_after_pair, 2.5));
+    CHECK(near(p.pos(), 0.0));
+    CHECK(p.trade_count() == 2);
+    if (p.trade_count() == 2) {
+        const Trade& scratch = p.get_trade(0);
+        const Trade& cleanup = p.get_trade(1);
+        CHECK(scratch.is_long);
+        CHECK(scratch.entry_id == "HLF-E1-L");
+        CHECK(scratch.exit_id == "HLF-E2-S");
+        CHECK(near(scratch.qty, 2.5));
+        CHECK(scratch.entry_bar_index == 1);
+        CHECK(scratch.exit_bar_index == 1);
+        CHECK(!cleanup.is_long);
+        CHECK(cleanup.entry_id == "HLF-E2-S");
+        CHECK(near(cleanup.qty, 2.5));
+        CHECK(cleanup.entry_bar_index == 1);
+        CHECK(cleanup.exit_bar_index == 2);
+    }
+}
+
+// Source-interleaved brackets are load-bearing for the real Thula shape. The
+// paired sell's transaction-net close must not purge pending EXIT orders while
+// process_pending_orders is iterating its vector; both pair legs still produce
+// the same HSF decomposition with bracket seq slots between them.
+static void test_MM_HSF_interleaved_brackets_keep_fill_iteration_stable() {
+    std::printf("test_MM_HSF_interleaved_brackets_keep_fill_iteration_stable\n");
+    struct P : PendingMarketProbeBase {
+        size_t queued_after_signal = 0;
+        int candidate_market_orders = 0;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("BR-E1-S", false, kNaN, kNaN, 2.5);
+                strategy_exit("BR-X-LIM", "BR-E1-S", 90.0, kNaN,
+                              kNaN, kNaN, kNaN, 100.0, "", 2.5);
+                strategy_exit("BR-X-STP", "BR-E1-S", kNaN, 110.0,
+                              kNaN, kNaN, kNaN, 100.0, "", 2.5);
+                strategy_entry("BR-E2-L", true, kNaN, kNaN, 2.5);
+                queued_after_signal = pending_orders_.size();
+                for (const PendingOrder& order : pending_orders_) {
+                    if (order.type == OrderType::MARKET
+                        && order.paired_flat_market_candidate) {
+                        ++candidate_market_orders;
+                    }
+                }
+            } else if (bar_index_ == 1) {
+                strategy_close_all();
+            }
+        }
+    } p;
+    Bar bars[3] = { mk(100, 600'000), mk(100, 1'200'000), mk(100, 1'800'000) };
+    p.run(bars, 3);
+
+    CHECK(p.queued_after_signal == 4);
+    CHECK(p.candidate_market_orders == 2);
+    CHECK(p.trade_count() == 2);
+    if (p.trade_count() == 2) {
+        CHECK(p.get_trade(0).is_long);
+        CHECK(p.get_trade(0).entry_id == "BR-E2-L");
+        CHECK(p.get_trade(0).exit_id == "BR-E1-S");
+        CHECK(near(p.get_trade(0).qty, 2.5));
+        CHECK(p.get_trade(0).entry_bar_index == 1);
+        CHECK(p.get_trade(0).exit_bar_index == 1);
+        CHECK(p.get_trade(1).is_long);
+        CHECK(p.get_trade(1).entry_id == "BR-E2-L");
+        CHECK(near(p.get_trade(1).qty, 2.5));
+        CHECK(p.get_trade(1).exit_bar_index == 2);
+    }
+}
+
+// TSF/TLF: each own leg is 55% and independently affordable, but the later
+// opposite call's own+pending transaction is 110% and is rejected at placement.
+static void test_MM_tight_gross_110pct_rejects_later_leg_both_directions() {
+    std::printf("test_MM_tight_gross_110pct_rejects_later_leg_both_directions\n");
+    struct TSF : PendingMarketProbeBase {
+        size_t queued_after_signal = 0;
+        bool both_own_orders_queued = false;
+        double position_after_finalization = 0.0;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("TSF-E1-S", false, kNaN, kNaN, 5.5, "TSF-E1-S");
+                strategy_entry("TSF-E2-L", true,  kNaN, kNaN, 5.5, "TSF-E2-L");
+                queued_after_signal = pending_orders_.size();
+                both_own_orders_queued = pending_orders_.size() == 2
+                    && pending_has("TSF-E1-S", false, 5.5)
+                    && pending_has("TSF-E2-L", true, 5.5);
+            } else if (bar_index_ == 1) {
+                position_after_finalization = pos();
+                strategy_close_all();
+            }
+        }
+    } tsf;
+    struct TLF : PendingMarketProbeBase {
+        size_t queued_after_signal = 0;
+        bool both_own_orders_queued = false;
+        double position_after_finalization = 0.0;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("TLF-E1-L", true,  kNaN, kNaN, 5.5, "TLF-E1-L");
+                strategy_entry("TLF-E2-S", false, kNaN, kNaN, 5.5, "TLF-E2-S");
+                queued_after_signal = pending_orders_.size();
+                both_own_orders_queued = pending_orders_.size() == 2
+                    && pending_has("TLF-E1-L", true, 5.5)
+                    && pending_has("TLF-E2-S", false, 5.5);
+            } else if (bar_index_ == 1) {
+                position_after_finalization = pos();
+                strategy_close_all();
+            }
+        }
+    } tlf;
+    Bar bars[3] = { mk(100, 600'000), mk(100, 1'200'000), mk(100, 1'800'000) };
+    tsf.run(bars, 3);
+    tlf.run(bars, 3);
+
+    CHECK(tsf.queued_after_signal == 2);
+    CHECK(tsf.both_own_orders_queued);
+    CHECK(near(tsf.position_after_finalization, -5.5));
+    CHECK(tsf.trade_count() == 1);
+    if (tsf.trade_count() == 1) {
+        const Trade& t = tsf.get_trade(0);
+        CHECK(!t.is_long);
+        CHECK(t.entry_id == "TSF-E1-S");
+        CHECK(near(t.qty, 5.5));
+    }
+    CHECK(tlf.queued_after_signal == 2);
+    CHECK(tlf.both_own_orders_queued);
+    CHECK(near(tlf.position_after_finalization, 5.5));
+    CHECK(tlf.trade_count() == 1);
+    if (tlf.trade_count() == 1) {
+        const Trade& t = tlf.get_trade(0);
+        CHECK(t.is_long);
+        CHECK(t.entry_id == "TLF-E1-L");
+        CHECK(near(t.qty, 5.5));
+    }
+}
+
+// Single-order controls prove that rejection above comes from pending-aware
+// gross 110% admission, not from rejecting an own 55% explicit market order.
+static void test_MM_tight_single_55pct_controls_admit() {
+    std::printf("test_MM_tight_single_55pct_controls_admit\n");
+    struct CTL : PendingMarketProbeBase {
+        bool long_side;
+        explicit CTL(bool side) : long_side(side) {}
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry(long_side ? "CTL-L" : "CTL-S", long_side,
+                               kNaN, kNaN, 5.5,
+                               long_side ? "CTL-L" : "CTL-S");
+            } else if (bar_index_ == 1) {
+                strategy_close_all();
+            }
+        }
+    } ctl(true), cts(false);
+    Bar bars[3] = { mk(100, 600'000), mk(100, 1'200'000), mk(100, 1'800'000) };
+    ctl.run(bars, 3);
+    cts.run(bars, 3);
+
+    CHECK(ctl.trade_count() == 1);
+    if (ctl.trade_count() == 1) {
+        CHECK(ctl.get_trade(0).is_long);
+        CHECK(ctl.get_trade(0).entry_id == "CTL-L");
+        CHECK(near(ctl.get_trade(0).qty, 5.5));
+    }
+    CHECK(cts.trade_count() == 1);
+    if (cts.trade_count() == 1) {
+        CHECK(!cts.get_trade(0).is_long);
+        CHECK(cts.get_trade(0).entry_id == "CTL-S");
+        CHECK(near(cts.get_trade(0).qty, 5.5));
+    }
+}
+
+// Characterization fence: every predicate excluded from the clean-room pair
+// contract must keep ordinary placement. At the 55% wedge both own legs are
+// independently affordable but a leaked gross gate would reject the second.
+static void test_MM_scope_predicates_do_not_pair_or_gross_gate() {
+    std::printf("test_MM_scope_predicates_do_not_pair_or_gross_gate\n");
+    struct P : PendingMarketProbeBase {
+        enum class Mode {
+            DEFAULT_QTY, SAME_ID, SAME_DIRECTION, POOC, COOF,
+            RAW_SIBLING, OCA, SLIPPAGE, ZERO_QTY, NON_P2,
+            CUSTOM_MARGIN, RISK_RULE, THREE_CALLS,
+        };
+        Mode mode;
+        size_t queued = 0;
+        bool metadata_clean = false;
+        bool issued = false;
+
+        explicit P(Mode m) : mode(m) {
+            if (mode == Mode::DEFAULT_QTY) default_qty_value_ = 5.5;
+            if (mode == Mode::POOC) process_orders_on_close_ = true;
+            if (mode == Mode::COOF) calc_on_order_fills_ = true;
+            if (mode == Mode::SLIPPAGE) slippage_ = 1;
+            if (mode == Mode::NON_P2) pyramiding_ = 1;
+            if (mode == Mode::CUSTOM_MARGIN) {
+                margin_long_ = 50.0;
+                margin_short_ = 50.0;
+            }
+            if (mode == Mode::RISK_RULE) risk_max_position_size_ = 100.0;
+        }
+        void snapshot() {
+            queued = pending_count();
+            metadata_clean = pending_pair_metadata_clean();
+        }
+        void on_bar(const Bar&) override {
+            if (bar_index_ != 0 || issued) return;
+            issued = true;
+            switch (mode) {
+                case Mode::DEFAULT_QTY:
+                    strategy_entry("D-S", false);
+                    strategy_entry("D-L", true);
+                    break;
+                case Mode::SAME_ID:
+                    strategy_entry("SAME", false, kNaN, kNaN, 5.5);
+                    strategy_entry("SAME", true, kNaN, kNaN, 5.5);
+                    break;
+                case Mode::SAME_DIRECTION:
+                    strategy_entry("DIR-1", true, kNaN, kNaN, 5.5);
+                    strategy_entry("DIR-2", true, kNaN, kNaN, 5.5);
+                    break;
+                case Mode::RAW_SIBLING:
+                    strategy_order("RAW-S", false, 5.5);
+                    strategy_entry("RAW-L", true, kNaN, kNaN, 5.5);
+                    break;
+                case Mode::OCA:
+                    strategy_entry("OCA-S", false, kNaN, kNaN, 5.5, "",
+                                   "PAIR-G", 1);
+                    strategy_entry("OCA-L", true, kNaN, kNaN, 5.5, "",
+                                   "PAIR-G", 1);
+                    break;
+                case Mode::ZERO_QTY:
+                    strategy_entry("ZERO-S", false, kNaN, kNaN, 0.0);
+                    strategy_entry("ZERO-L", true, kNaN, kNaN, 5.5);
+                    break;
+                case Mode::CUSTOM_MARGIN:
+                    strategy_entry("MARGIN-S", false, kNaN, kNaN, 11.0);
+                    strategy_entry("MARGIN-L", true, kNaN, kNaN, 11.0);
+                    break;
+                case Mode::THREE_CALLS:
+                    strategy_entry("THREE-L1", true, kNaN, kNaN, 5.5);
+                    strategy_entry("THREE-L2", true, kNaN, kNaN, 5.5);
+                    strategy_entry("THREE-S3", false, kNaN, kNaN, 5.5);
+                    break;
+                case Mode::POOC:
+                case Mode::COOF:
+                case Mode::SLIPPAGE:
+                case Mode::NON_P2:
+                case Mode::RISK_RULE:
+                    strategy_entry("MODE-S", false, kNaN, kNaN, 5.5);
+                    strategy_entry("MODE-L", true, kNaN, kNaN, 5.5);
+                    break;
+            }
+            snapshot();
+        }
+    } default_qty(P::Mode::DEFAULT_QTY), same_id(P::Mode::SAME_ID),
+      same_direction(P::Mode::SAME_DIRECTION), pooc(P::Mode::POOC),
+      coof(P::Mode::COOF), raw(P::Mode::RAW_SIBLING), oca(P::Mode::OCA),
+      slippage(P::Mode::SLIPPAGE), zero_qty(P::Mode::ZERO_QTY),
+      non_p2(P::Mode::NON_P2), custom_margin(P::Mode::CUSTOM_MARGIN),
+      risk_rule(P::Mode::RISK_RULE), three_calls(P::Mode::THREE_CALLS);
+
+    Bar one[1] = { mk(100, 600'000) };
+    P* probes[] = { &default_qty, &same_id, &same_direction, &pooc, &coof,
+                    &raw, &oca, &slippage, &zero_qty, &non_p2,
+                    &custom_margin, &risk_rule, &three_calls };
+    for (P* probe : probes) probe->run(one, 1);
+
+    CHECK(default_qty.queued == 2 && default_qty.metadata_clean);
+    CHECK(same_id.queued == 1 && same_id.metadata_clean);
+    CHECK(same_direction.queued == 2 && same_direction.metadata_clean);
+    CHECK(pooc.queued == 2 && pooc.metadata_clean);
+    CHECK(coof.queued == 2 && coof.metadata_clean);
+    CHECK(raw.queued == 2 && raw.metadata_clean);
+    CHECK(oca.queued == 2 && oca.metadata_clean);
+    CHECK(slippage.queued == 2 && slippage.metadata_clean);
+    CHECK(zero_qty.queued == 2 && zero_qty.metadata_clean);
+    CHECK(non_p2.queued == 2 && non_p2.metadata_clean);
+    CHECK(custom_margin.queued == 2 && custom_margin.metadata_clean);
+    CHECK(risk_rule.queued == 2 && risk_rule.metadata_clean);
+    CHECK(three_calls.queued == 3 && three_calls.metadata_clean);
+}
+
+// A market order cannot remain pending across the next source evaluation: it
+// fills at that bar's open before on_bar. This pins the reachable cross-bar
+// shape—second placement sees a live position, not a same-source flat peer.
+static void test_MM_cross_bar_calls_do_not_pair() {
+    std::printf("test_MM_cross_bar_calls_do_not_pair\n");
+    struct P : PendingMarketProbeBase {
+        size_t queued = 0;
+        bool metadata_clean = false;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("XB-S", false, kNaN, kNaN, 5.5);
+            } else if (bar_index_ == 1) {
+                strategy_entry("XB-L", true, kNaN, kNaN, 5.5);
+                queued = pending_count();
+                metadata_clean = pending_pair_metadata_clean();
+            }
+        }
+    } p;
+    Bar bars[2] = { mk(100, 600'000), mk(100, 1'200'000) };
+    p.run(bars, 2);
+    CHECK(p.queued == 1);
+    CHECK(p.metadata_clean);
+}
+
+// Pair scope is the complete broker book, not just the candidate source bar.
+// A prior-bar long limit remains resting while the current short/long MARKET
+// calls are placed, then gaps through at the shared next open. All three entry-
+// like orders must retain ordinary sequence semantics. At the 55% wedge, a
+// leaked pair would gross-reject PAIR-L and leave the short held instead.
+static void test_MM_prior_bar_gapped_limit_disqualifies_current_pair() {
+    std::printf("test_MM_prior_bar_gapped_limit_disqualifies_current_pair\n");
+    struct P : PendingMarketProbeBase {
+        double position_after_fills = 0.0;
+        int trades_after_fills = 0;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("REST-L", true, 90.0, kNaN, 1.0);
+            } else if (bar_index_ == 1) {
+                strategy_entry("PAIR-S", false, kNaN, kNaN, 5.5);
+                strategy_entry("PAIR-L", true,  kNaN, kNaN, 5.5);
+            } else if (bar_index_ == 2) {
+                position_after_fills = pos();
+                trades_after_fills = trade_count();
+                strategy_close_all();
+            }
+        }
+    } p;
+    Bar bars[4] = {
+        mk(100, 600'000), mk(100, 1'200'000),
+        mk(80, 1'800'000), mk(80, 2'400'000),
+    };
+    p.run(bars, 4);
+
+    CHECK(near(p.position_after_fills, 5.5));
+    CHECK(p.trades_after_fills == 2);
+    if (p.trades_after_fills == 2) {
+        CHECK(p.get_trade(0).is_long);
+        CHECK(p.get_trade(0).entry_id == "REST-L");
+        CHECK(!p.get_trade(1).is_long);
+        CHECK(p.get_trade(1).entry_id == "PAIR-S");
+    }
+}
+
+// Pair lifecycle: removing or replacing one leg must clear the survivor's
+// frozen gross transaction. Otherwise an orphan could open own+removed-peer.
+static void test_MM_cancel_and_replacement_unpair_survivors() {
+    std::printf("test_MM_cancel_and_replacement_unpair_survivors\n");
+    struct Cancel : PendingMarketProbeBase {
+        size_t queued = 0;
+        bool survivor_clean = false;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("CAN-S", false, kNaN, kNaN, 2.5);
+                strategy_entry("CAN-L", true, kNaN, kNaN, 2.5);
+                strategy_cancel("CAN-S");
+                queued = pending_count();
+                survivor_clean = pending_pair_metadata_clean()
+                    && pending_has("CAN-L", true, 2.5);
+            } else if (bar_index_ == 1) {
+                strategy_close_all();
+            }
+        }
+    } cancel;
+    Bar bars[3] = { mk(100, 600'000), mk(100, 1'200'000), mk(100, 1'800'000) };
+    cancel.run(bars, 3);
+    CHECK(cancel.queued == 1);
+    CHECK(cancel.survivor_clean);
+    CHECK(cancel.trade_count() == 1);
+    if (cancel.trade_count() == 1) {
+        CHECK(cancel.get_trade(0).entry_id == "CAN-L");
+        CHECK(near(cancel.get_trade(0).qty, 2.5));
+    }
+
+    struct Replace : PendingMarketProbeBase {
+        size_t queued = 0;
+        bool both_clean = false;
+        double position_after_fills = 0.0;
+        int trades_after_fills = 0;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("REP-S", false, kNaN, kNaN, 2.5);
+                strategy_entry("REP-L", true, kNaN, kNaN, 2.5);
+                strategy_entry("REP-S", false, kNaN, kNaN, 5.5);
+                queued = pending_count();
+                both_clean = pending_pair_metadata_clean()
+                    && pending_has("REP-S", false, 5.5)
+                    && pending_has("REP-L", true, 2.5);
+            } else if (bar_index_ == 1) {
+                position_after_fills = pos();
+                trades_after_fills = trade_count();
+                strategy_close_all();
+            }
+        }
+    } replace;
+    replace.run(bars, 3);
+    CHECK(replace.queued == 2);
+    CHECK(replace.both_clean);
+    CHECK(replace.trades_after_fills == 1);
+    CHECK(!replace.get_trade(0).is_long);
+    CHECK(replace.get_trade(0).entry_id == "REP-S");
+    CHECK(near(replace.position_after_fills, 2.5));
+
+    struct CancelRearm : PendingMarketProbeBase {
+        int trades_after_fills = 0;
+        double position_after_fills = 0.0;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("CR-A-L", true,  kNaN, kNaN, 2.5);
+                strategy_entry("CR-B-S", false, kNaN, kNaN, 2.5);
+                strategy_cancel("CR-A-L");
+                strategy_entry("CR-C-L", true, kNaN, kNaN, 2.5);
+            } else if (bar_index_ == 1) {
+                trades_after_fills = trade_count();
+                position_after_fills = pos();
+                strategy_close_all();
+            }
+        }
+    } cancel_rearm;
+    cancel_rearm.run(bars, 3);
+    CHECK(cancel_rearm.trades_after_fills == 1);
+    CHECK(!cancel_rearm.get_trade(0).is_long);
+    CHECK(cancel_rearm.get_trade(0).entry_id == "CR-B-S");
+    CHECK(near(cancel_rearm.position_after_fills, 2.5));
+}
+
+// A current-bar candidate that replaces a prior-bar entry is a mutation, not
+// one side of an exact two-call pair. A rests as a limit on bar 0; on bar 1 B
+// is called first and A is replaced by a MARKET candidate. Because A preserves
+// its older broker sequence, leaked finalization would gross-reject B at 110%
+// and leave A long. The tainted ordinary path fills A then B and holds B short.
+static void test_MM_prior_bar_entry_replacement_taints_current_pair_set() {
+    std::printf(
+        "test_MM_prior_bar_entry_replacement_taints_current_pair_set\n");
+    struct P : PendingMarketProbeBase {
+        double position_after_fills = 0.0;
+        int trades_after_fills = 0;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("REP-A", true, 90.0, kNaN, 1.0);
+            } else if (bar_index_ == 1) {
+                strategy_entry("REP-B", false, kNaN, kNaN, 5.5);
+                strategy_entry("REP-A", true,  kNaN, kNaN, 5.5);
+            } else if (bar_index_ == 2) {
+                position_after_fills = pos();
+                trades_after_fills = trade_count();
+                strategy_close_all();
+            }
+        }
+    } p;
+    Bar bars[4] = {
+        mk(100, 600'000), mk(100, 1'200'000),
+        mk(100, 1'800'000), mk(100, 2'400'000),
+    };
+    p.run(bars, 4);
+
+    CHECK(near(p.position_after_fills, -5.5));
+    CHECK(p.trades_after_fills == 1);
+    if (p.trades_after_fills == 1) {
+        CHECK(p.get_trade(0).is_long);
+        CHECK(p.get_trade(0).entry_id == "REP-A");
+        CHECK(p.get_trade(0).exit_id == "REP-B");
+        CHECK(near(p.get_trade(0).qty, 5.5));
+    }
+}
+
+// Pair finalization must see the COMPLETE source-bar set. Alternating triples
+// are ordinary source-ordered calls; call 2 must neither pair nor gross-reject
+// before call 3 is known.
+static void test_MM_alternating_three_call_sets_remain_ordinary() {
+    std::printf("test_MM_alternating_three_call_sets_remain_ordinary\n");
+    struct P : PendingMarketProbeBase {
+        bool short_first;
+        size_t queued_after_signal = 0;
+        double position_after_fills = 0.0;
+        int trades_after_fills = 0;
+        explicit P(bool sf) : short_first(sf) {}
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                if (short_first) {
+                    strategy_entry("SLS-1-S", false, kNaN, kNaN, 5.5);
+                    strategy_entry("SLS-2-L", true,  kNaN, kNaN, 5.5);
+                    strategy_entry("SLS-3-S", false, kNaN, kNaN, 5.5);
+                } else {
+                    strategy_entry("LSL-1-L", true,  kNaN, kNaN, 5.5);
+                    strategy_entry("LSL-2-S", false, kNaN, kNaN, 5.5);
+                    strategy_entry("LSL-3-L", true,  kNaN, kNaN, 5.5);
+                }
+                queued_after_signal = pending_count();
+            } else if (bar_index_ == 1) {
+                position_after_fills = pos();
+                trades_after_fills = trade_count();
+                strategy_close_all();
+            }
+        }
+    } sls(true), lsl(false);
+    Bar bars[3] = { mk(100, 600'000), mk(100, 1'200'000), mk(100, 1'800'000) };
+    sls.run(bars, 3);
+    lsl.run(bars, 3);
+
+    CHECK(sls.queued_after_signal == 3);
+    CHECK(sls.trades_after_fills == 2);
+    CHECK(near(sls.position_after_fills, -5.5));
+    CHECK(sls.get_trade(0).entry_id == "SLS-1-S");
+    CHECK(sls.get_trade(1).entry_id == "SLS-2-L");
+    CHECK(sls.trade_count() == 3);
+
+    CHECK(lsl.queued_after_signal == 3);
+    CHECK(lsl.trades_after_fills == 2);
+    CHECK(near(lsl.position_after_fills, 5.5));
+    CHECK(lsl.get_trade(0).entry_id == "LSL-1-L");
+    CHECK(lsl.get_trade(1).entry_id == "LSL-2-S");
+    CHECK(lsl.trade_count() == 3);
+}
+
+// A scope change after placement but before broker processing must suppress
+// finalization. This pins the fill-boundary risk-config revalidation.
+static void test_MM_pair_scope_revalidated_before_fill() {
+    std::printf("test_MM_pair_scope_revalidated_before_fill\n");
+    struct P : PendingMarketProbeBase {
+        size_t queued_after_signal = 0;
+        double position_after_fills = 0.0;
+        int trades_after_fills = 0;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("RISK-S", false, kNaN, kNaN, 2.5);
+                strategy_entry("RISK-L", true,  kNaN, kNaN, 2.5);
+                queued_after_signal = pending_count();
+                // Non-blocking at qty 2.5, but its mere configuration is out
+                // of the pinned pair scope and must be observed at finalization.
+                risk_max_position_size_ = 100.0;
+            } else if (bar_index_ == 1) {
+                position_after_fills = pos();
+                trades_after_fills = trade_count();
+                strategy_close_all();
+            }
+        }
+    } p;
+    Bar bars[3] = { mk(100, 600'000), mk(100, 1'200'000), mk(100, 1'800'000) };
+    p.run(bars, 3);
+    CHECK(p.queued_after_signal == 2);
+    CHECK(p.trades_after_fills == 1);
+    CHECK(!p.get_trade(0).is_long);
+    CHECK(p.get_trade(0).entry_id == "RISK-S");
+    CHECK(near(p.position_after_fills, 2.5));
+}
+
+// Pair recognition counts every same-bar flat entry-like broker order, not
+// only explicit candidates. A default/OCA/RAW/priced third order disqualifies
+// the bar and leaves the first two in ordinary source order.
+static void test_MM_mixed_third_entry_like_order_disqualifies_pair() {
+    std::printf("test_MM_mixed_third_entry_like_order_disqualifies_pair\n");
+    struct P : PendingMarketProbeBase {
+        enum class Third { DEFAULT_MARKET, OCA_MARKET, RAW_MARKET, PRICED };
+        Third third;
+        int trades_after_fills = 0;
+        bool first_trade_is_ordinary_short = false;
+        explicit P(Third t) : third(t) {}
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("MIX-E1-S", false, kNaN, kNaN, 2.5);
+                strategy_entry("MIX-E2-L", true,  kNaN, kNaN, 2.5);
+                switch (third) {
+                    case Third::DEFAULT_MARKET:
+                        strategy_entry("MIX-D3-S", false);
+                        break;
+                    case Third::OCA_MARKET:
+                        strategy_entry("MIX-O3-S", false, kNaN, kNaN, 1.0,
+                                       "", "MIX-G", 1);
+                        break;
+                    case Third::RAW_MARKET:
+                        strategy_order("MIX-R3-S", false, 1.0);
+                        break;
+                    case Third::PRICED:
+                        strategy_entry("MIX-P3-S", false, kNaN, 50.0, 1.0);
+                        break;
+                }
+            } else if (bar_index_ == 1) {
+                trades_after_fills = trade_count();
+                if (trades_after_fills > 0) {
+                    first_trade_is_ordinary_short =
+                        !get_trade(0).is_long
+                        && get_trade(0).entry_id == "MIX-E1-S";
+                }
+                strategy_cancel_all();
+                strategy_close_all();
+            }
+        }
+    } def(P::Third::DEFAULT_MARKET), oca(P::Third::OCA_MARKET),
+      raw(P::Third::RAW_MARKET), priced(P::Third::PRICED);
+    Bar bars[3] = { mk(100, 600'000), mk(100, 1'200'000), mk(100, 1'800'000) };
+    P* probes[] = { &def, &oca, &raw, &priced };
+    for (P* probe : probes) probe->run(bars, 3);
+    for (P* probe : probes) {
+        CHECK(probe->trades_after_fills >= 1);
+        CHECK(probe->first_trade_is_ordinary_short);
+    }
+}
+
+// Quantize each own leg once, then sum those frozen broker quantities. Raw
+// 5.1+5.1 would be 102% and reject; with qty_step=1 TV sends 5+5=100%, admits,
+// and the internal pre-quantized path must preserve exactly 5 contracts.
+static void test_MM_pair_uses_sum_of_frozen_quantized_own_qty() {
+    std::printf("test_MM_pair_uses_sum_of_frozen_quantized_own_qty\n");
+    struct P : PendingMarketProbeBase {
+        double position_after_pair = 0.0;
+        double ledger_after_pair = 0.0;
+        P() { qty_step_ = 1.0; }
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("Q-S", false, kNaN, kNaN, 5.1);
+                strategy_entry("Q-L", true,  kNaN, kNaN, 5.1);
+            } else if (bar_index_ == 1) {
+                position_after_pair = pos();
+                ledger_after_pair = logical_open_qty("Q-L");
+                strategy_close_all();
+            }
+        }
+    } p;
+    Bar bars[3] = { mk(100, 600'000), mk(100, 1'200'000), mk(100, 1'800'000) };
+    p.run(bars, 3);
+    CHECK(near(p.position_after_pair, 5.0));
+    CHECK(near(p.ledger_after_pair, 5.0));
+    CHECK(p.trade_count() == 2);
+    CHECK(p.get_trade(0).is_long);
+    CHECK(p.get_trade(0).entry_id == "Q-L");
+    CHECK(near(p.get_trade(0).qty, 5.0));
+    CHECK(near(p.get_trade(1).qty, 5.0));
+}
+
+// The explicit-qty adverse-gap recheck must cost the paired GROSS broker fill.
+// Own qty 4 costs only 520 at the 130 fill and would admit incorrectly; gross
+// qty 8 costs 1040, so the buy is declined and the surviving short fills own 4.
+static void test_MM_pair_fill_gap_gate_uses_gross_transaction_qty() {
+    std::printf("test_MM_pair_fill_gap_gate_uses_gross_transaction_qty\n");
+    struct P : PendingMarketProbeBase {
+        double position_after_gap = 0.0;
+        int trades_after_gap = 0;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("GAP-S", false, kNaN, kNaN, 4.0);
+                strategy_exit("GAP-X1", "GAP-L", 180.0, kNaN,
+                              kNaN, kNaN, kNaN, 50.0, "", 2.0);
+                strategy_exit("GAP-X2", "GAP-L", kNaN, 80.0,
+                              kNaN, kNaN, kNaN, 50.0, "", 2.0);
+                strategy_entry("GAP-L", true,  kNaN, kNaN, 4.0);
+            } else if (bar_index_ == 1) {
+                position_after_gap = pos();
+                trades_after_gap = trade_count();
+                strategy_close_all();
+            }
+        }
+    } p;
+    Bar bars[3] = { mk(100, 600'000), mk(130, 1'200'000), mk(130, 1'800'000) };
+    p.run(bars, 3);
+    CHECK(near(p.position_after_gap, -4.0));
+    CHECK(p.trades_after_gap == 0);
+    CHECK(p.trade_count() == 1);
+    CHECK(!p.get_trade(0).is_long);
+    CHECK(p.get_trade(0).entry_id == "GAP-S");
+    CHECK(near(p.get_trade(0).qty, 4.0));
+}
+
+// Deferred percent-layered exits armed between pair calls resolve against the
+// final own exposure, not the transient gross open. At 2.5, 40%/60% must freeze
+// to 1.0/1.5 only after transaction netting completes.
+static void test_MM_pair_defers_percent_exit_reconciliation_until_net() {
+    std::printf("test_MM_pair_defers_percent_exit_reconciliation_until_net\n");
+    struct P : PendingMarketProbeBase {
+        double position_after_pair = 0.0;
+        double ledger_after_pair = 0.0;
+        double exit_one_qty = 0.0;
+        double exit_two_qty = 0.0;
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("LAY-S", false, kNaN, kNaN, 2.5);
+                strategy_exit("LAY-X1", "LAY-L", 150.0, kNaN,
+                              kNaN, kNaN, kNaN, 40.0, "", kNaN);
+                strategy_exit("LAY-X2", "LAY-L", 160.0, kNaN,
+                              kNaN, kNaN, kNaN, 60.0, "", kNaN);
+                strategy_entry("LAY-L", true, kNaN, kNaN, 2.5);
+            } else if (bar_index_ == 1) {
+                position_after_pair = pos();
+                ledger_after_pair = logical_open_qty("LAY-L");
+                for (const PendingOrder& order : pending_orders_) {
+                    if (order.id == "LAY-X1") exit_one_qty = order.qty;
+                    if (order.id == "LAY-X2") exit_two_qty = order.qty;
+                }
+                strategy_cancel_all();
+                strategy_close_all();
+            }
+        }
+    } p;
+    Bar bars[3] = { mk(100, 600'000), mk(100, 1'200'000), mk(100, 1'800'000) };
+    p.run(bars, 3);
+    CHECK(near(p.position_after_pair, 2.5));
+    CHECK(near(p.ledger_after_pair, 2.5));
+    CHECK(near(p.exit_one_qty, 1.0));
+    CHECK(near(p.exit_two_qty, 1.5));
+    CHECK(p.trade_count() == 2);
+}
+
 int main() {
     test_R1_ms_lf_a_short_held();
     test_R2_ms_sf_a_long_held();
@@ -274,6 +1095,22 @@ int main() {
     test_G1_ss_lf_a_single_close_flat();
     test_G2_mm_both_market_unchanged();
     test_G3_placement_rejected_contributes_zero();
+    test_MM_HSF_buy_first_exact_trade_decomposition();
+    test_MM_HLF_gross_sell_transaction_mirror();
+    test_MM_HSF_interleaved_brackets_keep_fill_iteration_stable();
+    test_MM_tight_gross_110pct_rejects_later_leg_both_directions();
+    test_MM_tight_single_55pct_controls_admit();
+    test_MM_scope_predicates_do_not_pair_or_gross_gate();
+    test_MM_cross_bar_calls_do_not_pair();
+    test_MM_prior_bar_gapped_limit_disqualifies_current_pair();
+    test_MM_cancel_and_replacement_unpair_survivors();
+    test_MM_prior_bar_entry_replacement_taints_current_pair_set();
+    test_MM_alternating_three_call_sets_remain_ordinary();
+    test_MM_pair_scope_revalidated_before_fill();
+    test_MM_mixed_third_entry_like_order_disqualifies_pair();
+    test_MM_pair_uses_sum_of_frozen_quantized_own_qty();
+    test_MM_pair_fill_gap_gate_uses_gross_transaction_qty();
+    test_MM_pair_defers_percent_exit_reconciliation_until_net();
     std::printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
     return tests_failed == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

- finalize exactly two explicit fixed opposite MARKET entries created broker-flat on the same source bar as a paired broker transaction
- preserve each call's own quantity while applying TradingView's gross affordability check to the later transaction
- execute admitted pairs buy-before-sell without reordering unrelated exits
- defer pair recognition until the complete source-bar order set is known and fence off prior resting entries, replacements, cancellation, risk, POOC, COOF, OCA, slippage, custom margins, and other unproven scopes
- add 178 focused assertions covering decomposition, rejection, ordering, gap admission, quantization, exit reconciliation, and lifecycle safety

## Root cause

The engine admitted each explicit market call using only its own quantity and then filled opposite calls in source order. The TradingView probes show that, in this narrow flat two-call scope, the later call is admitted using its own quantity plus the earlier pending opposite quantity, while an admitted pair fills buy-before-sell. This produced two proven extra Thula trades.

## Impact

- hardened affordability probe: 3,128 / 3,128 exact, 100% price parity
- bracket control probe: 3,128 / 3,128 exact
- precedence control remains unchanged at 6,256 / 7,429 (84.2%), 100% matched-price parity
- Thula absolute count gap improves from 8 to 6
- 11 non-target sentinel trade tapes remain byte-identical
- no codegen, verifier, tier-threshold, inputs, metrics, or TradingView-oracle changes

## Validation

- independent safety audit: PASS
- standalone engine: full build PASS; CTest 99 / 99
- cumulative accepted engine: full build PASS; CTest 103 / 103
- focused paired-market suite: 178 / 178
- corpus, standalone and cumulative: 252 / 252 runtimes; 240 Excellent / 11 Strong / 1 anomaly
- codegen header compatibility: 1,537 passed / 2 skipped
- targeted scraper gate: 12 / 12 OK; 0 UP / 0 DOWN
- forced no-cache full sweep: 412 accounted as 403 OK + 1 no-trades + 7 transpile errors + 0 compile errors + 1 run error
- full board: 337 Excellent / 54 Strong / 5 Moderate / 5 Weak; 0 UP / 0 DOWN
