### PR TITLE
fix: scope strategy.close replacement by callsite

### DIFF
--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -658,39 +658,30 @@ protected:
     // under the ANY rule (which closes id-matched physical lots directly).
     std::unordered_map<std::string, double> id_unclosed_qty_;
 
-    // ── Same-bar strategy.close batching (TV one-fill-per-bar rule) ──
-    // TradingView's broker emulator admits at most ONE default-FIFO
-    // ``strategy.close(id)`` market fill per bar under
-    // process_orders_on_close: every later close() call on the same bar
-    // REPLACES the pending close order. Empirically (3commas grid-bot TV
-    // exports, xau/xlm/pol/xrp — see fix/same-bar-multi-close-single-fill):
+    // ── Same-bar strategy.close batching ──
+    // Within one syntactic strategy.close callsite, TradingView keeps one
+    // pending broker instruction: later runtime evaluations replace its
+    // payload in place. Existing generated consumers omit a compiler token and
+    // therefore keep one global compatibility batch; regenerated consumers
+    // give every source callsite a nonzero token and thus an independent batch.
+    // For each batch, the accepted replacement/ledger contract is:
     //   - the FIRST replaced call's id-ledger is provisionally consumed
     //     silently (no fill, no trade rows);
     //   - when both the prior and current batches contain exactly two calls,
-    //     the prior batch's first admitted target is restored to that ledger. This is
-    //     provenance from the broker replacement chain, not a physical-lot
-    //     recount or ledger-minus-reservation calculation;
+    //     the prior batch's first admitted target is restored to that ledger.
+    //     This is provenance from the broker replacement chain, not a physical-
+    //     lot recount or ledger-minus-reservation calculation;
     //   - 3+ call batches never restore or create two-call provenance;
     //   - intermediate replaced calls keep their ledgers intact;
-    //   - the SURVIVING (last nonzero-target) call fills min(ledger,
-    //     avail) at the bar close. Its new reservation is capped to the
-    //     post-fill position capacity left after older reservations and caps
-    //     other ids' later targets via avail = position_qty_ -
-    //     sum(reservations of other ids). A positive truncated reservation
-    //     keeps the established survivor ledger; zero backing clears it;
-    //   - exact-two provenance is created only when that survivor's actual
-    //     fill remains fully backed after the fill;
+    //   - the SURVIVING (last nonzero-target) call fills min(ledger, avail) at
+    //     the bar close. Its reservation is capped to the post-fill physical
+    //     capacity left after older reservations;
     //   - a nonzero logical ledger with zero unreserved physical capacity is
-    //     consumed without a broker fill, so a later same-id entry starts a
-    //     new logical close cycle instead of accumulating a stale slice;
-    //   - a bar with exactly one close call behaves as before: fill =
-    //     min(ledger, avail), ledger consumed, reservation released.
-    // Calls whose target resolves to zero cannot survive; a logically live
-    // but physically blocked id still consumes its stale logical cycle.
-    // The batched fill executes at the end-of-bar order-processing point
-    // (dispatch_bar step 4 / magnifier last tick) at the same bar-close
-    // price the immediate path used. Order cancels/purges tied to a
-    // full-position close still run at CALL time (unchanged timing).
+    //     consumed without a broker fill;
+    //   - a sole close call consumes its ledger and releases its reservation.
+    // Calls whose target resolves to zero cannot replace a live instruction.
+    // Fills execute at the end-of-bar order-processing point; full-close order
+    // cancels/purges retain their established CALL-time timing.
     bool sb_close_active_ = false;
     int sb_close_bar_ = -1;
     int sb_close_calls_ = 0;          // effective distinct nonzero-target calls
@@ -702,10 +693,54 @@ protected:
     std::string sb_close_comment_;    // surviving order's comment
     std::unordered_map<std::string, double> close_reserved_qty_;
     // Live exact-two-call replacement provenance. A survivor id maps to the
-    // prior batch's FIRST target and is valid only while its reservation is
-    // live. A later exact-two-call batch can restore precisely that slice if
-    // this id is its first replaced call (ENA's two-call replacement chain).
+    // prior batch's FIRST target and remains valid only while its reservation
+    // is live.
     std::unordered_map<std::string, double> close_two_call_first_qty_;
+
+    // Nonzero compiler-token path. Every syntactic strategy.close site owns an
+    // independent copy of the accepted replacement batch. Distinct sites all
+    // flush; repeated runtime evaluations of one site replace only that batch.
+    int callsite_close_bar_ = -1;
+    uint64_t callsite_close_queue_seq_ = 0;
+    struct SameBarCloseCallsite {
+        uint64_t token = 0;
+        bool active = false;
+        int calls = 0;
+        std::string first_id;
+        double first_target = 0.0;
+        bool first_ledger_consumed = false;
+        bool first_carry_valid = false;
+        double first_carry_qty = 0.0;
+        std::string id;
+        std::string comment;
+        // Quantity admitted at call time. Distinct callsites reserve physical
+        // capacity in source order; a later zero-capacity evaluation cannot
+        // replace this pending instruction.
+        double target = 0.0;
+        // Persistent-reservation-blocked calls retain token-0's stale-ledger
+        // cleanup, but only as a site-local overlay during Pine evaluation.
+        // Shared mutation is deferred until every site's broker flush.
+        std::vector<std::string> deferred_cleanup_ids;
+        uint64_t queue_seq = 0;
+    };
+    // Per-source-bar only. Cross-bar reservation/provenance is stored in the
+    // owner-aware maps below, so a one-callsite generated strategy remains
+    // behavior-identical to token 0 while distinct sites coexist.
+    std::unordered_map<uint64_t, SameBarCloseCallsite> callsite_close_callsites_;
+    // Net physical capacity claimed by the currently surviving nonzero-site
+    // instructions on this source bar. This is distinct from
+    // pending_close_qty_in_bar_, which records cumulative accepted logical
+    // evaluations for the established later-entry carry rule.
+    double callsite_close_admitted_total_ = 0.0;
+    // Cross-bar replacement reservations/provenance belong to the syntactic
+    // source site that created them. Token 0 continues to use the historical
+    // id-only maps above without any behavior change.
+    std::unordered_map<
+        uint64_t, std::unordered_map<std::string, double>>
+        callsite_close_reserved_qty_;
+    std::unordered_map<
+        uint64_t, std::unordered_map<std::string, double>>
+        callsite_close_two_call_first_qty_;
 
     // --- KI-64: POOC script-visible position freeze ---
     // Under process_orders_on_close, a strategy.close/close_all that fills
@@ -1159,6 +1194,14 @@ protected:
                         double qty = std::numeric_limits<double>::quiet_NaN(),
                         double qty_percent = std::numeric_limits<double>::quiet_NaN(),
                         bool immediately = false);
