### PR TITLE
fix: preserve commissioned all-in opening lots

### DIFF
--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -596,6 +596,13 @@ protected:
     // and FIFO can reduce a real pyramid back to one live lot.
     bool opening_affordability_pending_ = false;
     bool opening_affordability_eligible_ = false;
+    // The queued event came from a successful, commissioned, omitted-qty
+    // percent_of_equity=100 high-level MARKET long that was created and filled
+    // from true flat.  process_margin_call combines this one-shot provenance
+    // with the actual margin/commission arithmetic before applying TV's
+    // fee-created, floor-zero one-contract fallback.  Reversals, adds,
+    // explicit/priced/RAW orders and zero/CASH commission stay outside it.
+    bool opening_affordability_commissioned_default_flat_long_ = false;
     double opening_affordability_raw_fill_base_ =
         std::numeric_limits<double>::quiet_NaN();
     int64_t position_entry_time_ = 0;

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -489,10 +489,13 @@ void BacktestEngine::process_margin_call(const Bar& bar) {
     // state that a later bar may reconstruct or reuse.
     const bool opening_event_pending = opening_affordability_pending_;
     const bool opening_event_eligible = opening_affordability_eligible_;
+    const bool opening_event_commissioned_default_flat_long =
+        opening_affordability_commissioned_default_flat_long_;
     const double opening_event_raw_fill_base =
         opening_affordability_raw_fill_base_;
     opening_affordability_pending_ = false;
     opening_affordability_eligible_ = false;
+    opening_affordability_commissioned_default_flat_long_ = false;
     opening_affordability_raw_fill_base_ =
         std::numeric_limits<double>::quiet_NaN();
 
@@ -563,6 +566,7 @@ void BacktestEngine::process_margin_call(const Bar& bar) {
 
     double q_min = 0.0;
     double raw_exit_fill_base = 0.0;
+    bool fee_created_floor_zero_candidate = false;
     if (opening_affordability) {
         // Post-fill affordability is evaluated from the current position's
         // actual, directionally snapped/slipped entry basis. Capital and
@@ -612,6 +616,24 @@ void BacktestEngine::process_margin_call(const Bar& bar) {
         const double required_margin = qty * margin_per_unit;
         if (opening_equity >= required_margin) return;
         q_min = qty - opening_equity / margin_per_unit;
+        // A source-faithful TV tape pins a discontinuous broker edge for the
+        // exact one-shot provenance above: margin remains affordable before a
+        // positive percentage opening fee, that fee alone creates a sub-step
+        // shortfall, and TV closes one whole contract instead of dust-nooping.
+        // Keep both comparisons directional and tolerance-aware.  An absolute
+        // difference alone would turn affordable headroom into a false call.
+        const double pre_fee_equity = opening_equity + entry_commission;
+        const double comparison_guard = std::max(
+            1e-9, std::abs(pre_fee_equity) * 1e-12);
+        const double pre_fee_headroom = pre_fee_equity - required_margin;
+        const double post_fee_deficit = required_margin - opening_equity;
+        fee_created_floor_zero_candidate =
+            opening_event_commissioned_default_flat_long
+            && commission_type_ == CommissionType::PERCENT
+            && commission_value_ > 0.0
+            && entry_commission > 0.0
+            && pre_fee_headroom > comparison_guard
+            && post_fee_deficit > comparison_guard;
         raw_exit_fill_base = opening_event_raw_fill_base;
     } else {
         // Shorts and leveraged longs without a fresh opening event keep the
@@ -644,6 +666,7 @@ void BacktestEngine::process_margin_call(const Bar& bar) {
     // / 53.0532 / 59.69 / … ; floor-AFTER matched 0/19 and desynced by step 7).
     // qty_step_ == 0 (corpus default; the explicit-leverage p2/5x margin probes
     // never set it) leaves both q_min and qty_liq untouched -> byte-identical.
+    const double raw_q_min = q_min;
     if (qty_step_ > 0.0) {
         // The quotient can land microscopically below an exact integer because
         // of binary representation (for example, one mathematical lot can be
@@ -663,8 +686,29 @@ void BacktestEngine::process_margin_call(const Bar& bar) {
     // not a reason to force the generic finite-price cascade's one-step
     // progress fallback. qty_step==0 intentionally retains continuous-qty
     // behavior because no exchange lot floor was configured.
-    if (opening_affordability && q_min <= kQtyEpsilon) return;
-    double qty_liq = 4.0 * q_min;
+    double opening_floor_zero_fallback =
+        std::numeric_limits<double>::quiet_NaN();
+    if (opening_affordability && q_min <= kQtyEpsilon) {
+        if (fee_created_floor_zero_candidate
+            && qty_step_ > 0.0
+            && qty_step_ <= 1.0
+            && raw_q_min > kQtyEpsilon
+            && raw_q_min < 1.0) {
+            const double candidate = std::min(1.0, qty);
+            const bool full_position_cap = candidate >= qty - kQtyEpsilon;
+            const double gridded = apply_exit_qty_step(candidate);
+            const double grid_guard = std::max(
+                1e-12, std::abs(candidate) * 1e-12);
+            if (full_position_cap
+                || std::abs(gridded - candidate) <= grid_guard) {
+                opening_floor_zero_fallback = candidate;
+            }
+        }
+        if (!std::isfinite(opening_floor_zero_fallback)) return;
+    }
+    double qty_liq = std::isfinite(opening_floor_zero_fallback)
+        ? opening_floor_zero_fallback
+        : 4.0 * q_min;
     if (qty_step_ > 0.0) {
         // q_min is already a multiple of qty_step_, so 4*q_min is mathematically
         // a multiple too — but binary float makes e.g. 4*5.7089 = 22.83559999…,
@@ -2665,6 +2709,7 @@ void BacktestEngine::apply_filled_order_to_state(
         if (successful_short_open_or_add && !scoped_short_opening_fill) {
             opening_affordability_pending_ = false;
             opening_affordability_eligible_ = false;
+            opening_affordability_commissioned_default_flat_long_ = false;
             opening_affordability_raw_fill_base_ =
                 std::numeric_limits<double>::quiet_NaN();
         }
@@ -2704,6 +2749,20 @@ void BacktestEngine::apply_filled_order_to_state(
             opening_affordability_eligible_ =
                 accepted_additional_entry
                 || !frozen_all_in_true_flat_exemption;
+            opening_affordability_commissioned_default_flat_long_ =
+                successful_fresh_open
+                && order.opening_affordability_exemption_candidate
+                && order.type == OrderType::MARKET
+                && order.is_long
+                && std::isnan(order.qty)
+                && order.created_position_side == PositionSide::FLAT
+                && !order.created_after_position_close_in_bar
+                && position_side_before_fill == PositionSide::FLAT
+                && admitted_flat_on_frozen_sizing_price
+                && commission_type_ == CommissionType::PERCENT
+                && commission_value_ > 0.0
+                && std::isfinite(new_opening_commission)
+                && new_opening_commission > 0.0;
             opening_affordability_raw_fill_base_ = fill_price;
         }
     }
@@ -2922,7 +2981,9 @@ void BacktestEngine::apply_market_order_fill(PendingOrder& order, double fill_pr
                          /*close_only_opposite=*/paired_flat_market,
                          /*is_priced_entry=*/false, /*tv_carry_qty=*/0.0,
                          order.created_bar, later_same_tick_entry,
-                         paired_flat_market);
+                         /*paired_flat_market_transaction=*/paired_flat_market,
+                         /*explicit_qty_prequantized=*/
+                             (frozen || paired_flat_market));
     double trail_best_after_fill = trail_best_price_;
     // Set entry comment on the just-created pyramid entry
     if (!pyramid_entries_.empty()
@@ -3265,6 +3326,7 @@ void BacktestEngine::apply_raw_order_fill(PendingOrder& order, double fill_price
         // open_fresh_position.
         opening_affordability_pending_ = false;
         opening_affordability_eligible_ = false;
+        opening_affordability_commissioned_default_flat_long_ = false;
         opening_affordability_raw_fill_base_ =
             std::numeric_limits<double>::quiet_NaN();
         position_entry_time_ = current_bar_.timestamp;

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -563,6 +563,7 @@ void BacktestEngine::reset_position_state_to_flat() {
     position_entry_price_ = 0.0;
     opening_affordability_pending_ = false;
     opening_affordability_eligible_ = false;
+    opening_affordability_commissioned_default_flat_long_ = false;
     opening_affordability_raw_fill_base_ =
         std::numeric_limits<double>::quiet_NaN();
     position_entry_time_ = 0;
@@ -612,6 +613,7 @@ void BacktestEngine::open_fresh_position(PositionSide requested, double fill_pri
     // transiently.
     opening_affordability_pending_ = false;
     opening_affordability_eligible_ = false;
+    opening_affordability_commissioned_default_flat_long_ = false;
     opening_affordability_raw_fill_base_ =
         std::numeric_limits<double>::quiet_NaN();
     position_entry_time_ = current_bar_.timestamp;

--- a/tests/test_default_qty_signal_freeze.cpp
+++ b/tests/test_default_qty_signal_freeze.cpp
@@ -24,6 +24,11 @@
  *      computation — POC sizing is unchanged.
  *   E. CASH default sizing freezes at close(S) too: qty = cash / close(S),
  *      not cash / open(S+1).
+ *   H. An ordinary true-flat omitted-qty MARKET dispatch preserves the
+ *      already-quantized frozen quantity.  It must not apply qty_step a
+ *      second time and lose one lot at an exact binary boundary.
+ *   I. The adjacent explicit-qty shape still receives its ordinary single
+ *      qty_step application; the frozen-quantity exception does not widen.
  */
 
 #include <cmath>
@@ -355,6 +360,99 @@ void test_reversal_bracket_binding_survives_freeze() {
     }
 }
 
+// H/I. Binary-boundary dispatch regression for the ordinary true-flat
+// omitted-qty MARKET path.
+//
+// The raw placement quantity is 6279.0000001 / 1000 = 6.2790000001.  Its
+// first qty_step floor is 6.2790.  In binary64, that result divided by 0.0001
+// is 62789.999999..., so applying the same floor a SECOND time produces
+// 6.2789.  frozen_default_qty is already exchange-quantized at placement;
+// dispatch must preserve it in the position, physical lot, and logical id
+// ledger.  Before the C fix, apply_market_order_fill handed the frozen value
+// to enter_market_from_flat as an ordinary FIXED quantity and it was floored
+// again.
+class FrozenDispatchBoundaryProbe : public BacktestEngine {
+public:
+    explicit FrozenDispatchBoundaryProbe(bool explicit_qty)
+        : explicit_qty_(explicit_qty) {
+        initial_capital_ = 6279.0000001;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100.0;
+        commission_value_ = 0.0;
+        qty_step_ = 0.0001;
+        margin_call_enabled_ = false;
+    }
+
+    void on_bar(const Bar& /*bar*/) override {
+        if (bar_index_ != 0) return;
+        if (explicit_qty_) {
+            // Adjacent control: an explicit raw quantity is not frozen and
+            // must still receive exactly one ordinary qty_step floor.
+            strategy_entry("BOUNDARY", true, kNaN, kNaN, 6.2790000001);
+        } else {
+            strategy_entry("BOUNDARY", true);
+        }
+    }
+
+    double one_floor_qty() const { return apply_qty_step(6.2790000001); }
+    double two_floor_qty() const { return apply_qty_step(one_floor_qty()); }
+    PositionSide position_side() const { return position_side_; }
+    double position_qty() const { return position_qty_; }
+    int live_lot_count() const { return static_cast<int>(pyramid_entries_.size()); }
+    double live_lot_qty() const {
+        return pyramid_entries_.empty() ? 0.0 : pyramid_entries_.front().qty;
+    }
+    std::string live_lot_id() const {
+        return pyramid_entries_.empty() ? "" : pyramid_entries_.front().entry_id;
+    }
+    double id_ledger_qty(const std::string& id) const {
+        const auto it = id_unclosed_qty_.find(id);
+        return it == id_unclosed_qty_.end() ? 0.0 : it->second;
+    }
+
+private:
+    bool explicit_qty_;
+};
+
+static std::vector<Bar> frozen_dispatch_boundary_bars() {
+    return {
+        mk_bar(1000, 1000.0, 1000.0, 1000.0, 1000.0),
+        mk_bar(2000, 1000.0, 1000.0, 1000.0, 1000.0),
+    };
+}
+
+void test_frozen_true_flat_market_dispatch_is_not_refloored() {
+    std::printf("-- H: frozen true-flat MARKET dispatch is not re-floored --\n");
+    FrozenDispatchBoundaryProbe eng(/*explicit_qty=*/false);
+    auto bars = frozen_dispatch_boundary_bars();
+    eng.run(bars.data(), static_cast<int>(bars.size()));
+
+    // Pin the test's binary boundary independently of the dispatch result.
+    CHECK_NEAR(eng.one_floor_qty(), 6.2790, 1e-12);
+    CHECK_NEAR(eng.two_floor_qty(), 6.2789, 1e-12);
+
+    CHECK(eng.position_side() == PositionSide::LONG);
+    CHECK_NEAR(eng.position_qty(), 6.2790, 1e-12);
+    CHECK(eng.live_lot_count() == 1);
+    CHECK_NEAR(eng.live_lot_qty(), 6.2790, 1e-12);
+    CHECK(eng.live_lot_id() == "BOUNDARY");
+    CHECK_NEAR(eng.id_ledger_qty("BOUNDARY"), 6.2790, 1e-12);
+}
+
+void test_explicit_true_flat_market_keeps_single_floor() {
+    std::printf("-- I: explicit true-flat MARKET keeps one qty floor --\n");
+    FrozenDispatchBoundaryProbe eng(/*explicit_qty=*/true);
+    auto bars = frozen_dispatch_boundary_bars();
+    eng.run(bars.data(), static_cast<int>(bars.size()));
+
+    CHECK(eng.position_side() == PositionSide::LONG);
+    CHECK_NEAR(eng.position_qty(), 6.2790, 1e-12);
+    CHECK(eng.live_lot_count() == 1);
+    CHECK_NEAR(eng.live_lot_qty(), 6.2790, 1e-12);
+    CHECK(eng.live_lot_id() == "BOUNDARY");
+    CHECK_NEAR(eng.id_ledger_qty("BOUNDARY"), 6.2790, 1e-12);
+}
+
 }  // namespace
 
 int main() {
@@ -366,6 +464,8 @@ int main() {
     test_cash_freeze();
     test_oca_default_sibling_cancelled();
     test_reversal_bracket_binding_survives_freeze();
+    test_frozen_true_flat_market_dispatch_is_not_refloored();
+    test_explicit_true_flat_market_keeps_single_floor();
     std::printf("\n=== Results: %d passed, %d failed ===\n",
                 tests_passed, tests_failed);
     return tests_failed == 0 ? 0 : 1;

--- a/tests/test_margin_call.cpp
+++ b/tests/test_margin_call.cpp
@@ -668,6 +668,117 @@ private:
     double qty_;
 };
 
+// A commissioned, default-sized all-in long can remain margin-affordable
+// before its opening fee while that fee alone creates a sub-step shortfall.
+// TV's broker closes one whole contract for this exact true-flat MARKET shape
+// when floor_step(q_min)==0.  These probes pin the rule, its full-position cap,
+// the existing nonzero-floor 4x path, and two important scope exclusions.
+class CommissionedDefaultPoeDustProbe : public MCEngine {
+public:
+    CommissionedDefaultPoeDustProbe(
+            double initial_capital, double qty_step,
+            CommissionType commission_type = CommissionType::PERCENT,
+            double commission_value = 0.1,
+            double default_percent = 100.0) {
+        initial_capital_ = initial_capital;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = default_percent;
+        commission_type_ = commission_type;
+        commission_value_ = commission_value;
+        margin_long_ = 100.0;
+        process_orders_on_close_ = false;
+        qty_step_ = qty_step;
+        syminfo_mintick_ = 0.0001;
+    }
+
+    void on_bar(const Bar& /*bar*/) override {
+        if (bar_index_ == 0) {
+            strategy_entry("L", true, kNaN, kNaN, kNaN);
+        }
+    }
+};
+
+static void test_fee_created_floor_zero_closes_one_contract() {
+    std::printf("test_fee_created_floor_zero_closes_one_contract\n");
+    std::vector<Bar> bars = {
+        mk_bar(1000, 1801.33, 1801.33, 1801.33, 1801.33, 1.0),
+        mk_bar(2000, 1801.34, 1801.34, 1801.34, 1801.34, 1.0),
+    };
+    CommissionedDefaultPoeDustProbe eng(
+        /*initial_capital=*/10000.0, /*qty_step=*/0.0001);
+    eng.run(bars.data(), (int)bars.size());
+
+    // Frozen qty is 5.5459. Margin alone retains positive headroom, but the
+    // 0.1% opening fee creates raw q_min=0.00002307... < one step.
+    CHECK(eng.trade_count() == 1);
+    CHECK(eng.exit_comment(0) == std::string("Margin call"));
+    CHECK(near(eng.entry_price(0), 1801.34));
+    CHECK(near(eng.exit_price(0), 1801.34));
+    CHECK(near(eng.trade_size(0), 1.0));
+    CHECK(near(eng.position_size(), 4.5459));
+}
+
+static void test_fee_created_floor_zero_caps_sub_one_position() {
+    std::printf("test_fee_created_floor_zero_caps_sub_one_position\n");
+    std::vector<Bar> bars = {
+        mk_bar(1000, 1500.0, 1500.0, 1500.0, 1500.0, 1.0),
+        mk_bar(2000, 1500.01, 1500.01, 1500.01, 1500.01, 1.0),
+    };
+    CommissionedDefaultPoeDustProbe eng(
+        /*initial_capital=*/1000.0, /*qty_step=*/0.0001);
+    eng.run(bars.data(), (int)bars.size());
+
+    CHECK(eng.trade_count() == 1);
+    CHECK(eng.exit_comment(0) == std::string("Margin call"));
+    CHECK(near(eng.trade_size(0), 0.666));
+    CHECK(near(eng.position_size(), 0.0));
+}
+
+static void test_fee_created_nonzero_floor_keeps_four_x_quantity() {
+    std::printf("test_fee_created_nonzero_floor_keeps_four_x_quantity\n");
+    std::vector<Bar> bars = {
+        mk_bar(1000, 1872.19, 1872.19, 1872.19, 1872.19, 1.0),
+        mk_bar(2000, 1872.27, 1872.27, 1872.27, 1872.27, 1.0),
+    };
+    CommissionedDefaultPoeDustProbe eng(
+        /*initial_capital=*/9949.545946, /*qty_step=*/0.0001);
+    eng.run(bars.data(), (int)bars.size());
+
+    // raw q_min=0.00014707... floors to 0.0001 before the established 4x.
+    CHECK(eng.trade_count() == 1);
+    CHECK(near(eng.trade_size(0), 0.0004));
+    CHECK(near(eng.position_size(), 5.3086));
+}
+
+static void test_fee_created_floor_zero_rejects_off_grid_one_contract() {
+    std::printf("test_fee_created_floor_zero_rejects_off_grid_one_contract\n");
+    std::vector<Bar> bars = {
+        mk_bar(1000, 1800.0, 1800.0, 1800.0, 1800.0, 1.0),
+        mk_bar(2000, 1800.01, 1800.01, 1800.01, 1800.01, 1.0),
+    };
+    CommissionedDefaultPoeDustProbe eng(
+        /*initial_capital=*/9009.02, /*qty_step=*/2.5);
+    eng.run(bars.data(), (int)bars.size());
+
+    CHECK(eng.trade_count() == 0);
+    CHECK(near(eng.position_size(), 5.0));
+}
+
+static void test_cash_per_order_floor_zero_stays_outside_percent_fee_rule() {
+    std::printf("test_cash_per_order_floor_zero_stays_outside_percent_fee_rule\n");
+    std::vector<Bar> bars = {
+        mk_bar(1000, 1800.0, 1800.0, 1800.0, 1800.0, 1.0),
+        mk_bar(2000, 1800.0, 1800.0, 1800.0, 1800.0, 1.0),
+    };
+    CommissionedDefaultPoeDustProbe eng(
+        /*initial_capital=*/10000.0, /*qty_step=*/0.0001,
+        CommissionType::CASH_PER_ORDER, /*commission_value=*/0.2);
+    eng.run(bars.data(), (int)bars.size());
+
+    CHECK(eng.trade_count() == 0);
+    CHECK(near(eng.position_size(), 5.5555));
+}
+
 // Repurposed from the KI-61 "sublot overage held" fixture (design-explicit-qty-
 // fill-admission). This is an EXPLICIT-qty all-in true-flat MARKET entry
 // (strategy.entry with qty=10 == equity/close) whose next-bar fill gaps
@@ -1769,6 +1880,11 @@ int main() {
     test_zero_cost_frozen_all_in_true_flat_gap_is_rejected();
     test_commissioned_frozen_all_in_true_flat_gap_is_eligible();
     test_paired_short_close_default_long_gap_remains_eligible();
+    test_fee_created_floor_zero_closes_one_contract();
+    test_fee_created_floor_zero_caps_sub_one_position();
+    test_fee_created_nonzero_floor_keeps_four_x_quantity();
+    test_fee_created_floor_zero_rejects_off_grid_one_contract();
+    test_cash_per_order_floor_zero_stays_outside_percent_fee_rule();
     test_explicit_all_in_zero_comm_adverse_gap_declined();
     test_explicit_all_in_commissioned_adverse_gap_declined();
     test_explicit_all_in_zero_comm_no_qty_step_declined();


### PR DESCRIPTION
## Summary

This carries two independently evidenced broker/runtime fixes atomically:

- when a commissioned, omitted-qty, 100%-of-equity, true-flat MARKET long is affordable before its percentage opening fee but that fee alone creates a positive sub-lot margin deficit, preserve TradingView's one-contract floor-zero liquidation fallback (capped by the live position)
- treat an already-frozen default MARKET quantity as pre-quantized on the actual-flat fill path, so an exact binary lot is not floored a second time

The first fix exposes the second one. Either patch alone leaves the source Strong; only the pair is regression-free and promotes the target.

## Exhaustive 2^2

All four cells used identical source, TradingView tape, feeds, generated C++, and semantic route (`qty_step=0.0001`, `asia_taipei`):

| Cell | Raw matched / TV | Tier | PnL P90 |
|---|---:|---|---:|
| baseline | 955 / 979 | Strong | 2.6870% |
| quantize-once only | 955 / 979 | Strong | 2.6792% |
| margin fallback only | 962 / 979 | Strong | 5.0159% |
| both | 979 / 979 | Excellent | 0.0000% |

The all-on target is exact: canonical match 100%, count/entry/exit/PnL errors all zero. Three baseline-Excellent sentinels remain Excellent; the related KI-57 Strong control remains stable.

## Causal anchors

- 2025-04-04 14:00 UTC: opening commission alone creates raw `q_min=0.000010904...`; ordinary lot flooring returns zero, while TV emits a 1-contract Margin call
- after that is fixed, 2025-04-07 exposes the independent second floor: TV `6.2790`, one-factor engine `6.2789`, paired fix `6.2790`
- the TV tape repeats the margin edge 25 times: one ordinary `0.0004` fragment, twenty-two 1-contract fallbacks, and two sub-one full-position caps

## Scope controls

The fallback requires exact true-flat omitted-qty high-level MARKET-long provenance, PoE=100, margin=100, admitted frozen sizing, and positive percentage commission. Explicit/priced/RAW/add/reversal/short/zero/CASH/off-grid cases remain outside it. The event flag is consumed before early returns and reset on every flat/fresh/raw/stale path.

A separate 8-case / 58-assertion private QA suite covers two consecutive position cycles, all exclusions above, and directional pre-fee headroom. `+0.3000` triggers; `-5.7645` does not, so replacing direction with `abs(difference)` would be incorrect here.

## Tests

- baseline-red F1 regression: 289/299; candidate 299/299
- baseline/F1-red quantize-once regression: 45/48 (`6.2789` vs `6.2790`); C/F1+C 48/48
- independent focused suites: 1,655/1,655
- fresh full Release CTest: 112/112
- ASan+UBSan focused margin/freeze/reset lane: 3/3
- committed-candidate fixed-feed rerun: z8830 979/979 and Excellent; all four controls unchanged

Final binary diff SHA-256: `ac994009bf2877d1c49a622f75025a723efef130c6f1e22c52b3192bf4dbafbc`.

No new TradingView export or public corpus probe is included.
