### PR TITLE
fix(ta): align PercentRank float comparisons

### DIFF
--- a/src/ta_misc.cpp
+++ b/src/ta_misc.cpp
@@ -19,6 +19,21 @@
 namespace pineforge {
 namespace ta {
 
+namespace {
+
+constexpr double kPineFloatEqualityBand = 1e-10;
+
+bool percentrank_less_equal(double lhs, double rhs) {
+    if (is_na(lhs) || is_na(rhs)) return false;
+    const bool equal =
+        lhs == rhs ||
+        (std::isfinite(lhs) && std::isfinite(rhs) &&
+         std::fabs(lhs - rhs) <= kPineFloatEqualityBand);
+    return lhs < rhs || equal;
+}
+
+}  // namespace
+
 
 // --- Linreg (Linear Regression) ---
 
@@ -87,7 +102,7 @@ double PercentRank::compute(double src) {
         double v = buffer_[i];
         if (is_na(v)) continue;
         valid++;
-        if (v <= current) {
+        if (percentrank_less_equal(v, current)) {
             count++;
         }
     }
@@ -240,7 +255,7 @@ double PercentRank::recompute(double src) {
         double v = buffer_[i];
         if (is_na(v)) continue;
         valid++;
-        if (v <= current) count++;
+        if (percentrank_less_equal(v, current)) count++;
     }
     if (valid == 0) return na<double>();
     return ((double)count / (double)valid) * 100.0;

--- a/tests/test_ta.cpp
+++ b/tests/test_ta.cpp
@@ -171,6 +171,82 @@ static int test_percentrank_pine_semantics() {
             fails++;
         }
     }
+    {
+        // PercentRank uses Pine's fixed finite comparison band internally:
+        // values at most 1e-10 above the current sample compare equal.
+        ta::PercentRank causal(2);
+        causal.compute(-10.0);
+        causal.compute(-5.349999999999909);
+        double got = causal.compute(-5.350000000000136);
+        if (!near(got, 100.0)) {
+            std::printf("FAIL percentrank fixed-band causal: got %g want 100\n", got);
+            fails++;
+        }
+
+        ta::PercentRank inside(2);
+        inside.compute(-1.0);
+        inside.compute(9e-11);
+        got = inside.compute(0.0);
+        if (!near(got, 100.0)) {
+            std::printf("FAIL percentrank fixed-band inside: got %g want 100\n", got);
+            fails++;
+        }
+
+        ta::PercentRank endpoint(2);
+        endpoint.compute(-1.0);
+        endpoint.compute(1e-10);
+        got = endpoint.compute(0.0);
+        if (!near(got, 100.0)) {
+            std::printf("FAIL percentrank fixed-band endpoint: got %g want 100\n", got);
+            fails++;
+        }
+
+        ta::PercentRank outside(2);
+        outside.compute(-1.0);
+        outside.compute(1.1e-10);
+        got = outside.compute(0.0);
+        if (!near(got, 50.0)) {
+            std::printf("FAIL percentrank fixed-band outside: got %g want 50\n", got);
+            fails++;
+        }
+    }
+    {
+        const double inf = std::numeric_limits<double>::infinity();
+
+        ta::PercentRank positive_inf(2);
+        positive_inf.compute(-inf);
+        positive_inf.compute(inf);
+        double got = positive_inf.compute(inf);
+        if (!near(got, 100.0)) {
+            std::printf("FAIL percentrank positive infinity: got %g want 100\n", got);
+            fails++;
+        }
+
+        ta::PercentRank negative_inf(2);
+        negative_inf.compute(-inf);
+        negative_inf.compute(inf);
+        got = negative_inf.compute(-inf);
+        if (!near(got, 50.0)) {
+            std::printf("FAIL percentrank negative infinity: got %g want 50\n", got);
+            fails++;
+        }
+    }
+    {
+        ta::PercentRank recomputed(2);
+        recomputed.compute(-1.0);
+        recomputed.compute(1.9e-10);
+        recomputed.compute(0.0);
+        double got = recomputed.recompute(1e-10);
+
+        ta::PercentRank fresh(2);
+        fresh.compute(-1.0);
+        fresh.compute(1.9e-10);
+        double want = fresh.compute(1e-10);
+        if (!near(got, 100.0) || !near(got, want)) {
+            std::printf("FAIL percentrank fixed-band recompute: got %g want %g\n", got, want);
+            fails++;
+        }
+    }
     return fails;
 }
 


### PR DESCRIPTION
## Summary

- apply Pine fixed-band float equality inside ta.percentrank internal less-than-or-equal comparisons
- preserve exact equality for infinities, reject na, and retain normal ordering outside the finite abs(left-right) <= 1e-10 band
- share the rule across causal compute and same-bar recompute
- pin the merged corpus artifact commit from pineforge-corpus PR #14

The target adjacent values differ by only 2.27e-13. The old raw comparison kept the rank at 6 to 6; the fixed band produces 6 to 8 and recovers the sole missing TradingView trade without losing any prior exact match.

## Validation

- exact final head a1ca227: clean Release build and CTest 112/112
- focused PercentRank boundary, na, infinity, and recompute tests pass
- merged codegen suite 1,358 passed / 2 skipped; relevant comparator tests 30 passed / 2 skipped
- exact-base OFF corpus: 252/252, 246 Excellent / 5 Strong / 1 anomaly
- ON corpus: 252/252, 247 Excellent / 4 Strong / 1 anomaly
- bytewise OFF/ON diff changes exactly 1/252 tapes: ta-percentrank-mean-reversion-01
- narrowed merged-gitlink verifier and report self-test pass at 247/4/1
- forced-no-cache scraper gate: 412/412 accounted, 0 unresolved timeouts, 0 UP / 0 DOWN; board remains 346/47/4/5

No Pine source, TradingView export, feed, verifier threshold, or tier rule changed.