+    // Keep the historical five-argument symbol above; regenerated legacy
+    // sources continue to bind token 0. This does not promise that arbitrary
+    // objects compiled against an older BacktestEngine class layout can be
+    // relinked without rebuilding. New codegen supplies a stable nonzero token
+    // for the syntactic strategy.close source site.
+    void strategy_close(const std::string& id, const std::string& comment,
+                        double qty, double qty_percent, bool immediately,
+                        uint64_t callsite_token);
     void strategy_close_all();
     void strategy_exit(const std::string& id, const std::string& from_entry,
                        double limit_price, double stop_price,
@@ -2352,12 +2395,22 @@ private:
     void cancel_orders_for_full_close(const std::string& id, bool closing_long);
     void cancel_same_bar_market_reentries_after_full_close(
         bool closed_long, bool preserve_undercap_entries);
-    // Same-bar close batching (TV one-fill-per-bar; see the field-block
-    // comment at close_reserved_qty_). enqueue replaces the pending
-    // same-bar close; flush executes the surviving one at bar close.
-    void enqueue_same_bar_close(const std::string& id, const std::string& comment);
+    // Same-bar default-FIFO close routing. Token 0 uses the accepted global
+    // survivor; nonzero compiler tokens use source-callsite scoped orders.
+    void enqueue_same_bar_close(const std::string& id,
+                                const std::string& comment,
+                                uint64_t callsite_token);
     void flush_same_bar_close();
+    void flush_active_same_bar_close(
+        double admitted_target = std::numeric_limits<double>::quiet_NaN(),
+        double pending_later_qty = 0.0,
+        bool defer_first_ledger_consume = false,
+        uint64_t callsite_token = 0);
     double close_reserved_other_qty(const std::string& id) const;
+    double callsite_close_reserved_other_qty(
+        uint64_t callsite_token, const std::string& id) const;
+    double callsite_close_physical_reserved_other_qty(
+        uint64_t callsite_token, const std::string& id) const;
     double pending_same_bar_close_target() const;
     void execute_immediate_close(const std::string& id,
                                  const std::string& comment,

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -584,6 +584,8 @@ void BacktestEngine::reset_position_state_to_flat() {
     id_unclosed_qty_.clear();
     close_reserved_qty_.clear();
     close_two_call_first_qty_.clear();
+    callsite_close_reserved_qty_.clear();
+    callsite_close_two_call_first_qty_.clear();
     consumed_partial_exit_ids_.clear();
 }
 
@@ -634,6 +636,8 @@ void BacktestEngine::open_fresh_position(PositionSide requested, double fill_pri
     id_unclosed_qty_.clear();
     close_reserved_qty_.clear();
     close_two_call_first_qty_.clear();
+    callsite_close_reserved_qty_.clear();
+    callsite_close_two_call_first_qty_.clear();
     consumed_partial_exit_ids_.clear();
     pyramid_entries_.push_back({fill_price, current_bar_.timestamp, qty, id, bar_index_});
     snapshot_entry_commission(pyramid_entries_.back());

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -595,6 +595,12 @@ void BacktestEngine::reset_run_state() {
     sb_close_comment_.clear();
     close_reserved_qty_.clear();
     close_two_call_first_qty_.clear();
+    callsite_close_bar_ = -1;
+    callsite_close_queue_seq_ = 0;
+    callsite_close_callsites_.clear();
+    callsite_close_admitted_total_ = 0.0;
+    callsite_close_reserved_qty_.clear();
+    callsite_close_two_call_first_qty_.clear();
     fold_exit_path_extremes_ = false;
     fold_exit_trail_peak_ = std::numeric_limits<double>::quiet_NaN();
     last_exit_fill_was_trail_ = false;

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <map>
 #include <utility>
 
 namespace pineforge {
@@ -555,22 +556,34 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
     invalidate_unsafe_pooc_global_full_exit_dynamic_qty();
 }
 
-void BacktestEngine::strategy_close(const std::string& id, const std::string& comment,
-                                    double qty, double qty_percent, bool immediately) {
+void BacktestEngine::strategy_close(const std::string& id,
+                                    const std::string& comment,
+                                    double qty, double qty_percent,
+                                    bool immediately) {
+    strategy_close(id, comment, qty, qty_percent, immediately,
+                   /*callsite_token=*/0);
+}
+
+void BacktestEngine::strategy_close(const std::string& id,
+                                    const std::string& comment,
+                                    double qty, double qty_percent,
+                                    bool immediately,
+                                    uint64_t callsite_token) {
     if (!trading_is_active(current_bar_.timestamp, trade_start_time_, script_tf_seconds_)) return;
     if (position_side_ == PositionSide::FLAT) {
         return;
     }
 
-    // TradingView one-close-fill-per-bar rule: under process_orders_on_close,
-    // default-FIFO ``strategy.close(id)`` calls (no explicit qty/qty_percent,
-    // FIFO close-entries rule) issued on the SAME bar collapse into a single
-    // surviving market close order that fills at the bar close. Route those
-    // calls through the same-bar batch; the fill executes at the end-of-bar
-    // order-processing point (dispatch_bar step 4 / magnifier last tick) via
-    // flush_same_bar_close(). Everything else (ANY rule, explicit qty,
-    // close_all, immediately=true, non-POC deferred closes) keeps the
-    // existing paths.
+    // TradingView same-callsite replacement rule: under
+    // process_orders_on_close, default-FIFO ``strategy.close(id)`` calls (no
+    // explicit qty/qty_percent, FIFO close-entries rule) issued by one
+    // syntactic callsite on the SAME bar collapse into one surviving market
+    // close. Distinct compiler-token callsites keep independent batches;
+    // token 0 retains the historical global compatibility batch. Their fills
+    // execute at the end-of-bar order-processing point (dispatch_bar step 4 /
+    // magnifier last tick) via flush_same_bar_close(). Everything else (ANY
+    // rule, explicit qty, close_all, immediately=true, non-POC deferred
+    // closes) keeps the existing paths.
     const bool pooc_can_fill_at_this_cursor =
         process_orders_on_close_
         && (!coof_scheduler_active_ || coof_cursor_is_bar_close_)
@@ -582,7 +595,7 @@ void BacktestEngine::strategy_close(const std::string& id, const std::string& co
     if (pooc_can_fill_at_this_cursor && !immediately
         && !close_entries_rule_any_ && !id.empty()
         && std::isnan(qty) && std::isnan(qty_percent)) {
-        enqueue_same_bar_close(id, comment);
+        enqueue_same_bar_close(id, comment, callsite_token);
         return;
     }
 
@@ -714,20 +727,26 @@ void BacktestEngine::strategy_close_all() {
     strategy_close("");
 }
 
-// Qty the pending same-bar close batch will fill at flush time (0 when no
-// batch is pending). Lets same-bar order sizing (strategy.exit) see the
-// post-close position before the flush actually executes.
+// Total qty committed by token-0 legacy replacement plus every nonzero
+// callsite survivor. Later strategy.exit sizing sees the aggregate post-close
+// capacity without making any broker fill visible to the Pine body.
 double BacktestEngine::pending_same_bar_close_target() const {
-    if (!sb_close_active_) return 0.0;
-    auto it = id_unclosed_qty_.find(sb_close_id_);
-    double unclosed = (it != id_unclosed_qty_.end()) ? it->second : 0.0;
-    double avail = std::max(0.0, position_qty_ - close_reserved_other_qty(sb_close_id_));
-    return std::min(unclosed, avail);
+    double legacy = 0.0;
+    if (sb_close_active_) {
+        auto it = id_unclosed_qty_.find(sb_close_id_);
+        double unclosed =
+            (it != id_unclosed_qty_.end()) ? it->second : 0.0;
+        double avail = std::max(
+            0.0, position_qty_ - close_reserved_other_qty(sb_close_id_));
+        legacy = std::min(unclosed, avail);
+    }
+    double callsite = 0.0;
+    if (callsite_close_bar_ == bar_index_) {
+        callsite = callsite_close_admitted_total_;
+    }
+    return std::min(position_qty_, legacy + callsite);
 }
 
-// Sum of same-bar-close reservations held by OTHER ids. A surviving
-// multi-close fill leaves its unconsumed ledger amount reserved against
-// the position; other ids' close targets are capped by what remains.
 double BacktestEngine::close_reserved_other_qty(const std::string& id) const {
     double sum = 0.0;
     for (const auto& kv : close_reserved_qty_) {
@@ -736,104 +755,424 @@ double BacktestEngine::close_reserved_other_qty(const std::string& id) const {
     return sum;
 }
 
-// Admit a default-FIFO strategy.close(id) call into the same-bar batch
-// (TV one-fill-per-bar rule — see the close_reserved_qty_ field block in
-// engine.hpp). Order cancels tied to a full-position close keep their
-// CALL-time timing (identical to the previous immediate path); only the
-// FILL is deferred to flush_same_bar_close().
-void BacktestEngine::enqueue_same_bar_close(const std::string& id,
-                                            const std::string& comment) {
-    const double eps = kQtyEpsilon;
-    auto it = id_unclosed_qty_.find(id);
-    double unclosed = (it != id_unclosed_qty_.end()) ? it->second : 0.0;
-    double avail = std::max(0.0, position_qty_ - close_reserved_other_qty(id));
-    double target = std::min(unclosed, avail);
-    if (target <= eps) {
-        if (unclosed > eps && avail <= eps) {
-            // The logical slot was asked to close, but earlier surviving
-            // multi-close orders already reserve every physically available
-            // unit. TV emits no broker fill here, yet the close command still
-            // consumes this logical cycle: a later same-id entry must not be
-            // added to the stale ledger and double-close on its next signal.
-            id_unclosed_qty_.erase(id);
-            close_reserved_qty_.erase(id);
-            close_two_call_first_qty_.erase(id);
+double BacktestEngine::callsite_close_reserved_other_qty(
+        uint64_t /*callsite_token*/, const std::string& id) const {
+    // Persistent provenance is physically backed per logical entry id. Owner
+    // claims for the same id alias the shared id_unclosed_qty_ ledger, so only
+    // their maximum consumes capacity; claims for distinct ids remain
+    // additive. Token 0 participates in the same grouping.
+    // Ordered keys keep floating-point accumulation deterministic across
+    // standard-library hash implementations and platforms.
+    std::map<std::string, double> backing_by_id;
+    for (const auto& claim : close_reserved_qty_) {
+        backing_by_id[claim.first] = claim.second;
+    }
+    for (const auto& owner : callsite_close_reserved_qty_) {
+        for (const auto& claim : owner.second) {
+            double& backing = backing_by_id[claim.first];
+            backing = std::max(backing, claim.second);
         }
-        return;  // no order/fill; a zero-target call cannot survive
     }
-
-    // Same-bar source-order carry (see strategy_entry's tv_carry_qty): a
-    // subsequent strategy.entry on this on_bar sees the post-close size.
-    pending_close_qty_in_bar_ += target;
-
-    bool closes_full_position = target >= position_qty_ - eps;
-    if (closes_full_position) {
-        bool closing_long = (position_side_ == PositionSide::LONG);
-        cancel_orders_for_full_close(id, closing_long);
-        purge_exit_orders();
+    double sum = 0.0;
+    for (const auto& backing : backing_by_id) {
+        if (backing.first != id) sum += backing.second;
     }
+    return sum;
+}
 
-    if (!sb_close_active_ || sb_close_bar_ != bar_index_) {
-        sb_close_active_ = true;
-        sb_close_bar_ = bar_index_;
-        sb_close_calls_ = 1;
-        sb_close_first_id_ = id;
-        sb_close_first_target_ = target;
-        sb_close_first_carry_valid_ = false;
-        sb_close_first_carry_qty_ = 0.0;
+double BacktestEngine::callsite_close_physical_reserved_other_qty(
+        uint64_t callsite_token, const std::string& id) const {
+    // Post-fill reservation uses the identical per-id physical backing model
+    // as admission. The id being replaced is excluded across every owner.
+    return callsite_close_reserved_other_qty(callsite_token, id);
+}
+
+// Admit one default-FIFO strategy.close(id) call into the bar-close broker
+// queue. Token 0 retains the accepted global replacement batch. A nonzero
+// compiler token selects an independent copy of that same state machine:
+// runtime loop evaluations replace only their own syntactic site in place,
+// while distinct source sites all survive in first-admission queue order.
+void BacktestEngine::enqueue_same_bar_close(const std::string& id,
+                                            const std::string& comment,
+                                            uint64_t callsite_token) {
+    const double eps = kQtyEpsilon;
+    if (callsite_token == 0) {
+        auto it = id_unclosed_qty_.find(id);
+        double unclosed =
+            (it != id_unclosed_qty_.end()) ? it->second : 0.0;
+        double avail = std::max(
+            0.0, position_qty_ - close_reserved_other_qty(id));
+        double target = std::min(unclosed, avail);
+        if (target <= eps) {
+            if (unclosed > eps && avail <= eps) {
+                id_unclosed_qty_.erase(id);
+                close_reserved_qty_.erase(id);
+                close_two_call_first_qty_.erase(id);
+            }
+            return;
+        }
+
+        pending_close_qty_in_bar_ += target;
+        const bool closes_full_position = target >= position_qty_ - eps;
+        if (closes_full_position) {
+            const bool closing_long =
+                position_side_ == PositionSide::LONG;
+            cancel_orders_for_full_close(id, closing_long);
+            purge_exit_orders();
+        }
+
+        if (!sb_close_active_ || sb_close_bar_ != bar_index_) {
+            sb_close_active_ = true;
+            sb_close_bar_ = bar_index_;
+            sb_close_calls_ = 1;
+            sb_close_first_id_ = id;
+            sb_close_first_target_ = target;
+            sb_close_first_carry_valid_ = false;
+            sb_close_first_carry_qty_ = 0.0;
+            sb_close_id_ = id;
+            sb_close_comment_ = comment;
+            return;
+        }
+        if (id == sb_close_id_) {
+            sb_close_comment_ = comment;
+            return;
+        }
+        ++sb_close_calls_;
+        if (sb_close_calls_ == 2) {
+            const auto reserved =
+                close_reserved_qty_.find(sb_close_first_id_);
+            const auto provenance =
+                close_two_call_first_qty_.find(sb_close_first_id_);
+            if (reserved != close_reserved_qty_.end()
+                && provenance != close_two_call_first_qty_.end()) {
+                sb_close_first_carry_valid_ = true;
+                sb_close_first_carry_qty_ = provenance->second;
+            }
+            id_unclosed_qty_.erase(sb_close_first_id_);
+            close_reserved_qty_.erase(sb_close_first_id_);
+            close_two_call_first_qty_.erase(sb_close_first_id_);
+        } else if (sb_close_calls_ == 3) {
+            sb_close_first_carry_valid_ = false;
+            sb_close_first_carry_qty_ = 0.0;
+        }
         sb_close_id_ = id;
         sb_close_comment_ = comment;
         return;
     }
-    if (id == sb_close_id_) {
-        // Re-issued close for the id already pending: replaces the same
-        // order in place (comment refresh; not a new call).
-        sb_close_comment_ = comment;
+
+    if (callsite_close_bar_ != bar_index_) {
+        callsite_close_bar_ = bar_index_;
+        callsite_close_queue_seq_ = 0;
+        callsite_close_callsites_.clear();
+        callsite_close_admitted_total_ = 0.0;
+    }
+
+    auto existing = callsite_close_callsites_.find(callsite_token);
+    const SameBarCloseCallsite* prior_site =
+        existing == callsite_close_callsites_.end()
+            ? nullptr : &existing->second;
+    const auto locally_erased = [&](const std::string& key) {
+        if (prior_site == nullptr) return false;
+        if (prior_site->first_ledger_consumed
+            && key == prior_site->first_id) {
+            return true;
+        }
+        return std::find(prior_site->deferred_cleanup_ids.begin(),
+                         prior_site->deferred_cleanup_ids.end(), key)
+            != prior_site->deferred_cleanup_ids.end();
+    };
+    auto it = id_unclosed_qty_.find(id);
+    const double unclosed =
+        locally_erased(id) || it == id_unclosed_qty_.end()
+            ? 0.0 : it->second;
+    double pending_reserved = callsite_close_admitted_total_;
+    const bool same_id_reissue =
+        existing != callsite_close_callsites_.end()
+        && existing->second.active && existing->second.id == id;
+    bool replacement_can_reuse_own_claim = false;
+    if (existing != callsite_close_callsites_.end()
+        && existing->second.active && existing->second.id != id) {
+        const std::string& replaced_id = existing->second.id;
+        const bool another_site_targets_replaced_id = std::any_of(
+            callsite_close_callsites_.begin(),
+            callsite_close_callsites_.end(),
+            [&](const auto& candidate) {
+                return candidate.first != callsite_token
+                    && candidate.second.active
+                    && candidate.second.id == replaced_id;
+            });
+        replacement_can_reuse_own_claim =
+            !another_site_targets_replaced_id;
+    }
+    // A same-id reissue updates the already-admitted instruction in place.
+    // A different-id replacement can normally reuse its own in-place broker
+    // claim (single-site token-0 parity). But if another source site targets
+    // that same old id, the old claim remains load-bearing during admission:
+    // this is the direct TV site1/A + site2/A->B rejection oracle.
+    if (same_id_reissue || replacement_can_reuse_own_claim) {
+        pending_reserved -= existing->second.target;
+    }
+    double persistent_reserved_other =
+        callsite_close_reserved_other_qty(callsite_token, id);
+    if (prior_site != nullptr) {
+        const auto owner =
+            callsite_close_reserved_qty_.find(callsite_token);
+        if (owner != callsite_close_reserved_qty_.end()) {
+            for (const auto& kv : owner->second) {
+                if (kv.first != id && locally_erased(kv.first)) {
+                    // Releasing this site's locally-consumed slot frees only
+                    // its marginal contribution to the per-id maximum. A
+                    // legacy or different-site alias can keep part or all of
+                    // the same logical id physically backed.
+                    double competing_backing = 0.0;
+                    const auto legacy = close_reserved_qty_.find(kv.first);
+                    if (legacy != close_reserved_qty_.end()) {
+                        competing_backing = legacy->second;
+                    }
+                    for (const auto& candidate
+                         : callsite_close_reserved_qty_) {
+                        if (candidate.first == callsite_token) continue;
+                        const auto claim = candidate.second.find(kv.first);
+                        if (claim != candidate.second.end()) {
+                            competing_backing = std::max(
+                                competing_backing, claim->second);
+                        }
+                    }
+                    persistent_reserved_other -= std::max(
+                        0.0, kv.second - competing_backing);
+                }
+            }
+        }
+    }
+    persistent_reserved_other = std::max(0.0, persistent_reserved_other);
+    const double persistent_avail =
+        std::max(0.0, position_qty_ - persistent_reserved_other);
+    const double avail = std::max(
+        0.0, persistent_avail - pending_reserved);
+    const double target = std::min(unclosed, avail);
+    if (target <= eps) {
+        // Do not mutate shared ledgers here. Other source callsites may own
+        // earlier reservations against the same logical id. A zero-capacity
+        // evaluation is rejected and cannot replace its site's live order.
+        // A call blocked by a PRIOR-BAR persistent reservation still consumes
+        // the stale logical cycle under the accepted token-0 contract. Keep
+        // that cleanup site-local now and publish it only after all callsites
+        // have flushed. Capacity blocked solely by this bar's pending sites
+        // (the fresh A/A->B oracle) performs no cleanup.
+        if (unclosed > eps && persistent_avail <= eps) {
+            SameBarCloseCallsite& site =
+                callsite_close_callsites_[callsite_token];
+            if (std::find(site.deferred_cleanup_ids.begin(),
+                          site.deferred_cleanup_ids.end(), id)
+                == site.deferred_cleanup_ids.end()) {
+                site.deferred_cleanup_ids.push_back(id);
+            }
+        }
         return;
     }
-    sb_close_calls_ += 1;
-    if (sb_close_calls_ == 2) {
-        const auto reserved = close_reserved_qty_.find(sb_close_first_id_);
-        const auto provenance =
-            close_two_call_first_qty_.find(sb_close_first_id_);
-        if (reserved != close_reserved_qty_.end()
-            && provenance != close_two_call_first_qty_.end()) {
-            // Snapshot before releasing the old reservation. Restoration is
-            // deferred until flush proves the CURRENT batch also has exactly
-            // two calls; a later 3rd call invalidates this carry.
-            sb_close_first_carry_valid_ = true;
-            sb_close_first_carry_qty_ = provenance->second;
-        }
-        // Preserve the established provisional replacement rule immediately.
-        // Besides matching the broker lifecycle, this makes a later A,B,A
-        // source revisit observe A as zero-target while this batch is pending.
-        id_unclosed_qty_.erase(sb_close_first_id_);
-        close_reserved_qty_.erase(sb_close_first_id_);
-        close_two_call_first_qty_.erase(sb_close_first_id_);
-    } else if (sb_close_calls_ == 3) {
-        // The current batch is no longer exact-two. Keep the provisional
-        // ledger erase and discard the snapshotted two-call carry.
-        sb_close_first_carry_valid_ = false;
-        sb_close_first_carry_qty_ = 0.0;
+
+    const double replaced_target =
+        prior_site != nullptr && prior_site->active
+            ? prior_site->target : 0.0;
+    // The broker capacity claim is net-live, while the existing source-order
+    // entry-carry debt is cumulative across every accepted evaluation.
+    callsite_close_admitted_total_ += target - replaced_target;
+    pending_close_qty_in_bar_ += target;
+    const bool closes_full_position = target >= position_qty_ - eps;
+    if (closes_full_position) {
+        const bool closing_long = position_side_ == PositionSide::LONG;
+        cancel_orders_for_full_close(id, closing_long);
+        purge_exit_orders();
     }
-    // Intermediate replaced calls (3rd+) keep their ledgers as before.
-    sb_close_id_ = id;
-    sb_close_comment_ = comment;
+
+    SameBarCloseCallsite& site =
+        callsite_close_callsites_[callsite_token];
+    if (!site.active) {
+        site.active = true;
+        site.token = callsite_token;
+        site.calls = 1;
+        site.first_id = id;
+        site.first_target = target;
+        site.first_ledger_consumed = false;
+        site.first_carry_valid = false;
+        site.first_carry_qty = 0.0;
+        site.id = id;
+        site.comment = comment;
+        site.target = target;
+        site.queue_seq = ++callsite_close_queue_seq_;
+        return;
+    }
+    if (id == site.id) {
+        site.comment = comment;
+        site.target = target;
+        return;
+    }
+
+    ++site.calls;
+    if (site.calls == 2) {
+        const auto owner_reserved =
+            callsite_close_reserved_qty_.find(callsite_token);
+        const auto owner_provenance =
+            callsite_close_two_call_first_qty_.find(callsite_token);
+        if (owner_reserved != callsite_close_reserved_qty_.end()
+            && owner_provenance != callsite_close_two_call_first_qty_.end()) {
+            const auto reserved =
+                owner_reserved->second.find(site.first_id);
+            const auto provenance =
+                owner_provenance->second.find(site.first_id);
+            if (reserved != owner_reserved->second.end()
+                && provenance != owner_provenance->second.end()) {
+                site.first_carry_valid = true;
+                site.first_carry_qty = provenance->second;
+            }
+        }
+        site.first_ledger_consumed = true;
+    } else if (site.calls == 3) {
+        site.first_carry_valid = false;
+        site.first_carry_qty = 0.0;
+    }
+    site.id = id;
+    site.comment = comment;
+    site.target = target;
 }
 
-// Execute the surviving same-bar close at the bar's close price. Called
-// from the end-of-bar order-processing points (dispatch_bar step 4 and
-// the magnifier's last tick), i.e. the same bar and price the immediate
-// path used, after the strategy's on_bar has fully run.
+// End the script-evaluation phase. Distinct compiler callsites flush by the
+// order of their first effective admission. A same-site replacement changes
+// the payload in place without moving its queue slot (authoritative A,B,A =>
+// A_LAST,B_MIDDLE). Each flush reuses the exact accepted token-0 batch below.
 void BacktestEngine::flush_same_bar_close() {
-    // KI-64: on_bar has returned — release any POOC script-visible position
-    // freeze so the flush below, step-4 order processing, and post-run reads
-    // all observe the real (post-close) position. Runs on every POOC bar
-    // (flush is the first call after each POOC on_bar), before the early
-    // return so a bar with an in-line close but no enqueued survivor still
-    // clears. Broker reads here use position_side_/position_qty_ directly.
     clear_script_position_view();
+
+    SameBarCloseCallsite legacy;
+    legacy.active = sb_close_active_;
+    legacy.calls = sb_close_calls_;
+    legacy.first_id = sb_close_first_id_;
+    legacy.first_target = sb_close_first_target_;
+    legacy.first_carry_valid = sb_close_first_carry_valid_;
+    legacy.first_carry_qty = sb_close_first_carry_qty_;
+    legacy.id = sb_close_id_;
+    legacy.comment = sb_close_comment_;
+
+    std::vector<SameBarCloseCallsite> callsites;
+    std::vector<std::pair<uint64_t, std::string>> deferred_cleanup_ids;
+    std::vector<std::pair<uint64_t, std::string>> ledger_mutation_owners;
+    if (callsite_close_bar_ == bar_index_) {
+        callsites.reserve(callsite_close_callsites_.size());
+        for (const auto& kv : callsite_close_callsites_) {
+            if (kv.second.active) callsites.push_back(kv.second);
+            for (const std::string& id : kv.second.deferred_cleanup_ids) {
+                deferred_cleanup_ids.emplace_back(kv.first, id);
+            }
+        }
+        std::stable_sort(
+            callsites.begin(), callsites.end(),
+            [](const SameBarCloseCallsite& a,
+               const SameBarCloseCallsite& b) {
+                return a.queue_seq < b.queue_seq;
+            });
+        for (const SameBarCloseCallsite& site : callsites) {
+            // A sole call consumes its survivor ledger; a replacement batch
+            // may clear that ledger when its post-fill backing reaches zero.
+            // Track the owning site so a later reconciliation protects only
+            // a different token's still-live claim.
+            ledger_mutation_owners.emplace_back(site.token, site.id);
+            if (site.first_ledger_consumed) {
+                ledger_mutation_owners.emplace_back(
+                    site.token, site.first_id);
+            }
+        }
+    }
+    callsite_close_bar_ = -1;
+    callsite_close_queue_seq_ = 0;
+    callsite_close_callsites_.clear();
+    callsite_close_admitted_total_ = 0.0;
+
+    // Detach token 0 while each compiler-token batch borrows the accepted
+    // scalar batch fields. Generated programs are all-token-0 or all-tokenized;
+    // flushing token 0 last makes a mixed transitional program deterministic.
+    sb_close_active_ = false;
+    double callsite_qty_remaining = 0.0;
+    for (const SameBarCloseCallsite& site : callsites) {
+        callsite_qty_remaining += site.target;
+    }
+    for (const SameBarCloseCallsite& site : callsites) {
+        callsite_qty_remaining =
+            std::max(0.0, callsite_qty_remaining - site.target);
+        sb_close_active_ = site.active;
+        sb_close_bar_ = bar_index_;
+        sb_close_calls_ = site.calls;
+        sb_close_first_id_ = site.first_id;
+        sb_close_first_target_ = site.first_target;
+        sb_close_first_carry_valid_ = site.first_carry_valid;
+        sb_close_first_carry_qty_ = site.first_carry_qty;
+        sb_close_id_ = site.id;
+        sb_close_comment_ = site.comment;
+        flush_active_same_bar_close(
+            site.target, callsite_qty_remaining,
+            site.first_ledger_consumed, site.token);
+    }
+
+    for (const auto& cleanup : deferred_cleanup_ids) {
+        const uint64_t token = cleanup.first;
+        const std::string& id = cleanup.second;
+        ledger_mutation_owners.push_back(cleanup);
+        id_unclosed_qty_.erase(id);
+        auto reserved = callsite_close_reserved_qty_.find(token);
+        if (reserved != callsite_close_reserved_qty_.end()) {
+            reserved->second.erase(id);
+            if (reserved->second.empty()) {
+                callsite_close_reserved_qty_.erase(reserved);
+            }
+        }
+        auto provenance =
+            callsite_close_two_call_first_qty_.find(token);
+        if (provenance != callsite_close_two_call_first_qty_.end()) {
+            provenance->second.erase(id);
+            if (provenance->second.empty()) {
+                callsite_close_two_call_first_qty_.erase(provenance);
+            }
+        }
+    }
+
+    // Publish the owner-aware shared-ledger reduction after every site has
+    // flushed. A mutation by T1 may remove only (T1,id): if a DIFFERENT token
+    // T2 still owns a backed claim for that id, retain T2's ledger floor and
+    // exact-two provenance. Do not generally floor a site's own survivor;
+    // token-0/single-token corpus behavior includes accepted zero-backing
+    // ledger cleanup and must remain byte-identical.
+    for (const auto& mutation : ledger_mutation_owners) {
+        double other_owner_floor = 0.0;
+        for (const auto& owner : callsite_close_reserved_qty_) {
+            if (owner.first == mutation.first) continue;
+            const auto claim = owner.second.find(mutation.second);
+            if (claim != owner.second.end()) {
+                other_owner_floor =
+                    std::max(other_owner_floor, claim->second);
+            }
+        }
+        if (other_owner_floor > kQtyEpsilon) {
+            double& ledger = id_unclosed_qty_[mutation.second];
+            ledger = std::max(ledger, other_owner_floor);
+        }
+    }
+
+    sb_close_active_ = legacy.active;
+    sb_close_bar_ = legacy.active ? bar_index_ : -1;
+    sb_close_calls_ = legacy.calls;
+    sb_close_first_id_ = legacy.first_id;
+    sb_close_first_target_ = legacy.first_target;
+    sb_close_first_carry_valid_ = legacy.first_carry_valid;
+    sb_close_first_carry_qty_ = legacy.first_carry_qty;
+    sb_close_id_ = legacy.id;
+    sb_close_comment_ = legacy.comment;
+    flush_active_same_bar_close();
+}
+
+void BacktestEngine::flush_active_same_bar_close(
+    double admitted_target, double pending_later_qty,
+    bool defer_first_ledger_consume, uint64_t callsite_token) {
     if (!sb_close_active_) return;
+
     const std::string id = sb_close_id_;
     const std::string comment = sb_close_comment_;
     const int batch_calls = sb_close_calls_;
@@ -851,13 +1190,51 @@ void BacktestEngine::flush_same_bar_close() {
     sb_close_first_carry_qty_ = 0.0;
     sb_close_id_.clear();
     sb_close_comment_.clear();
+
+    if (defer_first_ledger_consume && batch_calls >= 2) {
+        // Tokenized sites must not mutate the shared logical ledger while the
+        // Pine body is still admitting later source callsites. Apply the
+        // accepted legacy first-call provisional consumption only when this
+        // site's queued broker instruction reaches the flush point.
+        id_unclosed_qty_.erase(first_id);
+        if (callsite_token == 0) {
+            close_reserved_qty_.erase(first_id);
+            close_two_call_first_qty_.erase(first_id);
+        } else {
+            auto reserved =
+                callsite_close_reserved_qty_.find(callsite_token);
+            if (reserved != callsite_close_reserved_qty_.end()) {
+                reserved->second.erase(first_id);
+                if (reserved->second.empty()) {
+                    callsite_close_reserved_qty_.erase(reserved);
+                }
+            }
+            auto provenance =
+                callsite_close_two_call_first_qty_.find(callsite_token);
+            if (provenance
+                != callsite_close_two_call_first_qty_.end()) {
+                provenance->second.erase(first_id);
+                if (provenance->second.empty()) {
+                    callsite_close_two_call_first_qty_.erase(provenance);
+                }
+            }
+        }
+    }
     if (position_side_ == PositionSide::FLAT) return;
 
     const double eps = kQtyEpsilon;
     auto it = id_unclosed_qty_.find(id);
     double unclosed = (it != id_unclosed_qty_.end()) ? it->second : 0.0;
-    double avail = std::max(0.0, position_qty_ - close_reserved_other_qty(id));
-    double target = std::min(unclosed, avail);
+    const bool has_admitted_target = std::isfinite(admitted_target);
+    double target = 0.0;
+    if (has_admitted_target) {
+        target = std::min(admitted_target, position_qty_);
+    } else {
+        double avail =
+            std::max(0.0,
+                     position_qty_ - close_reserved_other_qty(id));
+        target = std::min(unclosed, avail);
+    }
     if (target <= eps) return;
 
     bool closes_full_position = target >= position_qty_ - eps;
@@ -877,14 +1254,36 @@ void BacktestEngine::flush_same_bar_close() {
     }
 
     if (sole_call) {
-        // Single close call this bar: classic semantics — consume the
-        // ledger and release any prior reservation for this id.
-        it->second -= target;
-        if (it->second <= eps) {
-            id_unclosed_qty_.erase(it);
+        // Single close call for this source site: consume the ledger and
+        // release any prior reservation for this id.
+        if (it != id_unclosed_qty_.end()) {
+            it->second -= target;
+            if (it->second <= eps) {
+                id_unclosed_qty_.erase(it);
+            }
         }
-        close_reserved_qty_.erase(id);
-        close_two_call_first_qty_.erase(id);
+        if (callsite_token == 0) {
+            close_reserved_qty_.erase(id);
+            close_two_call_first_qty_.erase(id);
+        } else {
+            auto reserved =
+                callsite_close_reserved_qty_.find(callsite_token);
+            if (reserved != callsite_close_reserved_qty_.end()) {
+                reserved->second.erase(id);
+                if (reserved->second.empty()) {
+                    callsite_close_reserved_qty_.erase(reserved);
+                }
+            }
+            auto provenance =
+                callsite_close_two_call_first_qty_.find(callsite_token);
+            if (provenance
+                != callsite_close_two_call_first_qty_.end()) {
+                provenance->second.erase(id);
+                if (provenance->second.empty()) {
+                    callsite_close_two_call_first_qty_.erase(provenance);
+                }
+            }
+        }
     }
 
     size_t trades_before = trades_.size();
@@ -895,9 +1294,8 @@ void BacktestEngine::flush_same_bar_close() {
             ? coof_cursor_price_ : current_bar_.close;
     if (closes_full_position) {
         const bool closed_long = (position_side_ == PositionSide::LONG);
-        // Exit-order cancel/purge already ran at CALL time in
-        // enqueue_same_bar_close — orders armed after the close call
-        // must survive exactly as they did under the immediate path.
+        // Exit-order cancel/purge already ran at CALL time in enqueue; orders
+        // armed after the close call must survive the established POOC path.
         execute_market_exit(broker_price);
         if (position_side_ == PositionSide::FLAT) {
             cancel_same_bar_market_reentries_after_full_close(
@@ -906,8 +1304,8 @@ void BacktestEngine::flush_same_bar_close() {
     } else {
         execute_partial_exit_qty(broker_price, target);
         if (position_side_ == PositionSide::FLAT) {
-            // Retain from_entry brackets whose parent entry is still a
-            // pending order (it fills right after this flush).
+            // Retain from_entry brackets whose parent entry is still pending;
+            // it fills immediately after this flush.
             purge_exit_orders(/*retain_for_pending_entries=*/true);
         }
     }
@@ -920,14 +1318,8 @@ void BacktestEngine::flush_same_bar_close() {
         || trades_.size() != trades_before;
     if (close_filled) {
         ++broker_fill_event_seq_;
-        // Default-off follow-up to the no-op MARKET candidate: this broker
-        // fill bypasses apply_filled_order_to_state, but TradingView's
-        // max_intraday_filled_orders counts filled close orders too.  Without
-        // this accounting, removing phantom no-op fills merely unmasks the
-        // opposite under-count and can admit an extra late-day trade cycle.
-        // Scope to the ordinary POOC same-bar batch exercised by Regime; other
-        // immediate/COOF close variants remain unchanged pending their own
-        // oracle.
+        // This custom broker fill bypasses apply_filled_order_to_state, but
+        // TradingView's max_intraday_filled_orders counts filled closes too.
         if (intraday_cap_count_pooc_full_close_fills_
             && process_orders_on_close_
             && !calc_on_order_fills_
@@ -938,12 +1330,8 @@ void BacktestEngine::flush_same_bar_close() {
             && !close_entries_rule_any_
             && closes_full_position
             && max_intraday_filled_orders_ > 0) {
-            // Count the close now, never from the mere presence of a queued
-            // opposite order. If one co-queued opposite MARKET survives to
-            // its fill-time admission point, the earliest broker-order
-            // incarnation inherits this already-spent slot. A rejection,
-            // cancellation, replacement, or later no-op therefore cannot
-            // erase the real close fill; the marker simply expires.
+            // Transfer the already-spent slot to the earliest co-queued
+            // opposite MARKET order if one survives to fill-time admission.
             const PendingOrder* inheritor = nullptr;
             for (const PendingOrder& pending : pending_orders_) {
                 if (pending.type != OrderType::MARKET
@@ -980,41 +1368,66 @@ void BacktestEngine::flush_same_bar_close() {
             --coof_direct_fill_events_remaining_;
         }
     }
+
     if (!sole_call && close_filled
         && position_side_ != PositionSide::FLAT) {
-        // A surviving multi-call close normally keeps its established ledger
-        // (TV leaves the id closable again later). The post-fill reservation
-        // below determines whether any physical backing remains; zero backing
-        // clears that ledger, while a positive truncated reservation keeps it.
+        // A surviving multi-evaluation close normally keeps its established
+        // ledger. Exact-two replacement chains may first restore the prior
+        // batch's recorded first target (never a physical-lot recount).
         if (batch_calls == 2 && first_carry_valid
             && std::isfinite(first_carry_qty) && first_carry_qty > eps) {
-            // Exact two-call -> two-call replacement chain: restore the PRIOR
-            // batch's first admitted target, never ledger-reservation and
-            // never +=. ENA's L59 chain carries 0.0991 here; a 5->2 XAU chain
-            // has no provenance. Restore only after a real broker fill so a
-            // zero/deferred batch cannot resurrect a replaced ledger.
             id_unclosed_qty_[first_id] = first_carry_qty;
         }
-        // A reservation is bounded by physical capacity AFTER this fill.
-        // Existing reservations for other ids have first claim on the
-        // remaining position; blindly reserving the just-filled target can
-        // make total reservations exceed position_qty_ and suppress valid
-        // closes after the next entry. Preserve only the capacity left after
-        // those older claims (ETH grid-bot replacement chain).
         const double actual_fill = std::max(0.0, qty_before - position_qty_);
+        // Bound the reservation by physical capacity after this fill; older
+        // reservations for other ids retain first claim on the position.
+        const double reserved_other = callsite_token == 0
+            ? close_reserved_other_qty(id)
+            : callsite_close_physical_reserved_other_qty(
+                  callsite_token, id);
         const double reserve_capacity =
-            std::max(0.0, position_qty_ - close_reserved_other_qty(id));
+            std::max(0.0, position_qty_ - reserved_other
+                              - pending_later_qty);
         const double reserve = std::min(actual_fill, reserve_capacity);
-        if (reserve > eps) {
-            close_reserved_qty_[id] = reserve;
+        if (callsite_token == 0) {
+            if (reserve > eps) {
+                close_reserved_qty_[id] = reserve;
+            } else {
+                id_unclosed_qty_.erase(id);
+                close_reserved_qty_.erase(id);
+            }
+            if (batch_calls == 2 && reserve >= actual_fill - eps) {
+                close_two_call_first_qty_[id] = first_target;
+            } else {
+                close_two_call_first_qty_.erase(id);
+            }
         } else {
-            id_unclosed_qty_.erase(id);
-            close_reserved_qty_.erase(id);
-        }
-        if (batch_calls == 2 && reserve >= actual_fill - eps) {
-            close_two_call_first_qty_[id] = first_target;
-        } else {
-            close_two_call_first_qty_.erase(id);
+            if (reserve > eps) {
+                callsite_close_reserved_qty_[callsite_token][id] = reserve;
+            } else {
+                id_unclosed_qty_.erase(id);
+                auto owner =
+                    callsite_close_reserved_qty_.find(callsite_token);
+                if (owner != callsite_close_reserved_qty_.end()) {
+                    owner->second.erase(id);
+                    if (owner->second.empty()) {
+                        callsite_close_reserved_qty_.erase(owner);
+                    }
+                }
+            }
+            if (batch_calls == 2 && reserve >= actual_fill - eps) {
+                callsite_close_two_call_first_qty_[callsite_token][id] =
+                    first_target;
+            } else {
+                auto owner =
+                    callsite_close_two_call_first_qty_.find(callsite_token);
+                if (owner != callsite_close_two_call_first_qty_.end()) {
+                    owner->second.erase(id);
+                    if (owner->second.empty()) {
+                        callsite_close_two_call_first_qty_.erase(owner);
+                    }
+                }
+            }
         }
     }
 }
@@ -1056,9 +1469,7 @@ void BacktestEngine::strategy_exit(const std::string& id, const std::string& fro
     // exit sequence freezes the OLD side's size into the bracket's reserved
     // qty (wayward-bison: the Long SL stop filled only the stale short-sized
     // 3.9629 of an 8.0672 long, fragmenting one TV exit into two rows).
-    double sb_pending_close = (sb_close_active_ && sb_close_bar_ == bar_index_)
-                                  ? pending_same_bar_close_target()
-                                  : 0.0;
+    double sb_pending_close = pending_same_bar_close_target();
     double live_pos_qty = (position_side_ == PositionSide::FLAT)
                               ? 0.0
                               : std::max(0.0, position_qty_ - sb_pending_close);

--- a/tests/test_calc_on_order_fills.cpp
+++ b/tests/test_calc_on_order_fills.cpp
@@ -93,7 +93,7 @@ public:
             && trades_.empty()) {
             strategy_entry("L", true);
         } else if (position_side_ == PositionSide::LONG) {
-            strategy_close("L");
+            strategy_close("L", "", kNaN, kNaN, false, 8'009);
         }
     }
 };
@@ -861,6 +861,124 @@ void test_pooc_same_tick_requires_close_cursor_or_immediately() {
     }
 }
 
+// Six-argument codegen path at an intrabar COOF cursor. The nonzero callsite
+// token must not accidentally enable the POOC bar-close queue before C; the
+// existing id-scoped COOF close path remains in charge at this cursor.
+class PoocIdCursorTimingProbe final : public CoofBase {
+public:
+    PoocIdCursorTimingProbe() {
+        process_orders_on_close_ = true;
+    }
+
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0 && position_side_ == PositionSide::FLAT) {
+            strategy_entry("A", true, kNaN, 100.0);
+            return;
+        }
+        if (bar_index_ == 1 && position_side_ == PositionSide::LONG
+            && trades_.empty()) {
+            if (coof_fill_recalc_active_) ++intrabar_close_calls;
+            strategy_close("A", "", kNaN, kNaN, false, 8'014);
+            queued_callsite_count =
+                static_cast<int>(callsite_close_callsites_.size());
+        }
+    }
+
+    int intrabar_close_calls = 0;
+    int queued_callsite_count = -1;
+};
+
+void test_tokenized_close_respects_coof_cursor_timing() {
+    std::printf("test_tokenized_close_respects_coof_cursor_timing\n");
+    Bar bars[] = {
+        {90.0, 95.0, 85.0, 90.0, 1000.0,   900'000},
+        {100.0, 105.0, 90.0, 95.0, 1000.0, 1'800'000},
+    };
+
+    PoocIdCursorTimingProbe tokenized;
+    tokenized.run(bars, 2);
+    CHECK(tokenized.last_error().empty());
+    CHECK(tokenized.intrabar_close_calls == 1);
+    CHECK(tokenized.queued_callsite_count == 0);
+    CHECK(tokenized.trade_count() == 1);
+    if (tokenized.trade_count() == 1) {
+        CHECK(near(tokenized.get_trade(0).exit_price, 100.0));
+    }
+}
+
+// A stop entry fills on L->H and its recalc creates both a market add and a
+// stop exit for the first lot. The add fills at H; the exit then reaches its
+// exact stop on H->C. Its fill-recalc cursor is therefore both active and at
+// bar close while the added lot remains open. That broker point is already
+// consumed, so an ordinary six-argument close must bypass the same-bar
+// callsite queue.
+class PoocCloseAtCRecalcProbe final : public CoofBase {
+public:
+    PoocCloseAtCRecalcProbe() {
+        process_orders_on_close_ = true;
+    }
+
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0 && position_side_ == PositionSide::FLAT) {
+            strategy_entry("A", true, kNaN, 105.0);
+            return;
+        }
+        if (bar_index_ != 1 || !coof_fill_recalc_active_) return;
+        if (!cascade_issued_ && !coof_cursor_is_bar_close_) {
+            cascade_issued_ = true;
+            strategy_entry("B", true);
+            strategy_exit("XA", "A", kNaN, 100.0);
+        } else if (coof_cursor_is_bar_close_ && !close_issued_) {
+            close_issued_ = true;
+            ++close_at_c_recalc_calls;
+            strategy_close("B", "", kNaN, kNaN, false, 8'015);
+            queued_callsite_count =
+                static_cast<int>(callsite_close_callsites_.size());
+            deferred_close_count = 0;
+            deferred_close_born_at_c = false;
+            for (const PendingOrder& order : pending_orders_) {
+                if (order.type == OrderType::EXIT
+                    && order.id == "__close__B") {
+                    ++deferred_close_count;
+                    deferred_close_born_at_c =
+                        order.created_during_coof_recalc
+                        && order.coof_born_at_close_recalc;
+                }
+            }
+            const auto ledger = id_unclosed_qty_.find("B");
+            ledger_after_close = ledger == id_unclosed_qty_.end()
+                ? 0.0 : ledger->second;
+        }
+    }
+
+    int close_at_c_recalc_calls = 0;
+    int queued_callsite_count = -1;
+    int deferred_close_count = -1;
+    bool deferred_close_born_at_c = false;
+    double ledger_after_close = -1.0;
+
+private:
+    bool cascade_issued_ = false;
+    bool close_issued_ = false;
+};
+
+void test_tokenized_close_bypasses_consumed_coof_c_cursor() {
+    std::printf("test_tokenized_close_bypasses_consumed_coof_c_cursor\n");
+    PoocCloseAtCRecalcProbe p;
+    Bar bars[] = {
+        {90.0, 95.0, 85.0, 90.0, 1000.0,   900'000},
+        {100.0, 110.0, 90.0, 100.0, 1000.0, 1'800'000},
+    };
+    p.run(bars, 2);
+
+    CHECK(p.last_error().empty());
+    CHECK(p.close_at_c_recalc_calls == 1);
+    CHECK(p.queued_callsite_count == 0);
+    CHECK(p.deferred_close_count == 1);
+    CHECK(p.deferred_close_born_at_c);
+    CHECK(near(p.ledger_after_close, 1.0));
+}
+
 // A priced bracket born in an INTRABAR fill recalc is a KI-67 cascade EXIT and
 // follows Model S ("R-cascade-gapjump"): held on its in-flight leg, then it
 // gap-fills at that leg-end waypoint if its level is in the in-flight remainder,
@@ -966,7 +1084,7 @@ public:
             && trades_.empty()) {
             strategy_entry("L", true);
         } else if (position_side_ == PositionSide::LONG) {
-            strategy_close("L");
+            strategy_close("L", "", kNaN, kNaN, false, 8'010);
         }
     }
 
@@ -1203,7 +1321,7 @@ public:
         if (position_side_ == PositionSide::FLAT) {
             strategy_entry("L", true);
         } else {
-            strategy_close("L");
+            strategy_close("L", "", kNaN, kNaN, false, 8'011);
         }
     }
 
@@ -1552,6 +1670,8 @@ int main() {
     test_recalc_wrong_limit_does_not_hide_valid_stop_leg();
     test_interior_fill_recalc_market_entry_waits_for_next_waypoint();
     test_pooc_same_tick_requires_close_cursor_or_immediately();
+    test_tokenized_close_respects_coof_cursor_timing();
+    test_tokenized_close_bypasses_consumed_coof_c_cursor();
     test_pooc_intrabar_recalc_priced_order_uses_remaining_path();
     test_historical_barstate_and_committed_state_rollback_hooks();
     test_pooc_terminal_close_fill_has_no_recalc_or_c_born_order();

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <array>
 #include <cmath>
 #include <cstdio>
 #include <vector>
@@ -1647,13 +1648,17 @@ public:
         commission_value_ = 0.0;
         slippage_ = 0;
         pyramiding_ = 3;
+        process_orders_on_close_ = true;
         close_entries_rule_any_ = true;
     }
     void on_bar(const Bar& bar) override {
         if (bar_index_ == 1) strategy_entry("A", true);
         if (bar_index_ == 2) strategy_entry("B", true);
         if (bar_index_ == 3) strategy_entry("C", true);
-        if (bar_index_ == 5) strategy_close("B");
+        if (bar_index_ == 5) {
+            strategy_close("B", "", na<double>(), na<double>(), false,
+                           8'001);
+        }
         if (bar_index_ == 7) strategy_close_all();
     }
 };
@@ -1666,8 +1671,12 @@ static void test_close_entries_any() {
         bars[i] = {100.0 + i, 105.0 + i, 95.0 + i, 102.0 + i, 50, (int64_t)(i + 1) * 60000};
     strat.run(bars, 9);
 
-    // Trade for "B" closed at bar 5, trades for "A" and "C" closed at bar 7
-    CHECK(strat.trade_count() >= 2);
+    // ANY must select B itself even though A is the FIFO-oldest entry.
+    // A and C are closed later by close_all.
+    CHECK(strat.trade_count() == 3);
+    if (strat.trade_count() == 3) {
+        CHECK(strat.get_trade(0).entry_id == "B");
+    }
 }
 
 // ---- 25. Trailing stop mechanics -------------------------------------------
@@ -3108,6 +3117,1394 @@ static void test_positive_truncated_close_reservation_keeps_ledger_only() {
     CHECK(near(strat.first_b, 0.0));
     CHECK(near(strat.total_res, 2.0));
 }
+// ---- 38a2. Pine-v6 POOC default-FIFO close queue --------------------------
+
+class SameBarMultiCloseQueueStrategy : public BacktestEngine {
+public:
+    double visible_after_first = -1.0;
+    double visible_after_second = -1.0;
+    double ledger_a_after_call = -1.0;
+    double ledger_b_after_call = -1.0;
+    double final_pos = -1.0;
+
+    SameBarMultiCloseQueueStrategy() {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    double ledger(const std::string& id) const {
+        const auto it = id_unclosed_qty_.find(id);
+        return it == id_unclosed_qty_.end() ? 0.0 : it->second;
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) strategy_entry("A", true, na, na, 1.0);
+        if (bar_index_ == 1) strategy_entry("B", true, na, na, 2.0);
+        if (bar_index_ == 2) {
+            strategy_close("A", "close-A", na, na, false, 101);
+            visible_after_first = signed_position_size();
+            ledger_a_after_call = ledger("A");
+            strategy_close("B", "close-B", na, na, false, 102);
+            visible_after_second = signed_position_size();
+            ledger_b_after_call = ledger("B");
+        }
+        if (bar_index_ == 3) final_pos = signed_position_size();
+    }
+};
+
+static void test_same_bar_multi_close_queues_all_in_source_order() {
+    std::printf("test_same_bar_multi_close_queues_all_in_source_order\n");
+    SameBarMultiCloseQueueStrategy strat;
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 101, 99, 100, 50, 120000},
+        {100, 106, 99, 105, 50, 180000},
+        {105, 106, 99, 105, 50, 240000},
+    };
+    strat.run(bars, 4);
+
+    // Neither physical fill is visible to the Pine body that issued it. Each
+    // independent one-call batch consumes its ledger at broker flush, exactly
+    // like an accepted token-0 sole call.
+    CHECK(near(strat.visible_after_first, 3.0));
+    CHECK(near(strat.visible_after_second, 3.0));
+    CHECK(near(strat.ledger_a_after_call, 1.0));
+    CHECK(near(strat.ledger_b_after_call, 2.0));
+
+    // The broker queue then fills both commands at C in source order.
+    CHECK(strat.trade_count() == 2);
+    if (strat.trade_count() == 2) {
+        CHECK(near(strat.get_trade(0).qty, 1.0));
+        CHECK(strat.get_trade(0).exit_comment == "close-A");
+        CHECK(near(strat.get_trade(0).exit_price, 105.0));
+        CHECK(near(strat.get_trade(1).qty, 2.0));
+        CHECK(strat.get_trade(1).exit_comment == "close-B");
+        CHECK(near(strat.get_trade(1).exit_price, 105.0));
+    }
+    CHECK(near(strat.final_pos, 0.0));
+}
+
+class OverlappingIdCallsiteReservationStrategy : public BacktestEngine {
+public:
+    double ledger_a_after_calls = -1.0;
+    double ledger_b_after_calls = -1.0;
+    double admitted_qty_after_calls = -1.0;
+    double final_pos = -1.0;
+
+    OverlappingIdCallsiteReservationStrategy() {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    double ledger(const std::string& id) const {
+        const auto it = id_unclosed_qty_.find(id);
+        return it == id_unclosed_qty_.end() ? 0.0 : it->second;
+    }
+
+    double admitted_qty() const {
+        double total = 0.0;
+        for (const auto& kv : callsite_close_callsites_) {
+            if (kv.second.active) total += kv.second.target;
+        }
+        return total;
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) strategy_entry("A", true, na, na, 1.0);
+        if (bar_index_ == 1) strategy_entry("B", true, na, na, 1.0);
+        if (bar_index_ == 2) {
+            strategy_close("A", "SITE1_A", na, na, false, 401);
+            strategy_close("A", "SITE2_A_FIRST", na, na, false, 402);
+            strategy_close("B", "SITE2_B_LAST", na, na, false, 402);
+            ledger_a_after_calls = ledger("A");
+            ledger_b_after_calls = ledger("B");
+            admitted_qty_after_calls = admitted_qty();
+        }
+        if (bar_index_ == 3) final_pos = signed_position_size();
+    }
+};
+
+static void test_overlapping_id_callsites_reserve_before_replacement() {
+    std::printf(
+        "test_overlapping_id_callsites_reserve_before_replacement\n");
+    OverlappingIdCallsiteReservationStrategy strat;
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 101, 99, 100, 50, 120000},
+        {100, 106, 99, 105, 50, 180000},
+        {105, 106, 99, 105, 50, 240000},
+    };
+    strat.run(bars, 4);
+
+    // Direct TV v6 oracle (BINANCE:ETHUSDT.P, 15m, 2026-07-18):
+    // site1/A and site2/A reserve the two live units. The later site2/B call
+    // has zero remaining admission capacity, so it cannot replace site2/A.
+    CHECK(near(strat.ledger_a_after_calls, 1.0));
+    CHECK(near(strat.ledger_b_after_calls, 1.0));
+    CHECK(near(strat.admitted_qty_after_calls, 2.0));
+    CHECK(strat.trade_count() == 2);
+    if (strat.trade_count() == 2) {
+        CHECK(strat.get_trade(0).exit_comment == "SITE1_A");
+        CHECK(near(strat.get_trade(0).qty, 1.0));
+        CHECK(strat.get_trade(1).exit_comment == "SITE2_A_FIRST");
+        CHECK(near(strat.get_trade(1).qty, 1.0));
+    }
+    CHECK(near(strat.final_pos, 0.0));
+}
+
+class SameIdDistinctCallsiteCapacityStrategy : public BacktestEngine {
+public:
+    int admitted_sites_after_calls = -1;
+    double admitted_qty_after_calls = -1.0;
+
+    SameIdDistinctCallsiteCapacityStrategy() {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) strategy_entry("C", true, na, na, 2.0);
+        if (bar_index_ == 1) {
+            strategy_close("C", "SITE1_C", na, na, false, 411);
+            strategy_close("C", "SITE2_C", na, na, false, 412);
+            admitted_sites_after_calls = 0;
+            admitted_qty_after_calls = 0.0;
+            for (const auto& kv : callsite_close_callsites_) {
+                if (!kv.second.active) continue;
+                ++admitted_sites_after_calls;
+                admitted_qty_after_calls += kv.second.target;
+            }
+        }
+    }
+};
+
+static void test_distinct_sites_same_id_share_physical_capacity() {
+    std::printf(
+        "test_distinct_sites_same_id_share_physical_capacity\n");
+    SameIdDistinctCallsiteCapacityStrategy strat;
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 106, 99, 105, 50, 120000},
+        {105, 106, 99, 105, 50, 180000},
+    };
+    strat.run(bars, 3);
+
+    // Direct TV companion oracle: the first close(C) reserves/fills qty 2;
+    // the second distinct site has no capacity and remains a no-op.
+    CHECK(strat.admitted_sites_after_calls == 1);
+    CHECK(near(strat.admitted_qty_after_calls, 2.0));
+    CHECK(strat.trade_count() == 1);
+    if (strat.trade_count() == 1) {
+        CHECK(strat.get_trade(0).exit_comment == "SITE1_C");
+        CHECK(near(strat.get_trade(0).qty, 2.0));
+    }
+}
+
+class SameCallsiteLoopCloseStrategy : public BacktestEngine {
+public:
+    double visible_after_loop = -1.0;
+    double ledger_a_after_loop = -1.0;
+    double ledger_b_after_loop = -1.0;
+    double ledger_c_after_loop = -1.0;
+    double final_pos = -1.0;
+
+    SameCallsiteLoopCloseStrategy() {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    double ledger(const std::string& id) const {
+        const auto it = id_unclosed_qty_.find(id);
+        return it == id_unclosed_qty_.end() ? 0.0 : it->second;
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) strategy_entry("A", true, na, na, 1.0);
+        if (bar_index_ == 1) strategy_entry("B", true, na, na, 1.0);
+        if (bar_index_ == 2) strategy_entry("C", true, na, na, 1.0);
+        if (bar_index_ == 3) {
+            const std::array<std::string, 3> ids = {"A", "B", "C"};
+            for (const std::string& id : ids) {
+                // One syntactic close statement evaluated three times. The
+                // nonzero token is exactly what codegen will derive from its
+                // AST source location; only the last effective id survives.
+                strategy_close(id, "loop-" + id, na, na, false, 201);
+            }
+            visible_after_loop = signed_position_size();
+            ledger_a_after_loop = ledger("A");
+            ledger_b_after_loop = ledger("B");
+            ledger_c_after_loop = ledger("C");
+        }
+        if (bar_index_ == 4) {
+            strategy_close("A", "later-A", na, na, false, 202);
+            strategy_close("B", "later-B", na, na, false, 203);
+        }
+        if (bar_index_ == 5) {
+            strategy_close("C", "later-C", na, na, false, 204);
+        }
+        if (bar_index_ == 6) final_pos = signed_position_size();
+    }
+};
+
+static void test_same_callsite_loop_close_replaces_in_place() {
+    std::printf("test_same_callsite_loop_close_replaces_in_place\n");
+    SameCallsiteLoopCloseStrategy strat;
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 101, 99, 100, 50, 120000},
+        {100, 101, 99, 100, 50, 180000},
+        {100, 106, 99, 105, 50, 240000},
+        {105, 111, 99, 110, 50, 300000},
+        {110, 111, 99, 110, 50, 360000},
+        {110, 111, 99, 110, 50, 420000},
+    };
+    strat.run(bars, 7);
+
+    CHECK(near(strat.visible_after_loop, 3.0));
+    // Tokenized callsites defer provisional ledger consumption until broker
+    // flush so later sites can perform independent admission.
+    CHECK(near(strat.ledger_a_after_loop, 1.0));
+    CHECK(near(strat.ledger_b_after_loop, 1.0));
+    CHECK(near(strat.ledger_c_after_loop, 1.0));
+    CHECK(strat.trade_count() == 3);
+    if (strat.trade_count() == 3) {
+        CHECK(strat.get_trade(0).exit_comment == "loop-C");
+        CHECK(near(strat.get_trade(0).qty, 1.0));
+        CHECK(strat.get_trade(1).exit_comment == "later-B");
+        CHECK(near(strat.get_trade(1).qty, 1.0));
+        CHECK(strat.get_trade(2).exit_comment == "later-C");
+        CHECK(near(strat.get_trade(2).qty, 1.0));
+    }
+    CHECK(near(strat.final_pos, 0.0));
+}
+
+class SameCallsiteCarryCompatibilityStrategy : public BacktestEngine {
+public:
+    explicit SameCallsiteCarryCompatibilityStrategy(bool tokenized)
+        : tokenized_(tokenized) {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    double pending_close_after_replacement = -1.0;
+    double admitted_total_after_replacement = -1.0;
+    double later_entry_carry = -1.0;
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) strategy_entry("A", true, na, na, 1.0);
+        if (bar_index_ == 1) strategy_entry("B", true, na, na, 1.0);
+        if (bar_index_ != 2) return;
+
+        if (tokenized_) {
+            strategy_close("A", "first", na, na, false, 301);
+            strategy_close("B", "survivor", na, na, false, 301);
+        } else {
+            // Exercise the real five-argument ABI-compatible overload.
+            strategy_close("A", "first", na, na, false);
+            strategy_close("B", "survivor", na, na, false);
+        }
+        pending_close_after_replacement = pending_close_qty_in_bar_;
+        admitted_total_after_replacement =
+            callsite_close_admitted_total_;
+
+        // This priced order stays out of range. Its placement snapshot exposes
+        // the source-order carry calculation without adding another fill.
+        strategy_entry("LATER", true, na, 1000.0, 1.0);
+        if (!pending_orders_.empty()
+            && pending_orders_.back().id == "LATER") {
+            later_entry_carry = pending_orders_.back().tv_carry_qty;
+        }
+    }
+
+private:
+    bool tokenized_;
+};
+
+static void test_callsite_replacement_separates_live_claim_from_entry_debt() {
+    std::printf(
+        "test_callsite_replacement_separates_live_claim_from_entry_debt\n");
+    SameCallsiteCarryCompatibilityStrategy legacy(/*tokenized=*/false);
+    SameCallsiteCarryCompatibilityStrategy tokenized(/*tokenized=*/true);
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 101, 99, 100, 50, 120000},
+        {100, 106, 99, 105, 50, 180000},
+    };
+    legacy.run(bars, 3);
+    tokenized.run(bars, 3);
+
+    // Accepted evaluations keep the established cumulative source-order debt
+    // used by later-entry carry. The tokenized broker queue separately owns
+    // one net-live physical claim after A is replaced by B.
+    CHECK(near(legacy.pending_close_after_replacement, 2.0));
+    CHECK(near(tokenized.pending_close_after_replacement, 2.0));
+    CHECK(near(legacy.admitted_total_after_replacement, 0.0));
+    CHECK(near(tokenized.admitted_total_after_replacement, 1.0));
+    CHECK(near(legacy.later_entry_carry, 0.0));
+    CHECK(near(tokenized.later_entry_carry, 0.0));
+}
+
+class SingleCallsiteReplacementCapacityStrategy : public BacktestEngine {
+public:
+    explicit SingleCallsiteReplacementCapacityStrategy(bool tokenized)
+        : tokenized_(tokenized) {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    double debt_after_calls = -1.0;
+    double admitted_after_calls = -1.0;
+    double final_position = -1.0;
+
+    void close_site(const std::string& id, const std::string& comment) {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (tokenized_) {
+            strategy_close(id, comment, na, na, false, 715);
+        } else {
+            strategy_close(id, comment, na, na, false);
+        }
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) {
+            strategy_entry("seed", true, na, na, 1.2542);
+        } else if (bar_index_ == 1) {
+            // Exact bounded shape from the ETH compatibility discriminator:
+            // two older reservations leave .356 physical capacity. Replacing
+            // L3(.2069) with L4(.4159) must reuse this site's own live claim,
+            // admitting the full .356 just like token 0.
+            id_unclosed_qty_.clear();
+            close_reserved_qty_.clear();
+            close_two_call_first_qty_.clear();
+            callsite_close_reserved_qty_.clear();
+            callsite_close_two_call_first_qty_.clear();
+            id_unclosed_qty_["L3"] = 0.2069;
+            id_unclosed_qty_["L4"] = 0.4159;
+            if (tokenized_) {
+                callsite_close_reserved_qty_[715]["L7"] = 0.4310;
+                callsite_close_reserved_qty_[715]["L15"] = 0.4672;
+                callsite_close_two_call_first_qty_[715]["L7"] = 0.2133;
+                callsite_close_two_call_first_qty_[715]["L15"] = 0.2312;
+            } else {
+                close_reserved_qty_["L7"] = 0.4310;
+                close_reserved_qty_["L15"] = 0.4672;
+                close_two_call_first_qty_["L7"] = 0.2133;
+                close_two_call_first_qty_["L15"] = 0.2312;
+            }
+            close_site("L3", "FIRST_L3");
+            close_site("L4", "SURVIVOR_L4");
+            debt_after_calls = pending_close_qty_in_bar_;
+            admitted_after_calls = callsite_close_admitted_total_;
+        } else if (bar_index_ == 2) {
+            final_position = signed_position_size();
+        }
+    }
+
+private:
+    bool tokenized_;
+};
+
+static void test_single_site_replacement_reuses_own_live_claim() {
+    std::printf("test_single_site_replacement_reuses_own_live_claim\n");
+    SingleCallsiteReplacementCapacityStrategy legacy(/*tokenized=*/false);
+    SingleCallsiteReplacementCapacityStrategy tokenized(/*tokenized=*/true);
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 106, 99, 105, 50, 120000},
+        {105, 106, 99, 105, 50, 180000},
+    };
+    legacy.run(bars, 3);
+    tokenized.run(bars, 3);
+
+    for (BacktestEngine* base : std::array<BacktestEngine*, 2>{
+             &legacy, &tokenized}) {
+        CHECK(base->trade_count() == 1);
+        if (base->trade_count() == 1) {
+            CHECK(near(base->get_trade(0).qty, 0.3560));
+            CHECK(base->get_trade(0).exit_comment == "SURVIVOR_L4");
+        }
+    }
+    CHECK(near(legacy.debt_after_calls, 0.5629));
+    CHECK(near(tokenized.debt_after_calls, 0.5629));
+    CHECK(near(legacy.admitted_after_calls, 0.0));
+    CHECK(near(tokenized.admitted_after_calls, 0.3560));
+    CHECK(near(legacy.final_position, 0.8982));
+    CHECK(near(tokenized.final_position, 0.8982));
+}
+
+class RejectedCallsiteReplacementStrategy : public BacktestEngine {
+public:
+    int exits_before_rejected = -1;
+    int exits_after_rejected = -1;
+    double debt_before_rejected = -1.0;
+    double debt_after_rejected = -1.0;
+    double admitted_before_rejected = -1.0;
+    double admitted_after_rejected = -1.0;
+    int site_calls_after_rejected = -1;
+    std::string site_id_after_rejected;
+    std::string site_comment_after_rejected;
+    uint64_t site_queue_after_rejected = 0;
+
+    RejectedCallsiteReplacementStrategy() {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    int pending_exit_count() const {
+        return static_cast<int>(std::count_if(
+            pending_orders_.begin(), pending_orders_.end(),
+            [](const PendingOrder& order) {
+                return order.type == OrderType::EXIT;
+            }));
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) strategy_entry("A", true, na, na, 1.0);
+        if (bar_index_ == 1) strategy_entry("B", true, na, na, 1.0);
+        if (bar_index_ != 2) return;
+
+        strategy_exit("protect-B", "B", 200.0, na);
+        // Make B look like a would-be full close if the two already-admitted
+        // A instructions were incorrectly ignored during replacement.
+        id_unclosed_qty_["B"] = 2.0;
+        strategy_close("A", "SITE1_A", na, na, false, 721);
+        strategy_close("A", "SITE2_A", na, na, false, 722);
+        exits_before_rejected = pending_exit_count();
+        debt_before_rejected = pending_close_qty_in_bar_;
+        admitted_before_rejected = callsite_close_admitted_total_;
+
+        strategy_close("B", "REJECTED_FULL_B", na, na, false, 722);
+        exits_after_rejected = pending_exit_count();
+        debt_after_rejected = pending_close_qty_in_bar_;
+        admitted_after_rejected = callsite_close_admitted_total_;
+        const auto site = callsite_close_callsites_.find(722);
+        if (site != callsite_close_callsites_.end()) {
+            site_calls_after_rejected = site->second.calls;
+            site_id_after_rejected = site->second.id;
+            site_comment_after_rejected = site->second.comment;
+            site_queue_after_rejected = site->second.queue_seq;
+        }
+    }
+};
+
+static void test_rejected_replacement_has_no_debt_or_order_side_effects() {
+    std::printf(
+        "test_rejected_replacement_has_no_debt_or_order_side_effects\n");
+    RejectedCallsiteReplacementStrategy strat;
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 101, 99, 100, 50, 120000},
+        {100, 106, 99, 105, 50, 180000},
+    };
+    strat.run(bars, 3);
+
+    CHECK(strat.exits_before_rejected == 1);
+    CHECK(strat.exits_after_rejected == 1);
+    CHECK(near(strat.debt_before_rejected, 2.0));
+    CHECK(near(strat.debt_after_rejected, 2.0));
+    CHECK(near(strat.admitted_before_rejected, 2.0));
+    CHECK(near(strat.admitted_after_rejected, 2.0));
+    CHECK(strat.site_calls_after_rejected == 1);
+    CHECK(strat.site_id_after_rejected == "A");
+    CHECK(strat.site_comment_after_rejected == "SITE2_A");
+    CHECK(strat.site_queue_after_rejected == 2);
+}
+
+class OwnerAwareCloseReservationStrategy : public BacktestEngine {
+public:
+    explicit OwnerAwareCloseReservationStrategy(bool cleanup_site_first)
+        : cleanup_site_first_(cleanup_site_first) {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    double t2_claim = -1.0;
+    double t2_provenance = -1.0;
+    double shared_k_ledger = -1.0;
+    double total_claims = -1.0;
+    double live_position = -1.0;
+    bool t1_owns_k = true;
+    bool owner_maps_empty_after_flat = false;
+    bool ledger_empty_after_flat = false;
+
+    double owner_value(
+        const std::unordered_map<
+            uint64_t, std::unordered_map<std::string, double>>& owners,
+        uint64_t token, const std::string& id) const {
+        const auto owner = owners.find(token);
+        if (owner == owners.end()) return 0.0;
+        const auto value = owner->second.find(id);
+        return value == owner->second.end() ? 0.0 : value->second;
+    }
+
+    void cleanup_site() {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        strategy_close("K", "T1_FIRST_K", na, na, false, 731);
+        strategy_close("J", "T1_SURVIVOR_J", na, na, false, 731);
+    }
+
+    void t2_survivor_site() {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        strategy_close("A", "T2_FIRST_A", na, na, false, 732);
+        strategy_close("K", "T2_SURVIVOR_K", na, na, false, 732);
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) {
+            strategy_entry("seed", true, na, na, 6.0);
+        } else if (bar_index_ == 1) {
+            id_unclosed_qty_.clear();
+            close_reserved_qty_.clear();
+            close_two_call_first_qty_.clear();
+            callsite_close_reserved_qty_.clear();
+            callsite_close_two_call_first_qty_.clear();
+            id_unclosed_qty_["A"] = 1.0;
+            id_unclosed_qty_["J"] = 1.0;
+            id_unclosed_qty_["K"] = 1.0;
+            if (cleanup_site_first_) {
+                cleanup_site();
+                t2_survivor_site();
+            } else {
+                t2_survivor_site();
+                cleanup_site();
+            }
+        } else if (bar_index_ == 2) {
+            t2_claim = owner_value(
+                callsite_close_reserved_qty_, 732, "K");
+            t2_provenance = owner_value(
+                callsite_close_two_call_first_qty_, 732, "K");
+            const auto ledger = id_unclosed_qty_.find("K");
+            shared_k_ledger = ledger == id_unclosed_qty_.end()
+                ? 0.0 : ledger->second;
+            total_claims = 0.0;
+            for (const auto& owner : callsite_close_reserved_qty_) {
+                for (const auto& claim : owner.second) {
+                    total_claims += claim.second;
+                }
+            }
+            live_position = position_qty_;
+            const auto t1 = callsite_close_reserved_qty_.find(731);
+            t1_owns_k = t1 != callsite_close_reserved_qty_.end()
+                && t1->second.find("K") != t1->second.end();
+            strategy_close("", "FLAT_RESET");
+        } else if (bar_index_ == 3) {
+            owner_maps_empty_after_flat =
+                callsite_close_reserved_qty_.empty()
+                && callsite_close_two_call_first_qty_.empty();
+            ledger_empty_after_flat = id_unclosed_qty_.empty();
+        }
+    }
+
+private:
+    bool cleanup_site_first_;
+};
+
+static void test_owner_reservation_survives_other_token_cleanup_permutations() {
+    std::printf(
+        "test_owner_reservation_survives_other_token_cleanup_permutations\n");
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 106, 99, 105, 50, 120000},
+        {105, 106, 99, 104, 50, 180000},
+        {104, 105, 98,  99, 50, 240000},
+    };
+    for (bool cleanup_first : {false, true}) {
+        OwnerAwareCloseReservationStrategy strat(cleanup_first);
+        strat.run(bars, 4);
+        CHECK(near(strat.t2_claim, 1.0));
+        CHECK(near(strat.t2_provenance, 1.0));
+        CHECK(strat.shared_k_ledger + 1e-9 >= strat.t2_claim);
+        CHECK(!strat.t1_owns_k);
+        CHECK(strat.total_claims <= strat.live_position + 1e-9);
+        CHECK(strat.owner_maps_empty_after_flat);
+        CHECK(strat.ledger_empty_after_flat);
+    }
+}
+
+class CrossOwnerReserveBackingStrategy : public BacktestEngine {
+public:
+    double t1_b_claim = -1.0;
+    double t1_b_provenance = -1.0;
+    double t2_c_claim = -1.0;
+    double t2_c_provenance = -1.0;
+    double total_claims = -1.0;
+    double live_position = -1.0;
+    double ledger_c = -1.0;
+
+    CrossOwnerReserveBackingStrategy() {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    double owner_value(
+        const std::unordered_map<
+            uint64_t, std::unordered_map<std::string, double>>& owners,
+        uint64_t token, const std::string& id) const {
+        const auto owner = owners.find(token);
+        if (owner == owners.end()) return 0.0;
+        const auto value = owner->second.find(id);
+        return value == owner->second.end() ? 0.0 : value->second;
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) {
+            strategy_entry("seed", true, na, na, 3.0);
+        } else if (bar_index_ == 1) {
+            id_unclosed_qty_.clear();
+            id_unclosed_qty_["A"] = 1.0;
+            id_unclosed_qty_["B"] = 1.0;
+            id_unclosed_qty_["C"] = 1.0;
+            strategy_close("A", "T1_FIRST_A", na, na, false, 741);
+            strategy_close("B", "T1_SURVIVOR_B", na, na, false, 741);
+            strategy_close("A", "T2_FIRST_A", na, na, false, 742);
+            strategy_close("C", "T2_SURVIVOR_C", na, na, false, 742);
+        } else if (bar_index_ == 2) {
+            t1_b_claim = owner_value(
+                callsite_close_reserved_qty_, 741, "B");
+            t1_b_provenance = owner_value(
+                callsite_close_two_call_first_qty_, 741, "B");
+            t2_c_claim = owner_value(
+                callsite_close_reserved_qty_, 742, "C");
+            t2_c_provenance = owner_value(
+                callsite_close_two_call_first_qty_, 742, "C");
+            total_claims = 0.0;
+            for (const auto& owner : callsite_close_reserved_qty_) {
+                for (const auto& claim : owner.second) {
+                    total_claims += claim.second;
+                }
+            }
+            live_position = position_qty_;
+            const auto c = id_unclosed_qty_.find("C");
+            ledger_c = c == id_unclosed_qty_.end() ? 0.0 : c->second;
+        }
+    }
+};
+
+static void test_cross_owner_post_fill_backing_is_physically_bounded() {
+    std::printf(
+        "test_cross_owner_post_fill_backing_is_physically_bounded\n");
+    CrossOwnerReserveBackingStrategy strat;
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 106, 99, 105, 50, 120000},
+        {105, 106, 99, 105, 50, 180000},
+    };
+    strat.run(bars, 3);
+
+    CHECK(strat.trade_count() == 2);
+    if (strat.trade_count() == 2) {
+        CHECK(strat.get_trade(0).exit_comment == "T1_SURVIVOR_B");
+        CHECK(strat.get_trade(1).exit_comment == "T2_SURVIVOR_C");
+        CHECK(near(strat.get_trade(0).qty, 1.0));
+        CHECK(near(strat.get_trade(1).qty, 1.0));
+    }
+    CHECK(near(strat.live_position, 1.0));
+    CHECK(near(strat.t1_b_claim, 1.0));
+    CHECK(near(strat.t1_b_provenance, 1.0));
+    CHECK(near(strat.t2_c_claim, 0.0));
+    CHECK(near(strat.t2_c_provenance, 0.0));
+    CHECK(near(strat.ledger_c, 0.0));
+    CHECK(strat.total_claims <= strat.live_position + 1e-9);
+}
+
+// Persistent claims owned by different source sites follow the same
+// different-id capacity rule as token 0. After B and C each retain one unit,
+// a fresh D close for three units can use only the two unclaimed units of the
+// four-unit live position.
+class CrossBarDifferentIdClaimCapacityStrategy : public BacktestEngine {
+public:
+    double position_before_d = -1.0;
+    double claims_before_d = -1.0;
+    double admitted_d = -1.0;
+    double position_after_d = -1.0;
+
+    CrossBarDifferentIdClaimCapacityStrategy() {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) {
+            strategy_entry("seed", true, na, na, 6.0);
+        } else if (bar_index_ == 1) {
+            id_unclosed_qty_.clear();
+            close_reserved_qty_.clear();
+            close_two_call_first_qty_.clear();
+            callsite_close_reserved_qty_.clear();
+            callsite_close_two_call_first_qty_.clear();
+            id_unclosed_qty_["A"] = 1.0;
+            id_unclosed_qty_["B"] = 1.0;
+            id_unclosed_qty_["C"] = 1.0;
+            strategy_close("A", "T1_FIRST_A", na, na, false, 751);
+            strategy_close("B", "T1_SURVIVOR_B", na, na, false, 751);
+            strategy_close("A", "T2_FIRST_A", na, na, false, 752);
+            strategy_close("C", "T2_SURVIVOR_C", na, na, false, 752);
+        } else if (bar_index_ == 2) {
+            position_before_d = position_qty_;
+            claims_before_d = 0.0;
+            for (const auto& owner : callsite_close_reserved_qty_) {
+                for (const auto& claim : owner.second) {
+                    claims_before_d += claim.second;
+                }
+            }
+            id_unclosed_qty_["D"] = 3.0;
+            strategy_close("D", "SECOND_BAR_D", na, na, false, 753);
+            admitted_d = callsite_close_admitted_total_;
+        } else if (bar_index_ == 3) {
+            position_after_d = position_qty_;
+        }
+    }
+};
+
+static void test_cross_bar_different_id_claims_cap_fresh_site() {
+    std::printf("test_cross_bar_different_id_claims_cap_fresh_site\n");
+    CrossBarDifferentIdClaimCapacityStrategy strat;
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 106, 99, 105, 50, 120000},
+        {105, 106, 99, 104, 50, 180000},
+        {104, 105, 98,  99, 50, 240000},
+    };
+    strat.run(bars, 4);
+
+    CHECK(near(strat.position_before_d, 4.0));
+    CHECK(near(strat.claims_before_d, 2.0));
+    CHECK(near(strat.admitted_d, 2.0));
+    CHECK(near(strat.position_after_d, 2.0));
+    CHECK(strat.trade_count() == 3);
+    if (strat.trade_count() == 3) {
+        CHECK(strat.get_trade(0).exit_comment == "T1_SURVIVOR_B");
+        CHECK(strat.get_trade(1).exit_comment == "T2_SURVIVOR_C");
+        CHECK(strat.get_trade(2).exit_comment == "SECOND_BAR_D");
+        CHECK(near(strat.get_trade(2).qty, 2.0));
+    }
+}
+
+class SameIdOwnerClaimsShareBackingStrategy : public BacktestEngine {
+public:
+    double admitted_d = -1.0;
+    double final_position = -1.0;
+
+    SameIdOwnerClaimsShareBackingStrategy() {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) {
+            strategy_entry("seed", true, na, na, 4.0);
+        } else if (bar_index_ == 1) {
+            id_unclosed_qty_.clear();
+            close_reserved_qty_.clear();
+            close_two_call_first_qty_.clear();
+            callsite_close_reserved_qty_.clear();
+            callsite_close_two_call_first_qty_.clear();
+
+            // Two source sites alias one shared A ledger. Physical backing is
+            // max(0.6, 1.0), not their 1.6 sum.
+            id_unclosed_qty_["A"] = 1.0;
+            callsite_close_reserved_qty_[761]["A"] = 0.6;
+            callsite_close_reserved_qty_[762]["A"] = 1.0;
+            callsite_close_two_call_first_qty_[761]["A"] = 0.6;
+            callsite_close_two_call_first_qty_[762]["A"] = 1.0;
+            id_unclosed_qty_["D"] = 3.0;
+
+            strategy_close("D", "GROUPED_BACKING_D", na, na, false, 763);
+            admitted_d = callsite_close_admitted_total_;
+        } else if (bar_index_ == 2) {
+            final_position = position_qty_;
+        }
+    }
+};
+
+static void test_same_id_owner_claims_share_physical_backing() {
+    std::printf("test_same_id_owner_claims_share_physical_backing\n");
+    SameIdOwnerClaimsShareBackingStrategy strat;
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 106, 99, 105, 50, 120000},
+        {105, 106, 99, 104, 50, 180000},
+    };
+    strat.run(bars, 3);
+
+    CHECK(near(strat.admitted_d, 3.0));
+    CHECK(near(strat.final_position, 1.0));
+    CHECK(strat.trade_count() == 1);
+    if (strat.trade_count() == 1) {
+        CHECK(strat.get_trade(0).exit_comment == "GROUPED_BACKING_D");
+        CHECK(near(strat.get_trade(0).qty, 3.0));
+    }
+}
+
+class SameIdAliasesExcludedFromPostFillBackingStrategy
+    : public BacktestEngine {
+public:
+    double new_a_claim = -1.0;
+    double final_position = -1.0;
+
+    SameIdAliasesExcludedFromPostFillBackingStrategy() {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) {
+            strategy_entry("seed", true, na, na, 2.0);
+        } else if (bar_index_ == 1) {
+            id_unclosed_qty_.clear();
+            close_reserved_qty_.clear();
+            close_two_call_first_qty_.clear();
+            callsite_close_reserved_qty_.clear();
+            callsite_close_two_call_first_qty_.clear();
+            id_unclosed_qty_["A"] = 1.0;
+            id_unclosed_qty_["X"] = 1.0;
+            callsite_close_reserved_qty_[771]["A"] = 0.6;
+            callsite_close_reserved_qty_[772]["A"] = 1.0;
+            callsite_close_two_call_first_qty_[771]["A"] = 0.6;
+            callsite_close_two_call_first_qty_[772]["A"] = 1.0;
+
+            strategy_close("X", "FIRST_X", na, na, false, 773);
+            strategy_close("A", "SURVIVOR_A", na, na, false, 773);
+        } else if (bar_index_ == 2) {
+            final_position = position_qty_;
+            const auto owner = callsite_close_reserved_qty_.find(773);
+            if (owner != callsite_close_reserved_qty_.end()) {
+                const auto claim = owner->second.find("A");
+                if (claim != owner->second.end()) {
+                    new_a_claim = claim->second;
+                }
+            }
+        }
+    }
+};
+
+static void test_post_fill_backing_excludes_all_same_id_aliases() {
+    std::printf(
+        "test_post_fill_backing_excludes_all_same_id_aliases\n");
+    SameIdAliasesExcludedFromPostFillBackingStrategy strat;
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 106, 99, 105, 50, 120000},
+        {105, 106, 99, 104, 50, 180000},
+    };
+    strat.run(bars, 3);
+
+    CHECK(near(strat.final_position, 1.0));
+    CHECK(near(strat.new_a_claim, 1.0));
+    CHECK(strat.trade_count() == 1);
+    if (strat.trade_count() == 1) {
+        CHECK(strat.get_trade(0).exit_comment == "SURVIVOR_A");
+        CHECK(near(strat.get_trade(0).qty, 1.0));
+    }
+}
+
+class UnequalAliasLocalReleaseStrategy : public BacktestEngine {
+public:
+    UnequalAliasLocalReleaseStrategy(double current_claim,
+                                     double competing_claim)
+        : current_claim_(current_claim),
+          competing_claim_(competing_claim) {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    double admitted_d = -1.0;
+    double final_position = -1.0;
+    double competing_claim_after = -1.0;
+    bool current_claim_erased = false;
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) {
+            strategy_entry("seed", true, na, na, 4.0);
+        } else if (bar_index_ == 1) {
+            id_unclosed_qty_.clear();
+            close_reserved_qty_.clear();
+            close_two_call_first_qty_.clear();
+            callsite_close_reserved_qty_.clear();
+            callsite_close_two_call_first_qty_.clear();
+            id_unclosed_qty_["B"] = 1.0;
+            id_unclosed_qty_["C"] = 1.0;
+            id_unclosed_qty_["D"] = 4.0;
+            callsite_close_reserved_qty_[781]["B"] = current_claim_;
+            callsite_close_reserved_qty_[782]["B"] = competing_claim_;
+            callsite_close_two_call_first_qty_[781]["B"] = current_claim_;
+            callsite_close_two_call_first_qty_[782]["B"] = competing_claim_;
+
+            strategy_close("B", "FIRST_B", na, na, false, 781);
+            strategy_close("C", "MIDDLE_C", na, na, false, 781);
+            strategy_close("D", "SURVIVOR_D", na, na, false, 781);
+            admitted_d = callsite_close_admitted_total_;
+        } else if (bar_index_ == 2) {
+            final_position = position_qty_;
+            const auto current = callsite_close_reserved_qty_.find(781);
+            current_claim_erased = current == callsite_close_reserved_qty_.end()
+                || current->second.find("B") == current->second.end();
+            const auto competing = callsite_close_reserved_qty_.find(782);
+            if (competing != callsite_close_reserved_qty_.end()) {
+                const auto claim = competing->second.find("B");
+                if (claim != competing->second.end()) {
+                    competing_claim_after = claim->second;
+                }
+            }
+        }
+    }
+
+private:
+    double current_claim_;
+    double competing_claim_;
+};
+
+static void test_local_alias_release_frees_only_marginal_backing() {
+    std::printf(
+        "test_local_alias_release_frees_only_marginal_backing\n");
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 106, 99, 105, 50, 120000},
+        {105, 106, 99, 104, 50, 180000},
+    };
+    struct Case {
+        double current;
+        double competing;
+        double expected_d;
+    };
+    const Case cases[] = {
+        {0.6, 1.0, 3.0},
+        {1.0, 0.6, 3.4},
+    };
+    for (const Case& test : cases) {
+        UnequalAliasLocalReleaseStrategy strat(
+            test.current, test.competing);
+        strat.run(bars, 3);
+        CHECK(near(strat.admitted_d, test.expected_d));
+        CHECK(near(strat.final_position, test.competing));
+        CHECK(strat.current_claim_erased);
+        CHECK(near(strat.competing_claim_after, test.competing));
+        CHECK(strat.final_position + 1e-9
+              >= strat.competing_claim_after);
+        CHECK(strat.trade_count() == 1);
+        if (strat.trade_count() == 1) {
+            CHECK(strat.get_trade(0).exit_comment == "SURVIVOR_D");
+            CHECK(near(strat.get_trade(0).qty, test.expected_d));
+        }
+    }
+}
+
+class InterleavedCallsiteCloseStrategy : public BacktestEngine {
+public:
+    double ledger_a_after_calls = -1.0;
+    double ledger_b_after_calls = -1.0;
+    double ledger_c_after_calls = -1.0;
+
+    InterleavedCallsiteCloseStrategy() {
+        initial_capital_ = 100000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 10;
+        process_orders_on_close_ = true;
+    }
+
+    double ledger(const std::string& id) const {
+        const auto it = id_unclosed_qty_.find(id);
+        return it == id_unclosed_qty_.end() ? 0.0 : it->second;
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) strategy_entry("A", true, na, na, 1.0);
+        if (bar_index_ == 1) strategy_entry("B", true, na, na, 1.0);
+        if (bar_index_ == 2) strategy_entry("C", true, na, na, 1.0);
+        if (bar_index_ == 3) {
+            strategy_close("A", "A_FIRST", na, na, false, 211);
+            strategy_close("B", "B_MIDDLE", na, na, false, 212);
+            strategy_close("C", "A_LAST", na, na, false, 211);
+            ledger_a_after_calls = ledger("A");
+            ledger_b_after_calls = ledger("B");
+            ledger_c_after_calls = ledger("C");
+        }
+        if (bar_index_ == 4) {
+            strategy_close("C", "later-C", na, na, false, 213);
+        }
+    }
+};
+
+static void test_interleaved_callsite_replacement_preserves_queue_position() {
+    std::printf(
+        "test_interleaved_callsite_replacement_preserves_queue_position\n");
+    InterleavedCallsiteCloseStrategy strat;
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 101, 99, 100, 50, 120000},
+        {100, 101, 99, 100, 50, 180000},
+        {100, 106, 99, 105, 50, 240000},
+        {105, 111, 99, 110, 50, 300000},
+        {110, 111, 99, 110, 50, 360000},
+    };
+    strat.run(bars, 6);
+
+    CHECK(near(strat.ledger_a_after_calls, 1.0));
+    CHECK(near(strat.ledger_b_after_calls, 1.0));
+    CHECK(near(strat.ledger_c_after_calls, 1.0));
+    CHECK(strat.trade_count() == 3);
+    if (strat.trade_count() == 3) {
+        CHECK(strat.get_trade(0).exit_comment == "A_LAST");
+        CHECK(strat.get_trade(1).exit_comment == "B_MIDDLE");
+        CHECK(strat.get_trade(2).exit_comment == "later-C");
+    }
+}
+
+// Direct engine mirror of the authoritative Pine-v6 exported tape in
+// pf-probe-close-callsite-interleaving. The two loop branches are distinct
+// syntactic sites; reissuing site A after site B updates A in place without
+// moving its first-admission queue slot. The next bar's two distinct inner UDF
+// statements are new sites and must not be blocked by A's prior provenance.
+class ExportedCallsiteInterleavingOracleStrategy : public BacktestEngine {
+public:
+    ExportedCallsiteInterleavingOracleStrategy() {
+        initial_capital_ = 1000000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 20;
+        process_orders_on_close_ = true;
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) {
+            strategy_entry("X", true, na, na, 1.0, "ENTRY_X");
+            strategy_entry("B", true, na, na, 1.0, "ENTRY_B");
+            strategy_entry("Y", true, na, na, 1.0, "ENTRY_Y");
+            strategy_entry("U1", true, na, na, 1.0, "ENTRY_U1");
+            strategy_entry("U2", true, na, na, 1.0, "ENTRY_U2");
+        } else if (bar_index_ == 1) {
+            strategy_close("X", "A_FIRST", na, na, false, 701);
+            strategy_close("B", "B_MIDDLE", na, na, false, 702);
+            strategy_close("Y", "A_LAST", na, na, false, 701);
+        } else if (bar_index_ == 2) {
+            strategy_close("U1", "UDF_INNER_1", na, na, false, 703);
+            strategy_close("U2", "UDF_INNER_2", na, na, false, 704);
+        } else if (bar_index_ == 3) {
+            strategy_close("", "CLEANUP");
+        }
+    }
+};
+
+static void test_exported_callsite_interleaving_tv_oracle() {
+    std::printf("test_exported_callsite_interleaving_tv_oracle\n");
+    ExportedCallsiteInterleavingOracleStrategy strat;
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 106, 99, 105, 50, 120000},
+        {105, 106, 99, 104, 50, 180000},
+        {104, 105, 98,  99, 50, 240000},
+    };
+    strat.run(bars, 4);
+
+    const char* expected_comments[] = {
+        "A_LAST", "B_MIDDLE", "UDF_INNER_1", "UDF_INNER_2", "CLEANUP",
+    };
+    CHECK(strat.trade_count() == 5);
+    if (strat.trade_count() == 5) {
+        for (size_t i = 0; i < 5; ++i) {
+            CHECK(strat.get_trade(i).exit_comment == expected_comments[i]);
+            CHECK(near(strat.get_trade(i).qty, 1.0));
+        }
+    }
+}
+
+// Direct engine mirror of pf-probe-close-callsite-udf. All invocations route
+// through one shared inner strategy.close statement, so two written outer
+// calls replace each other and three loop evaluations retain only the last.
+class ExportedSharedInnerUdfOracleStrategy : public BacktestEngine {
+public:
+    ExportedSharedInnerUdfOracleStrategy() {
+        initial_capital_ = 1000000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 20;
+        process_orders_on_close_ = true;
+    }
+
+    void close_one(const std::string& id, const std::string& comment) {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        strategy_close(id, comment, na, na, false, 711);
+    }
+
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) {
+            strategy_entry("A", true, na, na, 1.0, "ENTRY_A");
+            strategy_entry("B", true, na, na, 1.0, "ENTRY_B");
+            strategy_entry("L0", true, na, na, 1.0, "ENTRY_L0");
+            strategy_entry("L1", true, na, na, 1.0, "ENTRY_L1");
+            strategy_entry("L2", true, na, na, 1.0, "ENTRY_L2");
+        } else if (bar_index_ == 1) {
+            close_one("A", "UDF_DISTINCT_A");
+            close_one("B", "UDF_DISTINCT_B");
+        } else if (bar_index_ == 2) {
+            close_one("L0", "UDF_LOOP_0");
+            close_one("L1", "UDF_LOOP_1");
+            close_one("L2", "UDF_LOOP_2");
+        } else if (bar_index_ == 3) {
+            strategy_close("", "CLEANUP");
+        }
+    }
+};
+
+static void test_exported_shared_inner_udf_tv_oracle() {
+    std::printf("test_exported_shared_inner_udf_tv_oracle\n");
+    ExportedSharedInnerUdfOracleStrategy strat;
+    Bar bars[] = {
+        {100, 101, 99, 100, 50,  60000},
+        {100, 106, 99, 105, 50, 120000},
+        {105, 106, 99, 104, 50, 180000},
+        {104, 105, 98,  99, 50, 240000},
+    };
+    strat.run(bars, 4);
+
+    const char* expected_comments[] = {
+        "UDF_DISTINCT_B", "UDF_LOOP_2", "CLEANUP", "CLEANUP", "CLEANUP",
+    };
+    CHECK(strat.trade_count() == 5);
+    if (strat.trade_count() == 5) {
+        for (size_t i = 0; i < 5; ++i) {
+            CHECK(strat.get_trade(i).exit_comment == expected_comments[i]);
+            CHECK(near(strat.get_trade(i).qty, 1.0));
+        }
+    }
+}
+
+class XauCloseLedgerCubeStrategy : public BacktestEngine {
+public:
+    std::array<double, 8> visible_after_prior{};
+    int reset_violations = 0;
+
+    XauCloseLedgerCubeStrategy() {
+        visible_after_prior.fill(-1.0);
+        initial_capital_ = 1000000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 50;
+        process_orders_on_close_ = true;
+        close_entries_rule_any_ = false;
+    }
+
+    static std::string bits(int cell) {
+        std::string out;
+        out += ((cell / 4) % 2) ? '1' : '0';
+        out += ((cell / 2) % 2) ? '1' : '0';
+        out += (cell % 2) ? '1' : '0';
+        return out;
+    }
+
+    void close_site(const std::string& id,
+                    const std::string& comment,
+                    uint64_t token) {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        strategy_close(id, comment, na, na, false, token);
+    }
+
+    void on_bar(const Bar&) override {
+        constexpr int kCellBars = 20;
+        const int cell = bar_index_ / kCellBars;
+        const int step = bar_index_ % kCellBars;
+        if (cell < 0 || cell >= 8) return;
+
+        const bool prior_exact_two = ((cell / 4) % 2) == 1;
+        const bool target_survives_role = ((cell / 2) % 2) == 1;
+        const bool later_target_interaction = (cell % 2) == 1;
+        const std::string p = "C_" + bits(cell);
+        const std::string q = p + "_Q";
+        const std::string a = p + "_A";
+        const std::string x = p + "_X";
+        const std::string t = p + "_T";
+        const std::string c = p + "_C";
+        const std::string d = p + "_D";
+        const std::string e = p + "_E";
+        const double na = std::numeric_limits<double>::quiet_NaN();
+
+        if (step == 0) {
+            if (!near(signed_position_size(), 0.0)) ++reset_violations;
+            strategy_entry(q, true, na, na, 20.0, p + "_ENTRY_Q20");
+        } else if (step == 1) {
+            strategy_entry(a, true, na, na, 1.0, p + "_ENTRY_A1");
+        } else if (step == 2) {
+            strategy_entry(x, true, na, na, 1.0, p + "_ENTRY_X1");
+        } else if (step == 3) {
+            strategy_entry(t, true, na, na, 1.0, p + "_ENTRY_T1_0");
+        } else if (step == 4) {
+            strategy_entry(c, true, na, na, 2.0, p + "_ENTRY_C2");
+        } else if (step == 5) {
+            strategy_entry(d, true, na, na, 1.0, p + "_ENTRY_D1");
+        } else if (step == 6) {
+            strategy_entry(e, true, na, na, 1.0, p + "_ENTRY_E1");
+        } else if (step == 7) {
+            close_site(a, p + "_P_A_FIRST", 301);
+            if (!prior_exact_two) close_site(x, p + "_P_X_MIDDLE", 302);
+            close_site(t, p + "_P_T_LAST", 303);
+            visible_after_prior[cell] = signed_position_size();
+        } else if (step == 8) {
+            strategy_entry(t, true, na, na, 1.0, p + "_ENTRY_T1_1");
+        } else if (step == 9) {
+            if (target_survives_role) {
+                close_site(c, p + "_R_C_FIRST", 304);
+                close_site(t, p + "_R_T_LAST", 305);
+            } else {
+                close_site(t, p + "_R_T_FIRST", 306);
+                close_site(c, p + "_R_C_LAST", 307);
+            }
+        } else if (step == 10) {
+            strategy_entry(t, true, na, na, 1.0, p + "_ENTRY_T1_2");
+        } else if (step == 11) {
+            if (later_target_interaction) {
+                close_site(t, p + "_I_T_FIRST", 308);
+            } else {
+                close_site(e, p + "_I_E_FIRST", 309);
+            }
+            close_site(d, p + "_I_D_LAST", 310);
+        } else if (step == 12) {
+            strategy_entry(t, true, na, na, 1.0, p + "_ENTRY_T1_3");
+        } else if (step == 13) {
+            close_site(t, p + "_FINAL_T_SOLE", 311);
+        } else if (step == 15) {
+            strategy_close("", p + "_CLEANUP");
+        } else if (step == 16) {
+            strategy_cancel_all();
+        }
+    }
+};
+
+static void test_xau_close_ledger_cube_matches_authoritative_tv_tape() {
+    std::printf("test_xau_close_ledger_cube_matches_authoritative_tv_tape\n");
+    XauCloseLedgerCubeStrategy strat;
+    std::array<Bar, 160> bars{};
+    for (size_t i = 0; i < bars.size(); ++i) {
+        bars[i] = {100, 101, 99, 100, 50,
+                   static_cast<int64_t>((i + 1) * 900000)};
+    }
+    strat.run(bars.data(), bars.size());
+
+    auto qty_for = [&](const std::string& comment) {
+        double total = 0.0;
+        for (size_t i = 0; i < strat.trade_count(); ++i) {
+            if (strat.get_trade(i).exit_comment == comment) {
+                total += strat.get_trade(i).qty;
+            }
+        }
+        return total;
+    };
+
+    const double tv_final[] = {2, 1, 2, 1, 2, 1, 2, 1};
+    const double tv_cleanup[] = {20, 21, 20, 21, 21, 22, 21, 22};
+    for (int cell = 0; cell < 8; ++cell) {
+        const std::string bits = XauCloseLedgerCubeStrategy::bits(cell);
+        const std::string p = "C_" + bits;
+        const bool prior_exact_two = ((cell / 4) % 2) == 1;
+        const bool target_survives_role = ((cell / 2) % 2) == 1;
+        const bool later_target_interaction = (cell % 2) == 1;
+
+        CHECK(near(strat.visible_after_prior[cell], 27.0));
+        CHECK(near(qty_for(p + "_P_A_FIRST"), 1.0));
+        CHECK(near(qty_for(p + "_P_T_LAST"), 1.0));
+        CHECK(near(qty_for(p + "_P_X_MIDDLE"),
+                   prior_exact_two ? 0.0 : 1.0));
+        CHECK(near(qty_for(p + (target_survives_role
+                                    ? "_R_C_FIRST" : "_R_C_LAST")), 2.0));
+        CHECK(near(qty_for(p + (target_survives_role
+                                    ? "_R_T_LAST" : "_R_T_FIRST")), 1.0));
+        CHECK(near(qty_for(p + (later_target_interaction
+                                    ? "_I_T_FIRST" : "_I_E_FIRST")), 1.0));
+        CHECK(near(qty_for(p + "_I_D_LAST"), 1.0));
+        CHECK(near(qty_for(p + "_FINAL_T_SOLE"), tv_final[cell]));
+        CHECK(near(qty_for(p + "_CLEANUP"), tv_cleanup[cell]));
+    }
+    CHECK(strat.reset_violations == 0);
+}
 
 // ---- 38b. process_orders_on_close: an exit gated on position visibility must
 // NOT fire on the entry bar. TradingView does not expose a just-placed market
