### PR TITLE
Keep matrix snapshot assertions active in Release

### DIFF
--- a/tests/test_matrix_snapshot_compat.cpp
+++ b/tests/test_matrix_snapshot_compat.cpp
@@ -1,6 +1,11 @@
 #include <pineforge/generic_matrix.hpp>
 #include <pineforge/matrix.hpp>
 
+// Keep this executable's assertions active in Release builds so the
+// compatibility gate cannot become vacuous under -DNDEBUG.
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
 #include <cassert>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
## What changed

Re-enable `assert()` in `test_matrix_snapshot_compat` even when the Release toolchain defines `NDEBUG`.

## Why

Copilot correctly noted on #128 that the new compatibility test's assertions became vacuous in Release builds. Debug CI exercised the assertions, so this does not change production behavior; this follow-up makes both Debug and Release gates meaningful.

## Validation

- Release build of `test_matrix_snapshot_compat`: **PASS**
- Release CTest for the target: **1/1 passed**
- Preprocessor check with explicit `-DNDEBUG`: `NDEBUG` is absent after processing the test translation unit
