### PR TITLE
fix(engine): emit TV same-bar close+reverse sequencing under frozen default sizing

### DIFF
--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -1870,8 +1870,22 @@ void BacktestEngine::sort_orders_by_fill_phase(const Bar& bar) {
     //
     // Do not reorder it. Tag only the exact authoritative three-object book so
     // the close kernel can materialize TV's second LONG lot and the final Short
-    // kernel can close both LONG lots to flat. The long-seed mirror is
-    // deliberately unproven and remains ordinary.
+    // kernel can close both LONG lots. The long-seed mirror is deliberately
+    // unproven and remains ordinary.
+    //
+    // Two independently pinned sizing regimes share this book:
+    //   - FIXED default sizing (the cntvxiao six-strategy cohort): seed qty
+    //     S == default qty L, both zero trades are qty S, and the final Short
+    //     ends flat.
+    //   - PERCENT_OF_EQUITY / CASH default sizing (finding 272, 25/25 exact
+    //     on the alpha-forge-liquidity-matrix-v2 tape): the entries carry
+    //     their placement-frozen default qty L which need not equal the seed
+    //     S. TV materializes the close's frozen target CAPPED at the live
+    //     long, min(S, L), and the final Short closes both LONG lots then
+    //     re-opens SHORT with exactly the unconsumed surplus max(0, L - S)
+    //     (flat when L <= S). There is no constant to pin the seed qty
+    //     against — it varies with equity — so the FIXED seed-equality gate
+    //     is replaced by the frozen-snapshot shape checks below.
     if (!close_entries_rule_any_
         && !process_orders_on_close_
         && !calc_on_order_fills_
@@ -1886,7 +1900,9 @@ void BacktestEngine::sort_orders_by_fill_phase(const Bar& bar) {
         && risk_max_position_size_ <= 0.0
         && max_intraday_filled_orders_ <= 0
         && !risk_halted_
-        && default_qty_type_ == QtyType::FIXED
+        && (default_qty_type_ == QtyType::FIXED
+            || default_qty_type_ == QtyType::PERCENT_OF_EQUITY
+            || default_qty_type_ == QtyType::CASH)
         && pyramiding_ == 1
         && pending_orders_.size() == 3
         && position_side_ == PositionSide::SHORT
@@ -1916,11 +1932,30 @@ void BacktestEngine::sort_orders_by_fill_phase(const Bar& bar) {
                 && order.oca_name.empty()
                 && order.oca_type == 0;
         };
+        const bool fixed_default_sizing =
+            default_qty_type_ == QtyType::FIXED;
         const auto pure_default_market_entry = [&](const PendingOrder& order) {
+            // FIXED default sizing keeps qty NaN end to end (no freeze).
+            // PERCENT_OF_EQUITY / CASH default sizing must carry the complete
+            // placement-frozen snapshot the fill-time consumers (dispatch qty,
+            // KI-54 / KI-72 admission) will read; a partial snapshot means
+            // some other placement path built this order — stay ordinary.
+            const bool default_sizing_shape = fixed_default_sizing
+                ? std::isnan(order.frozen_default_qty)
+                : (std::isfinite(order.frozen_default_qty)
+                   && order.frozen_default_qty > kQtyEpsilon
+                   && std::isfinite(order.sizing_equity)
+                   && order.sizing_equity > 0.0
+                   && std::isfinite(order.sizing_price)
+                   && order.sizing_price > 0.0
+                   && std::isfinite(order.sizing_mark)
+                   && order.sizing_mark > 0.0
+                   && std::isfinite(order.sizing_fx)
+                   && order.sizing_fx > 0.0);
             return order.type == OrderType::MARKET
                 && std::isnan(order.qty)
                 && order.qty_type == -1
-                && std::isnan(order.frozen_default_qty)
+                && default_sizing_shape
                 && std::isnan(order.limit_price)
                 && std::isnan(order.stop_price)
                 && std::isnan(order.trail_points)
@@ -1974,12 +2009,28 @@ void BacktestEngine::sort_orders_by_fill_phase(const Bar& bar) {
             }
             const double admit_price =
                 apply_fill_slippage(bar.open, /*is_buy=*/false);
-            const double final_short_qty = std::abs(calc_qty_for_type(
-                admit_price, source[1]->qty, source[1]->qty_type));
+            // The quantity each entry will actually dispatch at its fill:
+            // FIXED re-derives from the default at the admit price; frozen
+            // PERCENT/CASH orders carry their placement-frozen qty (L).
+            const double entry_qty = fixed_default_sizing
+                ? std::abs(calc_qty_for_type(
+                      admit_price, source[0]->qty, source[0]->qty_type))
+                : source[0]->frozen_default_qty;
+            const double final_short_qty = fixed_default_sizing
+                ? std::abs(calc_qty_for_type(
+                      admit_price, source[1]->qty, source[1]->qty_type))
+                : source[1]->frozen_default_qty;
             const double marked_equity = current_equity() + open_profit(bar.open);
             const double fx = active_account_currency_fx();
             const double notional_k = syminfo_.pointvalue * fx;
-            const double projected_long_qty = 2.0 * seed.qty;
+            // Projected long book after the entry (L) and the capped
+            // materialized lot (min(S, L)); the final-short transaction
+            // closes both lots and re-opens the surplus, so its admission
+            // sees projected_long + its own default qty. For the FIXED
+            // cohort (L pinned == S below) this collapses to the original
+            // 2*seed.qty forms exactly.
+            const double projected_long_qty =
+                entry_qty + std::min(seed.qty, entry_qty);
             const double projected_held_margin =
                 projected_long_qty * bar.open * notional_k;
             const double projected_free_funds =
@@ -1990,7 +2041,10 @@ void BacktestEngine::sort_orders_by_fill_phase(const Bar& bar) {
                 projected_transaction_qty * admit_price * notional_k;
             const double epsilon =
                 std::max(1e-9, std::abs(marked_equity) * 1e-12);
-            return std::isfinite(admit_price) && admit_price > 0.0
+            const bool projected_safe =
+                std::isfinite(admit_price) && admit_price > 0.0
+                && std::isfinite(entry_qty)
+                && entry_qty > kQtyEpsilon
                 && std::isfinite(final_short_qty)
                 && final_short_qty > kQtyEpsilon
                 && std::isfinite(marked_equity)
@@ -1999,6 +2053,38 @@ void BacktestEngine::sort_orders_by_fill_phase(const Bar& bar) {
                 && std::isfinite(projected_required_margin)
                 && projected_required_margin
                     <= projected_free_funds + epsilon;
+            if (!projected_safe) {
+                return false;
+            }
+            // PERCENT default sizing (pct <= 100) additionally faces the
+            // KI-54 frozen reversal re-check at BOTH reversal fills: the
+            // opposite entry reversing the seed short, then the final short
+            // reversing the projected long. Mirror that gate exactly, WITHOUT
+            // its fill-time epsilon, so a tagged book can never be
+            // half-declined mid-transaction (the middle leg would have
+            // created synthetic exposure with no rollback). CASH and
+            // pct > 100 books are admitted unconditionally by that gate and
+            // need no mirror.
+            if (default_qty_type_ == QtyType::PERCENT_OF_EQUITY
+                && default_qty_value_ <= 100.0) {
+                for (const PendingOrder* entry : {source[0], source[1]}) {
+                    const double leg_admit_price =
+                        apply_fill_slippage(bar.open, entry->is_long);
+                    const double leg_fx =
+                        std::isfinite(entry->sizing_fx) && entry->sizing_fx > 0.0
+                            ? entry->sizing_fx
+                            : fx;
+                    const double leg_required = entry->frozen_default_qty
+                        * leg_admit_price * syminfo_.pointvalue * leg_fx;
+                    if (!(std::isfinite(leg_admit_price)
+                          && leg_admit_price > 0.0
+                          && std::isfinite(leg_required)
+                          && leg_required <= entry->sizing_equity)) {
+                        return false;
+                    }
+                }
+            }
+            return true;
         };
         const bool exact_book =
             source_bar >= 0
@@ -2034,8 +2120,17 @@ void BacktestEngine::sort_orders_by_fill_phase(const Bar& bar) {
             && seed.entry_id == source[1]->id
             && seed.entry_bar_index < bar_index_
             && seed.qty > kQtyEpsilon
-            && std::isfinite(default_qty)
-            && std::abs(default_qty - seed.qty) <= kQtyEpsilon
+            // FIXED default sizing pins the seed against the constant default
+            // (the authoritative cohort's L == S regime). Frozen PERCENT/CASH
+            // sizing has no constant to pin — the seed was sized on an earlier
+            // bar's equity — so instead require the two entries to carry the
+            // SAME placement-frozen default qty (one L; both froze on this
+            // signal bar's close with zero slippage).
+            && (fixed_default_sizing
+                ? (std::isfinite(default_qty)
+                   && std::abs(default_qty - seed.qty) <= kQtyEpsilon)
+                : std::abs(source[0]->frozen_default_qty
+                           - source[1]->frozen_default_qty) <= kQtyEpsilon)
             && std::abs(position_qty_ - seed.qty) <= kQtyEpsilon
             && std::abs(source[2]->tv_carry_qty - seed.qty) <= kQtyEpsilon
             && std::abs(
@@ -2270,12 +2365,18 @@ bool BacktestEngine::short_seed_collision_materialization_is_live(
     }
 
     const PyramidEntry& long_lot = pyramid_entries_.front();
-    const double qty = order.suppressed_close_consumed_ledger_qty;
+    // The close order's placement-frozen target is the seed qty S; the lot the
+    // opposite entry just opened is the default qty L. TV materializes the
+    // frozen target CAPPED at the live position: min(S, L) (finding 272,
+    // 25/25). Under the FIXED cohort's pinned L == S this is exactly the old
+    // strict equality; the live-position invariant is that the fresh long book
+    // is the single entry lot.
+    const double frozen_target = order.suppressed_close_consumed_ledger_qty;
     return long_lot.entry_id == long_entry->id
         && long_lot.entry_bar_index == bar_index_
         && long_lot.qty > kQtyEpsilon
-        && std::abs(long_lot.qty - qty) <= kQtyEpsilon
-        && std::abs(position_qty_ - qty) <= kQtyEpsilon;
+        && frozen_target > kQtyEpsilon
+        && std::abs(position_qty_ - long_lot.qty) <= kQtyEpsilon;
 }
 
 bool BacktestEngine::short_seed_collision_final_short_is_live(
@@ -2324,14 +2425,24 @@ bool BacktestEngine::short_seed_collision_final_short_is_live(
 
     const PyramidEntry& source_long = pyramid_entries_[0];
     const PyramidEntry& close_short_long = pyramid_entries_[1];
-    const double qty = order.tv_carry_qty;
+    // order.tv_carry_qty is the seed short S (snapshotted at placement); the
+    // entry lot is the default qty L. The materialized second lot must be the
+    // close's frozen target capped at the entry lot, min(S, L) — the FIXED
+    // cohort's L == S makes this the old strict double equality, while the
+    // frozen PERCENT/CASH regime (finding 272) leaves a residual max(0, L - S)
+    // for the fill kernel to re-open SHORT.
+    const double seed_qty = order.tv_carry_qty;
+    const double expected_materialized =
+        std::min(seed_qty, source_long.qty);
     return source_long.entry_id == long_entry->id
         && close_short_long.entry_id == materialize_long->id
         && source_long.entry_bar_index == bar_index_
         && close_short_long.entry_bar_index == bar_index_
-        && std::abs(source_long.qty - qty) <= kQtyEpsilon
-        && std::abs(close_short_long.qty - qty) <= kQtyEpsilon
-        && std::abs(position_qty_ - 2.0 * qty) <= kQtyEpsilon
+        && source_long.qty > kQtyEpsilon
+        && std::abs(close_short_long.qty - expected_materialized)
+            <= kQtyEpsilon
+        && std::abs(position_qty_ - (source_long.qty + close_short_long.qty))
+            <= kQtyEpsilon
         && std::abs(source_long.price - close_short_long.price)
             <= std::max(1e-12, std::abs(source_long.price) * 1e-12);
 }
@@ -3884,12 +3995,40 @@ void BacktestEngine::apply_market_order_fill(PendingOrder& order, double fill_pr
                                              double& trail_best_path_state,
                                              bool later_same_tick_entry) {
     // The final Short in the exact SHORT-seed collision is the broker
-    // transaction that closes both physical LONG lots. It does not open a
-    // residual short. Re-prove the complete two-lot state here so any rejected,
+    // transaction that closes both physical LONG lots (the entry lot L and
+    // the materialized min(S, L) lot) and re-opens the direction with exactly
+    // the unconsumed surplus max(0, L - S) — TV holds that remnant SHORT under
+    // the final short's id through the gap (finding 272: 14/14 remnant
+    // episodes qty L - S exact, 11/11 flat when L <= S; the FIXED cohort's
+    // pinned L == S always ends flat, byte-identical to the pre-remnant
+    // kernel). Re-prove the complete two-lot state here so any rejected,
     // partial, or otherwise interrupted predecessor falls back to the ordinary
     // strategy.entry kernel.
     if (short_seed_collision_final_short_is_live(order)) {
+        const double residual =
+            pyramid_entries_[0].qty - pyramid_entries_[1].qty;
         execute_market_exit(fill_price);
+        if (residual > kQtyEpsilon) {
+            // Slippage is gated to 0 by the exact-book tagging, so the
+            // remnant re-opens at the same broker point the exit filled at.
+            open_fresh_position(
+                order.is_long ? PositionSide::LONG : PositionSide::SHORT,
+                fill_price, residual, order.id, order.incarnation);
+            pyramid_entries_.back().entry_comment = order.comment;
+            // Mirror the ordinary market-entry kernel's trail handling: the
+            // path state keeps the at-fill value, then the bar's remaining
+            // extreme folds into trail_best_price_ for same-bar exit
+            // evaluation (POOC same-bar close fills are excluded by the
+            // exact-book gate).
+            const double trail_best_after_fill = trail_best_price_;
+            if (position_side_ == PositionSide::LONG) {
+                trail_best_price_ = std::max(trail_best_price_, bar.high);
+            } else if (position_side_ == PositionSide::SHORT) {
+                trail_best_price_ = std::min(trail_best_price_, bar.low);
+            }
+            trail_best_path_state = trail_best_after_fill;
+            return;
+        }
         trail_best_path_state = trail_best_price_;
         return;
     }
@@ -4116,7 +4255,12 @@ void BacktestEngine::apply_exit_order_fill(PendingOrder& order, double fill_pric
     // lot. It is not an exit from the freshly opened Long. This bypasses the
     // pyramiding cap only for the pre-tagged, re-proven transaction.
     if (short_seed_collision_materialization_is_live(order)) {
-        const double qty = order.suppressed_close_consumed_ledger_qty;
+        // The close order fills against the same-tick re-opened same-id
+        // position at its placement-frozen target S, capped by the live long
+        // book L (finding 272: zero#2 qty == min(S, L) exact, 25/25). The
+        // FIXED cohort's pinned L == S keeps the historical full-target qty.
+        const double qty = std::min(order.suppressed_close_consumed_ledger_qty,
+                                    pyramid_entries_.front().qty);
         const double entry_fill = apply_fill_slippage(fill_price, /*is_buy=*/true);
         if (!std::isfinite(entry_fill) || qty <= kQtyEpsilon) return;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -116,6 +116,7 @@ set(TEST_SOURCES
     test_prearmed_market_parent_gap_exit
     test_relative_exit_after_limit_parent
     test_short_seed_close_collision
+    test_short_seed_collision_percent
 )
 
 find_package(Threads REQUIRED)

--- a/tests/test_short_seed_collision_percent.cpp
+++ b/tests/test_short_seed_collision_percent.cpp
@@ -1,0 +1,438 @@
+/*
+ * Regression coverage for the SHORT-seed default-FIFO close collision under
+ * frozen PERCENT_OF_EQUITY / CASH default sizing (finding 272).
+ *
+ * TV rule (25/25 exact on the alpha-forge-liquidity-matrix-v2 tape): with a
+ * SHORT seed of qty S entered on an earlier bar and the exact same-bar book
+ *   entry(Long); entry(Short); close(Long)[no-op]; close(Short)[frozen S]
+ * all filling at the next open P, TV emits: (1) the old short S exits via
+ * order 'Long'; (2) a zero-PnL dur-0 LONG round trip qty L (the frozen
+ * default qty), 'Long' -> 'Short'; (3) a second zero-PnL dur-0 LONG round
+ * trip qty min(S, L), '__close__Short' -> 'Short'; (4) the end-of-bar
+ * position is SHORT max(0, L - S) under id 'Short' (flat when L <= S), and
+ * the real opposite entry is NOT queued — the strategy resumes ordinary
+ * signal processing from that position.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+
+#include <pineforge/bar.hpp>
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define CHECK(cond)                                                             \
+    do {                                                                        \
+        if (!(cond)) {                                                          \
+            std::fprintf(stderr, "FAIL %s:%d %s\n", __FILE__, __LINE__, #cond); \
+            ++g_fail;                                                           \
+        } else {                                                                \
+            ++g_pass;                                                           \
+        }                                                                       \
+    } while (0)
+
+namespace {
+
+constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+Bar make_bar(double open, double high, double low, double close,
+             int64_t timestamp) {
+    return {open, high, low, close, 1'000.0, timestamp};
+}
+
+// Percent-of-equity remnant case (L > S): the seed short profits before the
+// collision bar, so the frozen default qty L exceeds the seed S and the final
+// Short must re-open exactly the surplus L - S. A later strategy.close on the
+// remnant proves the ledger / id / incarnation provenance of the re-opened
+// lot.
+class PercentRemnantProbe final : public BacktestEngine {
+public:
+    PercentRemnantProbe() {
+        initial_capital_ = 1'000'000.0;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 10.0;
+        pyramiding_ = 1;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+    }
+
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry("Short", false);
+        } else if (bar_index_ == 1) {
+            CHECK(position_side_ == PositionSide::SHORT);
+            CHECK(pyramid_entries_.size() == 1);
+            strategy_entry("Long", true);
+            strategy_entry("Short", false);
+            strategy_close("Long");  // no live default-FIFO ledger -> no-op
+            strategy_close("Short");
+        } else if (bar_index_ == 2) {
+            // The deferred real short is NOT a queued order: the episode
+            // consumed the whole book and left the remnant as an ordinary
+            // open position.
+            pending_after_collision_ = pending_orders_.size();
+            side_after_collision_ = position_side_;
+            qty_after_collision_ = signed_position_size();
+            remnant_entry_id_ = pyramid_entries_.size() == 1
+                ? pyramid_entries_[0].entry_id
+                : std::string();
+            strategy_close("Short");
+        }
+    }
+
+    std::size_t pending_after_collision_ = 999;
+    PositionSide side_after_collision_ = PositionSide::FLAT;
+    double qty_after_collision_ = kNaN;
+    std::string remnant_entry_id_;
+    PositionSide final_side() const { return position_side_; }
+};
+
+void run_percent_remnant_case() {
+    PercentRemnantProbe probe;
+    Bar bars[] = {
+        make_bar(100.0, 100.0, 100.0, 100.0, 600'000),
+        make_bar(100.0, 100.5, 89.5, 90.0, 1'200'000),
+        make_bar(90.0, 90.5, 89.5, 90.0, 1'800'000),
+        make_bar(90.0, 90.5, 89.5, 90.0, 2'400'000),
+        make_bar(90.0, 90.0, 90.0, 90.0, 3'000'000),
+    };
+    probe.run(bars, 5);
+
+    // Frozen sizing, mirrored with the engine's operation order:
+    // S at bar0 close (flat): (1e6 * 10%) / 100 = 1000 exactly.
+    // L at bar1 close: equity = 1e6 + 1000*(100-90) = 1'010'000,
+    // L = (1'010'000 * 10%) / 90.
+    const double kSeedQty = 1'000.0;
+    const double kL = (1'010'000.0 * (10.0 / 100.0)) / 90.0;
+    const double kResidual = kL - kSeedQty;
+    CHECK(kL > kSeedQty);  // test-shape sanity
+
+    // Same-bar outcome: SHORT remnant of exactly L - S, no pending orders.
+    CHECK(probe.pending_after_collision_ == 0);
+    CHECK(probe.side_after_collision_ == PositionSide::SHORT);
+    CHECK(std::fabs(probe.qty_after_collision_ + kResidual) < 1e-6);
+    CHECK(probe.remnant_entry_id_ == "Short");
+    CHECK(probe.final_side() == PositionSide::FLAT);
+
+    CHECK(probe.trade_count() == 4);
+    if (probe.trade_count() == 4) {
+        const Trade& seed = probe.get_trade(0);
+        const Trade& zero1 = probe.get_trade(1);
+        const Trade& zero2 = probe.get_trade(2);
+        const Trade& remnant = probe.get_trade(3);
+
+        // (1) Old short S exits at P via order 'Long'.
+        CHECK(!seed.is_long);
+        CHECK(seed.entry_id == "Short");
+        CHECK(seed.exit_id == "Long");
+        CHECK(seed.entry_time == 1'200'000);
+        CHECK(seed.exit_time == 1'800'000);
+        CHECK(std::fabs(seed.qty - kSeedQty) < 1e-6);
+        CHECK(std::fabs(seed.entry_price - 100.0) < 1e-9);
+        CHECK(std::fabs(seed.exit_price - 90.0) < 1e-9);
+        CHECK(std::fabs(seed.pnl - 10'000.0) < 1e-6);
+
+        // (2) Zero-PnL dur-0 LONG round trip qty L, 'Long' -> 'Short'.
+        CHECK(zero1.is_long);
+        CHECK(zero1.entry_id == "Long");
+        CHECK(zero1.exit_id == "Short");
+        CHECK(zero1.entry_time == 1'800'000);
+        CHECK(zero1.exit_time == 1'800'000);
+        CHECK(zero1.entry_bar_index == zero1.exit_bar_index);
+        CHECK(std::fabs(zero1.qty - kL) < 1e-6);
+        CHECK(std::fabs(zero1.entry_price - 90.0) < 1e-9);
+        CHECK(std::fabs(zero1.exit_price - 90.0) < 1e-9);
+        CHECK(std::fabs(zero1.pnl) < 1e-9);
+
+        // (3) Second zero-PnL dur-0 LONG round trip qty min(S, L),
+        //     '__close__Short' -> 'Short'.
+        CHECK(zero2.is_long);
+        CHECK(zero2.entry_id == "__close__Short");
+        CHECK(zero2.exit_id == "Short");
+        CHECK(zero2.entry_time == 1'800'000);
+        CHECK(zero2.exit_time == 1'800'000);
+        CHECK(std::fabs(zero2.qty - kSeedQty) < 1e-6);  // min(S, L) == S here
+        CHECK(std::fabs(zero2.pnl) < 1e-9);
+
+        // (4) The remnant lot carries the final Short's id/incarnation and
+        //     entered at the collision fill; the later close resolves it via
+        //     the ordinary ledger.
+        CHECK(!remnant.is_long);
+        CHECK(remnant.entry_id == "Short");
+        CHECK(remnant.exit_id == "__close__Short");
+        CHECK(remnant.entry_time == 1'800'000);
+        CHECK(remnant.exit_time == 2'400'000);
+        CHECK(std::fabs(remnant.qty - kResidual) < 1e-6);
+        CHECK(std::fabs(remnant.entry_price - 90.0) < 1e-9);
+        CHECK(std::fabs(remnant.pnl) < 1e-9);
+
+        // Physical provenance: the three collision objects carry consecutive
+        // incarnations Long -> Short -> __close__Short; the remnant lot is
+        // the final Short order's own incarnation.
+        CHECK(zero1.entry_incarnation != 0);
+        CHECK(remnant.entry_incarnation == zero1.entry_incarnation + 1);
+        CHECK(zero2.entry_incarnation == zero1.entry_incarnation + 2);
+    }
+}
+
+// Percent-of-equity flat case (L <= S): the seed short is underwater on the
+// collision bar, the frozen default qty L is below the seed S, the second
+// zero trade is min(S, L) == L, and the episode ends FLAT with no same-bar
+// short.
+class PercentFlatProbe final : public BacktestEngine {
+public:
+    PercentFlatProbe() {
+        initial_capital_ = 1'000'000.0;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 10.0;
+        pyramiding_ = 1;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+    }
+
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry("Short", false);
+        } else if (bar_index_ == 1) {
+            strategy_entry("Long", true);
+            strategy_entry("Short", false);
+            strategy_close("Long");
+            strategy_close("Short");
+        } else if (bar_index_ == 2) {
+            pending_after_collision_ = pending_orders_.size();
+            side_after_collision_ = position_side_;
+        }
+    }
+
+    std::size_t pending_after_collision_ = 999;
+    PositionSide side_after_collision_ = PositionSide::SHORT;
+    PositionSide final_side() const { return position_side_; }
+};
+
+void run_percent_flat_case() {
+    PercentFlatProbe probe;
+    Bar bars[] = {
+        make_bar(100.0, 100.0, 100.0, 100.0, 600'000),
+        make_bar(100.0, 110.5, 99.5, 110.0, 1'200'000),
+        make_bar(110.0, 110.5, 109.5, 110.0, 1'800'000),
+        make_bar(110.0, 110.0, 110.0, 110.0, 2'400'000),
+    };
+    probe.run(bars, 4);
+
+    // S = 1000; equity at bar1 close = 1e6 + 1000*(100-110) = 990'000;
+    // L = (990'000 * 10%) / 110 = 900 exactly. L < S -> flat episode.
+    const double kSeedQty = 1'000.0;
+    const double kL = (990'000.0 * (10.0 / 100.0)) / 110.0;
+    CHECK(kL < kSeedQty);  // test-shape sanity
+
+    CHECK(probe.pending_after_collision_ == 0);
+    CHECK(probe.side_after_collision_ == PositionSide::FLAT);
+    CHECK(probe.final_side() == PositionSide::FLAT);
+    CHECK(probe.trade_count() == 3);
+    if (probe.trade_count() == 3) {
+        const Trade& seed = probe.get_trade(0);
+        const Trade& zero1 = probe.get_trade(1);
+        const Trade& zero2 = probe.get_trade(2);
+        CHECK(!seed.is_long);
+        CHECK(seed.entry_id == "Short");
+        CHECK(seed.exit_id == "Long");
+        CHECK(std::fabs(seed.qty - kSeedQty) < 1e-6);
+        CHECK(std::fabs(seed.pnl + 10'000.0) < 1e-6);
+        CHECK(zero1.is_long);
+        CHECK(zero1.entry_id == "Long");
+        CHECK(zero1.exit_id == "Short");
+        CHECK(std::fabs(zero1.qty - kL) < 1e-6);
+        CHECK(std::fabs(zero1.pnl) < 1e-9);
+        CHECK(zero2.is_long);
+        CHECK(zero2.entry_id == "__close__Short");
+        CHECK(zero2.exit_id == "Short");
+        // min(S, L) == L in the flat regime.
+        CHECK(std::fabs(zero2.qty - kL) < 1e-6);
+        CHECK(std::fabs(zero2.pnl) < 1e-9);
+    }
+}
+
+// CASH default sizing follows the same frozen-snapshot collision shape.
+class CashRemnantProbe final : public BacktestEngine {
+public:
+    CashRemnantProbe() {
+        initial_capital_ = 1'000'000.0;
+        default_qty_type_ = QtyType::CASH;
+        default_qty_value_ = 100'000.0;
+        pyramiding_ = 1;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+    }
+
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry("Short", false);
+        } else if (bar_index_ == 1) {
+            strategy_entry("Long", true);
+            strategy_entry("Short", false);
+            strategy_close("Long");
+            strategy_close("Short");
+        }
+    }
+
+    PositionSide final_side() const { return position_side_; }
+    double final_qty() const { return signed_position_size(); }
+};
+
+void run_cash_remnant_case() {
+    CashRemnantProbe probe;
+    Bar bars[] = {
+        make_bar(100.0, 100.0, 100.0, 100.0, 600'000),
+        make_bar(100.0, 100.5, 89.5, 90.0, 1'200'000),
+        make_bar(90.0, 90.5, 89.5, 90.0, 1'800'000),
+        make_bar(90.0, 90.0, 90.0, 90.0, 2'400'000),
+    };
+    probe.run(bars, 4);
+
+    // S = 100'000/100 = 1000; L = 100'000/90; residual = L - S.
+    const double kSeedQty = 1'000.0;
+    const double kL = 100'000.0 / 90.0;
+    CHECK(probe.final_side() == PositionSide::SHORT);
+    CHECK(std::fabs(probe.final_qty() + (kL - kSeedQty)) < 1e-6);
+    CHECK(probe.trade_count() == 3);
+    if (probe.trade_count() == 3) {
+        CHECK(probe.get_trade(1).is_long);
+        CHECK(probe.get_trade(1).entry_id == "Long");
+        CHECK(std::fabs(probe.get_trade(1).qty - kL) < 1e-6);
+        CHECK(std::fabs(probe.get_trade(1).pnl) < 1e-9);
+        CHECK(probe.get_trade(2).is_long);
+        CHECK(probe.get_trade(2).entry_id == "__close__Short");
+        CHECK(std::fabs(probe.get_trade(2).qty - kSeedQty) < 1e-6);
+        CHECK(std::fabs(probe.get_trade(2).pnl) < 1e-9);
+    }
+}
+
+// Non-trigger control: an all-in (100%) book whose reversal legs face a
+// gap-up decline must NOT be tagged — the projection mirrors the KI-54
+// frozen reversal re-check, and the ordinary path's atomic decline
+// (entry declined, co-queued close suppressed, same-direction re-add
+// declined) is preserved byte-for-byte.
+class PercentGapDeclineControl final : public BacktestEngine {
+public:
+    PercentGapDeclineControl() {
+        initial_capital_ = 1'000'000.0;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100.0;
+        pyramiding_ = 1;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        margin_call_enabled_ = false;
+    }
+
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry("Short", false);
+        } else if (bar_index_ == 1) {
+            strategy_entry("Long", true);
+            strategy_entry("Short", false);
+            strategy_close("Long");
+            strategy_close("Short");
+        } else if (bar_index_ == 2) {
+            pending_after_collision_ = pending_orders_.size();
+        }
+    }
+
+    std::size_t pending_after_collision_ = 999;
+    PositionSide final_side() const { return position_side_; }
+    double final_qty() const { return signed_position_size(); }
+    bool has_materialized_close_trade() const {
+        for (int i = 0; i < trade_count(); ++i) {
+            if (get_trade(i).entry_id == "__close__Short") return true;
+        }
+        return false;
+    }
+};
+
+void run_percent_gap_decline_control() {
+    PercentGapDeclineControl probe;
+    Bar bars[] = {
+        make_bar(100.0, 100.0, 100.0, 100.0, 600'000),
+        make_bar(100.0, 100.5, 99.5, 100.0, 1'200'000),
+        // Gap-up fill bar: frozen L*open = 1e6*101/100 > sizing equity 1e6.
+        make_bar(101.0, 101.0, 100.5, 101.0, 1'800'000),
+        make_bar(101.0, 101.0, 101.0, 101.0, 2'400'000),
+    };
+    probe.run(bars, 4);
+
+    CHECK(probe.pending_after_collision_ == 0);
+    CHECK(probe.final_side() == PositionSide::SHORT);
+    CHECK(std::fabs(probe.final_qty() + 10'000.0) < 1e-6);
+    CHECK(probe.trade_count() == 0);
+    CHECK(!probe.has_materialized_close_trade());
+}
+
+// Non-trigger control: a PARTIAL close(held) breaks the exact three-object
+// book under percent sizing exactly as it does for the FIXED cohort — the
+// stale close is removed and the engine keeps its ordinary two-reversal
+// outcome with a full-size short.
+class PercentPartialCloseControl final : public BacktestEngine {
+public:
+    PercentPartialCloseControl() {
+        initial_capital_ = 1'000'000.0;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 10.0;
+        pyramiding_ = 1;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+    }
+
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry("Short", false);
+        } else if (bar_index_ == 1) {
+            strategy_entry("Long", true);
+            strategy_entry("Short", false);
+            strategy_close("Long");
+            strategy_close("Short", "", kNaN, 50.0);
+        }
+    }
+
+    PositionSide final_side() const { return position_side_; }
+    double final_qty() const { return signed_position_size(); }
+    bool has_materialized_close_trade() const {
+        for (int i = 0; i < trade_count(); ++i) {
+            if (get_trade(i).entry_id == "__close__Short") return true;
+        }
+        return false;
+    }
+};
+
+void run_percent_partial_close_control() {
+    PercentPartialCloseControl probe;
+    Bar bars[] = {
+        make_bar(100.0, 100.0, 100.0, 100.0, 600'000),
+        make_bar(100.0, 100.5, 89.5, 90.0, 1'200'000),
+        make_bar(90.0, 90.5, 89.5, 90.0, 1'800'000),
+        make_bar(90.0, 90.0, 90.0, 90.0, 2'400'000),
+    };
+    probe.run(bars, 4);
+
+    const double kL = (1'010'000.0 * (10.0 / 100.0)) / 90.0;
+    CHECK(probe.final_side() == PositionSide::SHORT);
+    CHECK(std::fabs(probe.final_qty() + kL) < 1e-6);
+    CHECK(probe.trade_count() == 2);
+    CHECK(!probe.has_materialized_close_trade());
+}
+
+}  // namespace
+
+int main() {
+    run_percent_remnant_case();
+    run_percent_flat_case();
+    run_cash_remnant_case();
+    run_percent_gap_decline_control();
+    run_percent_partial_close_control();
+    std::printf("%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Gate

`pr-gate` **PASS** — engine corpus zero regressions, scraped entering excellent+strong >= leaving.

Verdict: `/Users/haoliangwen/code/pineforge-lab/pr-gate-verdict.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)