@@ -3649,7 +5046,8 @@ static void test_strategy_entry_qty_type_cash_overrides_default_sizing() {
             if (bar_index_ == 0) {
                 strategy_entry("L", true, na<double>(), na<double>(), 1000.0, "", "", 0, 2);
             } else if (bar_index_ == 1 && signed_position_size() > 0.0) {
-                strategy_close("L");
+                strategy_close("L", "", na<double>(), na<double>(), false,
+                               8'002);
             }
         }
     };
@@ -3725,7 +5123,8 @@ static void test_market_close_fills_before_same_bar_opposite_stop_entry() {
                 // market close. TV still closes the existing position at next
                 // bar open before evaluating the opposite stop entry.
                 strategy_entry("S", false, na<double>(), 95.0);
-                strategy_close("L");
+                strategy_close("L", "", na<double>(), na<double>(), false,
+                               8'012);
             }
         }
         double get_signed_position_size() const { return signed_position_size(); }
@@ -4302,6 +5701,9 @@ static void test_strategy_close_immediate_cancels_prior_same_bar_market_reentry(
 
     class Strat : public BacktestEngine {
     public:
+        double visible_after_close = -1.0;
+        bool callsite_queue_empty_after_close = false;
+
         Strat() {
             initial_capital_ = 100000;
             default_qty_type_ = QtyType::FIXED;
@@ -4316,7 +5718,11 @@ static void test_strategy_close_immediate_cancels_prior_same_bar_market_reentry(
                 strategy_entry("L", true);
             } else if (bar_index_ == 1 && signed_position_size() > 0.0) {
                 strategy_entry("L_add", true);
-                strategy_close("L", "", na<double>(), na<double>(), true);
+                strategy_close("L", "", na<double>(), na<double>(), true,
+                               8'013);
+                visible_after_close = signed_position_size();
+                callsite_queue_empty_after_close =
+                    callsite_close_callsites_.empty();
             }
         }
         double get_signed_position_size() const { return signed_position_size(); }
@@ -4332,6 +5738,8 @@ static void test_strategy_close_immediate_cancels_prior_same_bar_market_reentry(
 
     CHECK(strat.trade_count() == 1);
     CHECK(near(strat.get_signed_position_size(), 0.0, 1e-9));
+    CHECK(near(strat.visible_after_close, 0.0, 1e-9));
+    CHECK(strat.callsite_queue_empty_after_close);
 }
 
 static void test_strategy_close_pooc_keeps_same_bar_pending_entry() {
@@ -4352,7 +5760,8 @@ static void test_strategy_close_pooc_keeps_same_bar_pending_entry() {
                 strategy_entry("L0", true);
             } else if (bar_index_ == 1 && signed_position_size() > 0.0) {
                 strategy_entry("L1", true, std::numeric_limits<double>::quiet_NaN(), 110.0);
-                strategy_close("L0");
+                strategy_close("L0", "", na<double>(), na<double>(), false,
+                               8'003);
             }
         }
         double get_signed_position_size() const { return signed_position_size(); }
@@ -4385,7 +5794,6 @@ static void test_strategy_close_pooc_partial_close_keeps_other_exit_bracket() {
             commission_value_ = 0.0;
             slippage_ = 0;
             process_orders_on_close_ = true;
-            close_entries_rule_any_ = true;
             pyramiding_ = 2;
         }
         void on_bar(const Bar& bar) override {
@@ -4395,7 +5803,8 @@ static void test_strategy_close_pooc_partial_close_keeps_other_exit_bracket() {
                 strategy_entry("B", true);
                 strategy_exit("XB", "B", 115.0, std::numeric_limits<double>::quiet_NaN());
             } else if (bar_index_ == 2 && signed_position_size() > 0.0) {
-                strategy_close("A");
+                strategy_close("A", "", na<double>(), na<double>(), false,
+                               8'004);
             }
         }
         double get_signed_position_size() const { return signed_position_size(); }
@@ -4621,9 +6030,11 @@ static void test_strategy_close_qty_percent_reduces_position() {
             if (bar_index_ == 0) {
                 strategy_entry("L", true);
             } else if (bar_index_ == 1 && signed_position_size() > 0.0) {
-                strategy_close("L", "half", na<double>(), 50.0, false);
+                strategy_close("L", "half", na<double>(), 50.0, false,
+                               8'005);
             } else if (bar_index_ == 2 && signed_position_size() > 0.0) {
-                strategy_close("L", "rest", na<double>(), na<double>(), false);
+                strategy_close("L", "rest", na<double>(), na<double>(),
+                               false, 8'006);
             }
         }
         double get_signed_position_size() const { return signed_position_size(); }
@@ -4663,7 +6074,8 @@ static void test_strategy_close_qty_reduces_position() {
             if (bar_index_ == 0) {
                 strategy_entry("L", true);
             } else if (bar_index_ == 1 && signed_position_size() > 0.0) {
-                strategy_close("L", "three", 3.0, na<double>(), false);
+                strategy_close("L", "three", 3.0, na<double>(), false,
+                               8'007);
             }
         }
         double get_signed_position_size() const { return signed_position_size(); }
@@ -4700,7 +6112,8 @@ static void test_strategy_close_immediately_fills_current_close() {
             if (bar_index_ == 0) {
                 strategy_entry("L", true);
             } else if (bar_index_ == 1 && signed_position_size() > 0.0) {
-                strategy_close("L", "now", na<double>(), na<double>(), true);
+                strategy_close("L", "now", na<double>(), na<double>(), true,
+                               8'008);
             }
         }
     };
@@ -4853,6 +6266,23 @@ int main() {
     test_three_call_current_batch_invalidates_two_call_carry();
     test_zero_backed_close_reservation_clears_stale_cycle();
     test_positive_truncated_close_reservation_keeps_ledger_only();
+    test_same_bar_multi_close_queues_all_in_source_order();
+    test_overlapping_id_callsites_reserve_before_replacement();
+    test_distinct_sites_same_id_share_physical_capacity();
+    test_same_callsite_loop_close_replaces_in_place();
+    test_callsite_replacement_separates_live_claim_from_entry_debt();
+    test_single_site_replacement_reuses_own_live_claim();
+    test_rejected_replacement_has_no_debt_or_order_side_effects();
+    test_owner_reservation_survives_other_token_cleanup_permutations();
+    test_cross_owner_post_fill_backing_is_physically_bounded();
+    test_cross_bar_different_id_claims_cap_fresh_site();
+    test_same_id_owner_claims_share_physical_backing();
+    test_post_fill_backing_excludes_all_same_id_aliases();
+    test_local_alias_release_frees_only_marginal_backing();
+    test_interleaved_callsite_replacement_preserves_queue_position();
+    test_exported_callsite_interleaving_tv_oracle();
+    test_exported_shared_inner_udf_tv_oracle();
+    test_xau_close_ledger_cube_matches_authoritative_tv_tape();
     test_pooc_exit_not_triggered_on_entry_bar();
     test_commission_deducted();
     test_slippage_applied();


### PR DESCRIPTION
## What changed

- add a stable six-argument strategy.close runtime path keyed by compiler callsite token
- preserve the five-argument compatibility path as token zero and leave the public C ABI unchanged
- queue distinct syntactic close sites in first-admission source order while repeated evaluations of one site replace in place
- keep per-site reservation and provenance state isolated across bars and reset it across engine lifecycles
- cover all existing bypass paths including ANY, explicit qty and percent, immediate, non-POOC, intrabar COOF, and consumed-C COOF

## Evidence

- native TradingView ledgers: XAU close-ledger cube, A-B-A interleaving, and shared-inner-UDF replacement
- exhaustive 2^2 interaction matrix: 4 of 4 cells passed with no early stop; all-off reproduced the defect and all-on matched every native ledger
- supplemental UI-observed overlap probe also matched; it is not presented as a native CSV export
- fresh Release CTest: 114 of 114 passed
- targeted integration: 1173 passed, 0 failed
- calc-on-order-fills: 281 checks passed
- corpus: 252 of 252, with 247 Excellent, 4 Strong, and 1 known anomaly
- full validation board: 416 of 416 completed, 355 Excellent, 46 Strong, 4 Moderate, 2 Weak, 0 downgrades
- six production-strategy tape and mismatch-set digests were byte-identical across all matrix cells; XAU remained Strong, so this runtime correctness milestone is intentionally tier-neutral

## Scope boundary

The cross-owner same-ID persistent backing model is regression-covered and preserves the established physical-capacity rule, but this PR does not claim a new native TradingView tape for that separate cross-bar edge.

## Landing order

Merge this engine overload first. The dependent codegen PR will emit nonzero source-location tokens only after this PR is green and merged.