### PR TITLE
engine: calendar/session auxiliary routing, HTF completion, and lot flooring fixes (factorial H·A·B)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ endif()
 # === pineforge library =================================================
 add_library(pineforge STATIC
     src/c_abi.cpp
+    src/engine_aux_security.cpp
     src/engine_fills.cpp
     src/engine_lower_tf.cpp
     src/engine_metrics.cpp

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1554,12 +1554,20 @@ protected:
     // floored, not rounded, before it ever contributes to cost basis or a
     // fill (see src/engine_fills.cpp's margin-call path, which already does
     // this for liquidation lots). qty_step_ == 0 (corpus default) leaves qty
-    // untouched. Unlike the liquidation path, a regular entry legitimately
-    // CAN floor to zero (an under-funded order is simply not placed), so
-    // there is no "never stall" floor-to-one-step fallback here.
+    // untouched. A quotient that is only binary64 residue below an integer is
+    // treated as that integer, using the same 1e-6-of-a-step tolerance as
+    // percent-derived exits below. This keeps an on-grid request such as
+    // 1 / 0.00001 from losing a whole lot because the quotient materializes as
+    // 99999.999999..., while a genuinely off-grid request still floors. When
+    // quantization would be a no-op, preserve the original double so the
+    // tolerance never increases a requested quantity. Unlike the liquidation
+    // path, a regular entry legitimately CAN floor to zero (an under-funded
+    // order is simply not placed), so there is no "never stall"
+    // floor-to-one-step fallback here.
     double apply_qty_step(double qty) const {
         if (qty_step_ <= 0.0 || !std::isfinite(qty) || qty <= 0.0) return qty;
-        return std::floor(qty / qty_step_) * qty_step_;
+        double floored = std::floor(qty / qty_step_ + 1e-6) * qty_step_;
+        return floored < qty ? floored : qty;
     }
 
     // Percent-derived strategy.exit lots are floored to the same lot

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1587,6 +1587,27 @@ protected:
         return floored < qty ? floored : qty;
     }
 
+    // Integer-lot symbols keep one minimum contract/share for any positive
+    // percent-derived strategy.exit request when at least one whole step is
+    // still unreserved. TradingView evidence on one-contract ES/NQ/NIFTY
+    // positions shows a pair of qty_percent=50 siblings reserving 1 + 0, not
+    // 0 + 0. Fractional-lot symbols retain the floor/dust rule above.
+    //
+    // This helper is intentionally exit-percent-specific: explicit exit qty,
+    // full-percent exits, entries and other broker quantities must not acquire
+    // a minimum-one-step fallback.
+    double apply_percent_exit_qty_step(double requested_qty,
+                                       double available_qty) const {
+        double gridded = apply_exit_qty_step(requested_qty);
+        if (qty_step_ >= 1.0
+            && requested_qty > 0.0
+            && requested_qty < qty_step_
+            && available_qty >= qty_step_) {
+            return qty_step_;
+        }
+        return gridded;
+    }
+
     // TradingView reserves the entry commission when sizing percent_of_equity:
     // it sizes the notional so that notional + entry_fee <= equity*pct, i.e.
     // divides the sizing cash by (1 + commRate). Proven from TV exports for
@@ -2601,7 +2622,9 @@ private:
     // of the entry it attaches to. Only acts on multi-leg from_entry groups that
     // contain at least one partial leg; single brackets and pure 100% OCA pairs
     // are left untouched (qty=NaN → full remaining close, as before).
-    void reconcile_deferred_layered_exits(const std::string& entry_id);
+    void reconcile_deferred_layered_exits(
+        const std::string& entry_id,
+        std::vector<std::size_t>& zero_reservation_indices);
     void apply_raw_order_fill(PendingOrder& order, double fill_price,
                               double& trail_best_path_state,
                               int& exit_closed_from_bar,

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -2175,6 +2175,26 @@ protected:
     };
 
     std::vector<SecurityEvalState> security_eval_states_;
+    // Boundary-fallback publication replays the completed caller's already
+    // evaluated final requested value. Force generated TA sites down their
+    // recompute path so the replay advances merged history only, never the
+    // requested-context TA cadence. Keep this byte layout-unconditional so
+    // generated strategy TUs and the statically linked runtime always agree on
+    // BacktestEngine offsets.
+    bool security_history_publication_replay_ = false;
+
+#ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+    // Optional immutable finer feed for request.security. Native chart bars
+    // remain the sole source for current_bar_, broker execution and
+    // bar_index_. Per-run ranges map each chart bar to its auxiliary slice.
+    std::vector<Bar> aux_security_bars_;
+    std::string aux_security_input_tf_;
+    std::vector<std::size_t> aux_security_chart_begin_;
+    std::vector<std::size_t> aux_security_chart_end_;
+#endif
+    // The raw feed used by security aggregators in the active run. This is the
+    // chart input TF on the legacy path and the auxiliary TF on the split path.
+    std::string security_input_tf_;
 
     // --- Runtime trace state ---
     // Gated by ``trace_enabled_`` (default false) so production strategies
@@ -2234,7 +2254,11 @@ protected:
     // per-state feed cursor.
     bool security_input_precedes_range_start(const SecurityEvalState& state,
                                              int64_t input_ts) const;
-    void feed_security_eval_state(SecurityEvalState& state, const Bar& input_bar);
+    void feed_security_eval_state(
+        SecurityEvalState& state, const Bar& input_bar,
+        bool calling_bar_complete = false);
+    void publish_security_eval_state_at_calling_boundary(
+        SecurityEvalState& state);
 
     virtual void configure_security_evaluators() {}
     virtual void evaluate_security(int sec_id, const Bar& bar, bool is_complete) {}
@@ -2251,9 +2275,12 @@ protected:
     virtual void commit_script_state() {}
 
     // Magnifier helpers
-    void run_magnified_bar(const std::vector<Bar>& sub_bars, int64_t script_bar_ts);
+    void run_magnified_bar(
+        const std::vector<Bar>& sub_bars, int64_t script_bar_ts,
+        bool caller_completed_on_boundary = false);
     void run_magnified_bar_calc_on_order_fills(const std::vector<Bar>& sub_bars,
-                                               int64_t script_bar_ts);
+                                               int64_t script_bar_ts,
+                                               bool caller_completed_on_boundary = false);
     virtual void finalize_bar() {}
 
     // --- Equity extremes update (called after each on_bar) ---
@@ -2754,6 +2781,42 @@ private:
         const Bar* input_bars, int n_input,
         const std::string& effective_input_tf);
     void clear_historical_security_lookahead_projections();
+#ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+    bool aux_security_feed_enabled() const { return !aux_security_bars_.empty(); }
+    void prepare_aux_security_chart_ranges(const Bar* chart_bars, int n_chart,
+                                           const std::string& chart_tf);
+    void feed_aux_security_for_chart_bar(int chart_index);
+    void clear_aux_security_chart_ranges();
+
+    // Neutral capability bridge for independent factorial patches. The
+    // two-argument feed exists in the base engine. A completion-aware factor
+    // may add a third bool argument; dependent-expression overload selection
+    // forwards the native chart completion only when that capability exists.
+    // Neither factor names or requires the other's feature macro.
+    template <typename EngineT>
+    static auto feed_security_at_calling_bar_boundary_impl(
+            EngineT* engine, SecurityEvalState& state, const Bar& bar,
+            bool calling_bar_complete, int)
+        -> decltype(engine->feed_security_eval_state(
+                        state, bar, calling_bar_complete), void()) {
+        engine->feed_security_eval_state(state, bar, calling_bar_complete);
+    }
+
+    template <typename EngineT>
+    static void feed_security_at_calling_bar_boundary_impl(
+            EngineT* engine, SecurityEvalState& state, const Bar& bar,
+            bool, long) {
+        engine->feed_security_eval_state(state, bar);
+    }
+
+    void feed_security_at_calling_bar_boundary(
+            SecurityEvalState& state, const Bar& bar,
+            bool calling_bar_complete) {
+        feed_security_at_calling_bar_boundary_impl(
+            this, state, bar, calling_bar_complete, 0);
+    }
+
+#endif
     // Runs the standard per-script-bar order/strategy sequence on current_bar_:
     //   process_pending_orders -> update_per_trade_extremes -> on_bar,
     // plus a second process_pending_orders when process_orders_on_close_ is set
@@ -2807,6 +2870,14 @@ public:
              bool bar_magnifier = false,
              int magnifier_samples = 4,
              MagnifierDistribution magnifier_dist = MagnifierDistribution::ENDPOINTS);
+
+#ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+    // Copies a finer request.security-only feed for subsequent historical
+    // runs. n == 0 clears it. Validation that depends on native chart bars is
+    // intentionally deferred to run(), where failures reach last_error().
+    bool set_aux_security_feed(const Bar* bars, int n,
+                               const std::string& input_tf);
+#endif
 
     // Execute confirmed historical bars, then keep this exact instance alive
     // for realtime trade updates. The warmup feed must contain at least one

--- a/include/pineforge/pineforge.h
+++ b/include/pineforge/pineforge.h
@@ -77,6 +77,10 @@
  *  version 1. */
 #define PF_ABI_VERSION 2
 
+/** Feature probe for the opt-in split chart/request.security feed boundary.
+ *  When defined, #strategy_set_aux_security_feed is available. */
+#define PINEFORGE_HAS_AUX_SECURITY_FEED_V1 1
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -666,6 +670,25 @@ PF_API void strategy_set_syminfo_metadata(pf_strategy_t s, const char* key,
 PF_API int strategy_set_account_currency_fx_series(
     pf_strategy_t s, const int64_t* effective_from_ms,
     const double* account_per_quote, int n);
+
+#ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+/** Copy a finer feed used exclusively by same-symbol request.security calls.
+ *
+ *  The next ordinary #run_backtest_full call must receive native chart bars
+ *  with @c input_tf equal to @c script_tf and bar magnifier disabled. Chart
+ *  OHLCV, broker fills, and @c bar_index continue to advance only from that
+ *  native chart feed; @p bars advance only request.security evaluators.
+ *  Every auxiliary bar must map to exactly one native chart bar and every
+ *  native chart bar must have at least one auxiliary bar, otherwise the run
+ *  fails closed via #strategy_get_last_error. Arrays are copied. Pass
+ *  @p n == 0 to clear the auxiliary feed.
+ *
+ *  @return 0 on success, -1 for a null strategy or invalid input. */
+PF_API int strategy_set_aux_security_feed(pf_strategy_t s,
+                                          const pf_bar_t* bars,
+                                          int n,
+                                          const char* input_tf);
+#endif
 
 /** Returns the error message captured by the most recent #run_backtest /
  *  #run_backtest_full call on this strategy.

--- a/scripts/check_c_abi_runtime.py
+++ b/scripts/check_c_abi_runtime.py
@@ -28,6 +28,7 @@ EXPECTED_RUNTIME = frozenset({
     "strategy_set_syminfo_pointvalue",
     "strategy_set_syminfo_metadata",
     "strategy_set_account_currency_fx_series",
+    "strategy_set_aux_security_feed",
     "strategy_get_last_error",
     "strategy_stream_begin",
     "strategy_stream_push_tick",

--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -43,6 +43,7 @@ import base64
 import csv
 import ctypes
 import hashlib
+import io
 import json
 import math
 import os
@@ -75,6 +76,8 @@ _VALIDATION_META_KEYS = frozenset({
     "strategy_overrides",
     "validation_overrides",
     "ohlcv_csv",
+    "aux_security_ohlcv_csv",
+    "aux_security_input_tf",
     "ohlcv_start_ms",
     "script_tf",
     "input_tf",
@@ -595,7 +598,7 @@ def build_runtime_provenance(run_kwargs: dict, trade_start_ms: int | None) -> di
             "first_effective_ms": int(timestamps[0]),
             "last_effective_ms": int(timestamps[-1]),
         }
-    return {
+    runtime = {
         "input_tf": run_kwargs.get("input_tf") or "",
         "script_tf": run_kwargs.get("script_tf") or "",
         "bar_magnifier": bool(run_kwargs.get("bar_magnifier")),
@@ -606,6 +609,17 @@ def build_runtime_provenance(run_kwargs: dict, trade_start_ms: int | None) -> di
         "account_currency_fx_scalar": fx_scalar,
         "account_currency_fx_series": fx_summary,
     }
+    aux_path = run_kwargs.get("aux_security_ohlcv_csv")
+    if aux_path is not None:
+        runtime["aux_security_feed"] = {
+            "input_tf": run_kwargs.get("aux_security_input_tf") or "",
+            "source_path": str(Path(aux_path).resolve()),
+            "source_file_sha256": run_kwargs.get(
+                "aux_security_source_file_sha256") or "",
+            "source_values_sha256": run_kwargs.get(
+                "aux_security_source_feed_sha256") or "",
+        }
+    return runtime
 
 
 # --- ctypes mirror of <pineforge/pineforge.h> -------------------------
@@ -928,6 +942,7 @@ def inputs_run_kwargs(params, strategy_dir: Path, default_ohlcv: Path,
 
     This is the single source of truth for how harnesses honour
     ``ohlcv_csv`` / ``input_tf`` / ``script_tf`` / ``ohlcv_start_ms`` /
+    ``aux_security_ohlcv_csv`` / ``aux_security_input_tf`` /
     ``chart_timezone`` / ``runtime_overrides`` — ``main()`` below and
     ``scripts/crossvalidate_metrics.py`` both consume it, so a probe that
     runs under one harness runs identically under the other. ``params``
@@ -943,6 +958,32 @@ def inputs_run_kwargs(params, strategy_dir: Path, default_ohlcv: Path,
                       else (strategy_dir / _csv_val)).resolve()
     else:
         ohlcv_path = Path(default_ohlcv).resolve()
+    aux_csv_present = "aux_security_ohlcv_csv" in params
+    aux_tf_present = "aux_security_input_tf" in params
+    aux_security_ohlcv_csv = None
+    aux_security_input_tf = None
+    aux_security_source_file_sha256 = None
+    if aux_csv_present or aux_tf_present:
+        aux_csv_value = str(params.get("aux_security_ohlcv_csv") or "")
+        aux_tf_value = str(params.get("aux_security_input_tf") or "")
+        if not aux_csv_value or not aux_tf_value:
+            raise ValueError(
+                "aux_security_ohlcv_csv and aux_security_input_tf must be set together")
+        aux_security_ohlcv_csv = (
+            Path(aux_csv_value) if aux_csv_value.startswith("/")
+            else strategy_dir / aux_csv_value
+        ).resolve()
+        if not aux_security_ohlcv_csv.is_file():
+            raise FileNotFoundError(
+                "auxiliary request.security OHLCV export not found: "
+                f"{aux_security_ohlcv_csv}")
+        aux_security_input_tf = aux_tf_value
+        aux_security_source_file_sha256 = _sha256_file(
+            aux_security_ohlcv_csv)
+        if aux_security_source_file_sha256 is None:
+            raise OSError(
+                "cannot hash auxiliary request.security OHLCV export: "
+                f"{aux_security_ohlcv_csv}")
     # Per-probe chart tz override wins over the caller default. Empty
     # string is honoured (engine UTC fast path).
     if "chart_timezone" in params:
@@ -1039,6 +1080,11 @@ def inputs_run_kwargs(params, strategy_dir: Path, default_ohlcv: Path,
         magnifier_volume_weighted=bool(
             runtime_overrides.get("magnifier_volume_weighted", False)),
     )
+    if aux_security_ohlcv_csv is not None:
+        kwargs["aux_security_ohlcv_csv"] = aux_security_ohlcv_csv
+        kwargs["aux_security_input_tf"] = aux_security_input_tf
+        kwargs["aux_security_source_file_sha256"] = \
+            aux_security_source_file_sha256
     return ohlcv_path, kwargs
 
 
@@ -1151,6 +1197,11 @@ class Strategy:
                 ctypes.c_void_p, ctypes.POINTER(ctypes.c_int64),
                 ctypes.POINTER(ctypes.c_double), ctypes.c_int]
             L.strategy_set_account_currency_fx_series.restype = ctypes.c_int
+        if hasattr(L, "strategy_set_aux_security_feed"):
+            L.strategy_set_aux_security_feed.argtypes = [
+                ctypes.c_void_p, ctypes.POINTER(BarC), ctypes.c_int,
+                ctypes.c_char_p]
+            L.strategy_set_aux_security_feed.restype = ctypes.c_int
         if hasattr(L, "strategy_set_syminfo_mintick"):
             L.strategy_set_syminfo_mintick.argtypes = [ctypes.c_void_p, ctypes.c_double]
             L.strategy_set_syminfo_mintick.restype = None
@@ -1176,6 +1227,9 @@ class Strategy:
             account_currency_fx_series: "tuple | None" = None,
             account_currency_fx_source_sha256: str | None = None,
             input_tf: str | None = None, script_tf: str | None = None,
+            aux_security_ohlcv_csv: Path | None = None,
+            aux_security_input_tf: str | None = None,
+            aux_security_source_file_sha256: str | None = None,
             ohlcv_start_ms: int | None = None,
             ohlcv_end_ms: int | None = None,
             bar_magnifier: bool = False,
@@ -1227,6 +1281,30 @@ class Strategy:
             bars, n, source_feed_sha256 = _load_bars(
                 bars_csv, ohlcv_start_ms=ohlcv_start_ms,
                 ohlcv_end_ms=ohlcv_end_ms)
+        aux_requested = (aux_security_ohlcv_csv is not None
+                         or aux_security_input_tf is not None)
+        aux_bars = None
+        aux_n = 0
+        aux_source_feed_sha256 = None
+        aux_source_file_sha256 = None
+        if aux_requested:
+            if aux_security_ohlcv_csv is None or not aux_security_input_tf:
+                raise ValueError(
+                    "aux_security_ohlcv_csv and aux_security_input_tf must be set together")
+            if not hasattr(self.lib, "strategy_set_aux_security_feed"):
+                raise RuntimeError(
+                    "strategy library lacks auxiliary request.security feed support; rebuild it")
+            (aux_bars, aux_n, aux_source_feed_sha256,
+             aux_source_file_sha256) = _load_aux_bars_snapshot(
+                 Path(aux_security_ohlcv_csv))
+            if (aux_security_source_file_sha256 is not None
+                    and aux_security_source_file_sha256
+                    != aux_source_file_sha256):
+                raise RuntimeError(
+                    "auxiliary request.security OHLCV export changed after metadata resolution")
+            if aux_n <= 0:
+                raise ValueError(
+                    "auxiliary request.security OHLCV export contains no bars")
         params = params or {}
         params_json = json.dumps(params).encode()
 
@@ -1340,6 +1418,19 @@ class Strategy:
                 str(magnifier_distribution or "").upper() == "VOLUME_WEIGHTED")
             if mag_on and vw_on and hasattr(self.lib, "strategy_set_magnifier_volume_weighted"):
                 self.lib.strategy_set_magnifier_volume_weighted(state, 1)
+            if aux_requested:
+                rc = self.lib.strategy_set_aux_security_feed(
+                    state, aux_bars, aux_n,
+                    str(aux_security_input_tf).encode())
+                if rc != 0:
+                    detail = ""
+                    if hasattr(self.lib, "strategy_get_last_error"):
+                        err_ptr = self.lib.strategy_get_last_error(state)
+                        if err_ptr:
+                            detail = err_ptr.decode("utf-8", "replace")
+                    raise RuntimeError(
+                        "engine rejected auxiliary request.security feed"
+                        + (f": {detail}" if detail else ""))
             self.lib.run_backtest_full(
                 state, bars, n,
                 input_tf_b, script_tf_b,  # empty -> auto-detect input_tf, default script_tf=input_tf
@@ -1366,6 +1457,15 @@ class Strategy:
                 )
             if source_feed_sha256 is not None:
                 result["source_feed_sha256"] = source_feed_sha256
+            if aux_requested:
+                result["aux_security_ohlcv_csv"] = str(
+                    Path(aux_security_ohlcv_csv).resolve())
+                result["aux_security_input_tf"] = str(
+                    aux_security_input_tf)
+                result["aux_security_source_file_sha256"] = (
+                    aux_source_file_sha256 or "")
+                result["aux_security_source_feed_sha256"] = (
+                    aux_source_feed_sha256 or "")
             return result
         finally:
             self.lib.report_free(ctypes.byref(report))
@@ -1453,6 +1553,74 @@ def _load_bars(csv_path: Path, *, ohlcv_start_ms: int | None = None,
         bars[i].volume = v
         bars[i].timestamp = ts
     return bars, n, feed_hasher.hexdigest()
+
+
+def _load_aux_bars_snapshot(
+        csv_path: Path) -> tuple[ctypes.Array, int, str, str]:
+    """Load auxiliary bars and both identities from one immutable byte read.
+
+    The raw SHA and parsed ``BarC`` values must attest the same bytes. Reading
+    the path once eliminates the hash-then-reopen window where a replacement
+    file could be executed under the previous file's hash.
+    """
+    with csv_path.open("rb") as handle:
+        snapshot = handle.read()
+    source_file_sha256 = hashlib.sha256(snapshot).hexdigest()
+    lines = snapshot.splitlines()
+    if not lines:
+        raise ValueError(
+            f"auxiliary request.security OHLCV export is empty: {csv_path}")
+    header = lines[0].decode("utf-8-sig").strip().split(",")
+    col = {name: header.index(name)
+           for name in ("open", "high", "low", "close", "volume", "timestamp")}
+
+    try:
+        import numpy as _np
+    except ImportError:
+        _np = None
+    if _np is not None:
+        if any(line.strip() for line in lines[1:]):
+            data = _np.loadtxt(
+                io.BytesIO(snapshot), delimiter=",", skiprows=1, ndmin=2)
+        else:
+            data = _np.empty((0, len(header)), dtype="<f8")
+        count = len(data)
+        dtype = _np.dtype([
+            ("open", "<f8"), ("high", "<f8"), ("low", "<f8"),
+            ("close", "<f8"), ("volume", "<f8"), ("timestamp", "<i8"),
+        ])
+        rows = _np.empty(count, dtype=dtype)
+        for name in ("open", "high", "low", "close", "volume"):
+            rows[name] = data[:, col[name]] if count else []
+        rows["timestamp"] = (
+            data[:, col["timestamp"]].astype("<i8") if count else [])
+        canonical = _new_source_feed_hasher()
+        canonical.update(memoryview(rows))
+        bars = ((BarC * count).from_buffer_copy(rows.tobytes())
+                if count else (BarC * 0)())
+        return bars, count, canonical.hexdigest(), source_file_sha256
+
+    parsed_rows: list[tuple[float, float, float, float, float, int]] = []
+    canonical = _new_source_feed_hasher()
+    reader = csv.DictReader(io.StringIO(snapshot.decode("utf-8-sig")))
+    for row in reader:
+        parsed = (
+            float(row["open"]), float(row["high"]), float(row["low"]),
+            float(row["close"]), float(row["volume"]), int(row["timestamp"]),
+        )
+        _update_source_feed_hash(canonical, parsed)
+        parsed_rows.append(parsed)
+    count = len(parsed_rows)
+    bars = (BarC * count)()
+    for index, (open_, high, low, close, volume, timestamp) in enumerate(
+            parsed_rows):
+        bars[index].open = open_
+        bars[index].high = high
+        bars[index].low = low
+        bars[index].close = close
+        bars[index].volume = volume
+        bars[index].timestamp = timestamp
+    return bars, count, canonical.hexdigest(), source_file_sha256
 
 
 def _report_to_dict(r: ReportC) -> dict:
@@ -1877,6 +2045,11 @@ def main() -> int:
                 "error: --runner docker does not support timestamped "
                 "account-currency FX; use --runner ctypes with a freshly "
                 "built strategy library.")
+        if run_kwargs.get("aux_security_ohlcv_csv") is not None:
+            sys.exit(
+                "error: --runner docker does not support an auxiliary "
+                "request.security feed; use --runner ctypes with a freshly "
+                "built strategy library.")
         strat = None
         report = _run_via_docker(strategy_dir, ohlcv_path, params, run_kwargs,
                                  trade_start_ms, args.image)
@@ -1912,7 +2085,12 @@ def main() -> int:
             overrides_applied = {
                 str(k): str(v) for k, v in (run_kwargs.get("strategy_overrides") or {}).items()
             }
-            runtime = build_runtime_provenance(run_kwargs, trade_start_ms)
+            runtime_kwargs = dict(run_kwargs)
+            if report.get("aux_security_source_feed_sha256"):
+                runtime_kwargs["aux_security_source_feed_sha256"] = \
+                    report["aux_security_source_feed_sha256"]
+            runtime = build_runtime_provenance(
+                runtime_kwargs, trade_start_ms)
             fp = build_fingerprint(build_provenance(
                 engine_version(strat.lib),
                 cpp_path if cpp_path.exists() else None,

--- a/scripts/test_run_strategy_aux_feed.py
+++ b/scripts/test_run_strategy_aux_feed.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Focused runner proof for the optional auxiliary request.security feed."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import run_strategy as rs
+
+from run_strategy import (
+    Strategy,
+    build_fingerprint,
+    build_runtime_provenance,
+    inputs_run_kwargs,
+)
+
+
+def _write_bars(path: Path, closes: list[float]) -> None:
+    rows = ["timestamp,open,high,low,close,volume"]
+    for index, close in enumerate(closes):
+        timestamp = 1_704_205_800_000 + index * 60_000
+        rows.append(
+            f"{timestamp},{close},{close + 1},{close - 1},{close},10")
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+class _FakeLibrary:
+    def __init__(self, *, aux_result: int | None = 0) -> None:
+        self.events = []
+        self.aux_result = aux_result
+
+    def strategy_create(self, _params):
+        self.events.append(("create",))
+        return 7
+
+    def run_backtest_full(self, _state, bars, count, *_rest):
+        self.events.append((
+            "run", count,
+            [float(bars[index].close) for index in range(count)],
+        ))
+
+    def strategy_get_last_error(self, _state):
+        return (b"rejected auxiliary feed"
+                if self.aux_result not in (None, 0) else b"")
+
+    def report_free(self, _report):
+        pass
+
+    def strategy_free(self, _state):
+        pass
+
+    def strategy_set_aux_security_feed(self, _state, bars, count, input_tf):
+        if self.aux_result is None:
+            raise AssertionError("setter must not be called")
+        self.events.append((
+            "aux", count, input_tf.decode(),
+            [float(bars[index].close) for index in range(count)],
+        ))
+        return self.aux_result
+
+
+class _FeatureAbsentLibrary(_FakeLibrary):
+    strategy_set_aux_security_feed = None
+
+    def __getattribute__(self, name):
+        if name == "strategy_set_aux_security_feed":
+            raise AttributeError(name)
+        return super().__getattribute__(name)
+
+
+def _strategy(fake) -> Strategy:
+    strategy = Strategy.__new__(Strategy)
+    strategy.lib = fake
+    return strategy
+
+
+class AuxSecurityRunnerTests(unittest.TestCase):
+    def test_metadata_pair_resolves_relative_export(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart = root / "chart.csv"
+            aux = root / "aux.csv"
+            _write_bars(chart, [100.0])
+            _write_bars(aux, [10.0])
+            _, kwargs = inputs_run_kwargs({
+                "aux_security_ohlcv_csv": "aux.csv",
+                "aux_security_input_tf": "1",
+            }, root, chart)
+            self.assertEqual(kwargs["aux_security_ohlcv_csv"], aux.resolve())
+            self.assertEqual(kwargs["aux_security_input_tf"], "1")
+            self.assertEqual(
+                len(kwargs["aux_security_source_file_sha256"]), 64)
+
+            _, legacy = inputs_run_kwargs({}, root, chart)
+            self.assertNotIn("aux_security_ohlcv_csv", legacy)
+            self.assertNotIn("aux_security_input_tf", legacy)
+
+    def test_aux_path_timeframe_and_content_mutate_runtime_provenance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart = root / "chart.csv"
+            aux_a = root / "aux-a.csv"
+            aux_b = root / "aux-b.csv"
+            _write_bars(chart, [100.0])
+            _write_bars(aux_a, [10.0, 11.0])
+            _write_bars(aux_b, [10.0, 11.0])
+
+            _, kwargs_a = inputs_run_kwargs({
+                "aux_security_ohlcv_csv": "aux-a.csv",
+                "aux_security_input_tf": "1",
+            }, root, chart)
+            _, kwargs_path = inputs_run_kwargs({
+                "aux_security_ohlcv_csv": "aux-b.csv",
+                "aux_security_input_tf": "1",
+            }, root, chart)
+            _, kwargs_tf = inputs_run_kwargs({
+                "aux_security_ohlcv_csv": "aux-a.csv",
+                "aux_security_input_tf": "5",
+            }, root, chart)
+            provenance_a = build_runtime_provenance(kwargs_a, None)
+            digest_a = build_fingerprint({"runtime": provenance_a})["digest"]
+            self.assertNotEqual(
+                provenance_a, build_runtime_provenance(kwargs_path, None))
+            self.assertNotEqual(
+                provenance_a, build_runtime_provenance(kwargs_tf, None))
+            self.assertNotEqual(
+                digest_a,
+                build_fingerprint({
+                    "runtime": build_runtime_provenance(kwargs_path, None),
+                })["digest"])
+            self.assertNotEqual(
+                digest_a,
+                build_fingerprint({
+                    "runtime": build_runtime_provenance(kwargs_tf, None),
+                })["digest"])
+
+            _write_bars(aux_a, [10.0, 12.0])
+            _, kwargs_content = inputs_run_kwargs({
+                "aux_security_ohlcv_csv": "aux-a.csv",
+                "aux_security_input_tf": "1",
+            }, root, chart)
+            self.assertNotEqual(
+                provenance_a, build_runtime_provenance(kwargs_content, None))
+            self.assertNotEqual(
+                digest_a,
+                build_fingerprint({
+                    "runtime": build_runtime_provenance(
+                        kwargs_content, None),
+                })["digest"])
+
+    def test_runner_loads_aux_bars_and_installs_them_before_chart_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart = root / "chart.csv"
+            aux = root / "aux.csv"
+            _write_bars(chart, [100.0, 200.0])
+            _write_bars(aux, [10.0, 11.0, 12.0])
+            fake = _FakeLibrary()
+
+            report = _strategy(fake).run(
+                chart, input_tf="1D", script_tf="1D",
+                aux_security_ohlcv_csv=aux,
+                aux_security_input_tf="1")
+
+            self.assertEqual(fake.events[1],
+                             ("aux", 3, "1", [10.0, 11.0, 12.0]))
+            self.assertEqual(fake.events[2],
+                             ("run", 2, [100.0, 200.0]))
+            self.assertEqual(report["aux_security_input_tf"], "1")
+            self.assertEqual(report["aux_security_ohlcv_csv"],
+                             str(aux.resolve()))
+            self.assertEqual(
+                len(report["aux_security_source_file_sha256"]), 64)
+            self.assertEqual(
+                len(report["aux_security_source_feed_sha256"]), 64)
+
+    def test_requested_aux_feed_requires_export_and_runtime_symbol(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart = root / "chart.csv"
+            aux = root / "aux.csv"
+            _write_bars(chart, [100.0])
+            _write_bars(aux, [10.0])
+
+            with self.assertRaisesRegex(RuntimeError, "lacks auxiliary"):
+                _strategy(_FeatureAbsentLibrary()).run(
+                    chart, aux_security_ohlcv_csv=aux,
+                    aux_security_input_tf="1")
+
+            with self.assertRaisesRegex(RuntimeError,
+                                        "rejected auxiliary feed"):
+                _strategy(_FakeLibrary(aux_result=-1)).run(
+                    chart, aux_security_ohlcv_csv=aux,
+                    aux_security_input_tf="1")
+
+            with self.assertRaisesRegex(FileNotFoundError,
+                                        "export not found"):
+                inputs_run_kwargs({
+                    "aux_security_ohlcv_csv": "missing.csv",
+                    "aux_security_input_tf": "1",
+                }, root, chart)
+
+
+    def test_hash_then_replace_adversary_cannot_change_loaded_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart = root / "chart.csv"
+            aux = root / "aux.csv"
+            _write_bars(chart, [100.0])
+            _write_bars(aux, [10.0])
+            real_hash = rs._sha256_file
+
+            def hash_then_replace(path):
+                digest = real_hash(path)
+                _write_bars(Path(path), [99.0])
+                return digest
+
+            # Reproduce the old vulnerability: replacement occurs immediately
+            # after the attested raw hash is returned. The run's one-read byte
+            # snapshot sees 99 and must reject the stale hash for 10.
+            with mock.patch.object(
+                    rs, "_sha256_file", side_effect=hash_then_replace):
+                _, resolved = inputs_run_kwargs({
+                    "aux_security_ohlcv_csv": "aux.csv",
+                    "aux_security_input_tf": "1",
+                }, root, chart)
+            with self.assertRaisesRegex(RuntimeError,
+                                        "changed after metadata resolution"):
+                _strategy(_FakeLibrary()).run(chart, **resolved)
+
+    def test_feature_absent_without_aux_request_keeps_legacy_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            chart = Path(tmp) / "chart.csv"
+            _write_bars(chart, [100.0])
+            fake = _FeatureAbsentLibrary()
+            _strategy(fake).run(chart)
+            self.assertEqual(fake.events,
+                             [("create",), ("run", 1, [100.0])])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/c_abi.cpp
+++ b/src/c_abi.cpp
@@ -9,7 +9,7 @@
  *     BEFORE shipping a .so that consumers depend on.
  *   - The runtime-library-side `extern "C"` symbols (the closed-trade
  *     incarnation accessor, setters, strategy_get_last_error,
- *     the strategy_stream_* lifecycle,
+ *     the auxiliary-security-feed setter, the strategy_stream_* lifecycle,
  *     pf_version_get/pf_version_string, pf_abi_version — the authoritative list is EXPECTED_RUNTIME in
  *     scripts/check_c_abi_runtime.py, enforced by CI). The other
  *     `extern "C"` symbols listed in pineforge.h (strategy_create,
@@ -310,6 +310,21 @@ PF_API int strategy_set_account_currency_fx_series(
                        effective_from_ms, account_per_quote, n)
         ? 0 : -1;
 }
+
+#ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+PF_API int strategy_set_aux_security_feed(pf_strategy_t s,
+                                          const pf_bar_t* bars,
+                                          int n,
+                                          const char* input_tf) {
+    if (!s || n < 0 || (n > 0 && (!bars || !input_tf))) return -1;
+    const auto* native = reinterpret_cast<const pineforge::Bar*>(bars);
+    return static_cast<pineforge::BacktestEngine*>(s)
+                   ->set_aux_security_feed(
+                       native, n,
+                       input_tf ? std::string(input_tf) : std::string())
+        ? 0 : -1;
+}
+#endif
 
 /* See PF_ABI_VERSION doc in pineforge.h. */
 PF_API int pf_abi_version(void) { return PF_ABI_VERSION; }

--- a/src/engine_aux_security.cpp
+++ b/src/engine_aux_security.cpp
@@ -101,13 +101,13 @@ void BacktestEngine::prepare_aux_security_chart_ranges(
                                      syminfo_.timezone, syminfo_.session);
     const CalendarPeriod chart_period = calendar_period_for(chart_tf);
     const bool calendar_chart = chart_period != CalendarPeriod::NONE;
-    // Calendar chart timestamps are the ACTUAL exchange bar opens.  Most
-    // sessions open at syminfo.session's nominal start, but special sessions
-    // can open at another time on the same trading date (NSE Muhurat is the
-    // pinned example).  Route calendar bars by their unique trading-period
-    // identity, then retain the native bar index/timestamp for chart and
-    // broker semantics.  Requiring timestamp equality here incorrectly turns
-    // a shifted special-session open into an interior missing-bar failure.
+    // Calendar chart timestamps are the ACTUAL exchange bar opens and define
+    // the authoritative partition.  A native daily bar may begin at a shifted
+    // special-session open (NSE Muhurat), or may coalesce more than one
+    // nominal session key (the CME Labor-Day Sunday/Monday sessions).  Route
+    // each auxiliary bar through [chart_ts[i], chart_ts[i + 1]) while retaining
+    // the native label for chart and broker semantics.  Nominal calendar keys
+    // remain useful only for ignoring wider leading/trailing feed coverage.
     std::vector<int64_t> chart_route_keys;
     chart_route_keys.reserve(static_cast<std::size_t>(n_chart));
     for (int i = 0; i < n_chart; ++i) {
@@ -125,34 +125,52 @@ void BacktestEngine::prepare_aux_security_chart_ranges(
     const int64_t first_chart_key = chart_route_keys.front();
     const int64_t last_chart_key = chart_route_keys.back();
     std::size_t chart_index = 0;
-    for (std::size_t aux_index = 0; aux_index < aux_security_bars_.size();
-         ++aux_index) {
-        const int64_t label = calendar_chart
-            ? session_period_open_ms(aux_security_bars_[aux_index].timestamp,
-                                     syminfo_.timezone, syminfo_.session,
-                                     chart_period)
-            : chart_router.bar_label_ms(
-                  aux_security_bars_[aux_index].timestamp);
-        // Evidence feeds may intentionally cover a wider history than the
-        // native chart tape. Those leading/trailing buckets are inert. Once a
-        // label enters the native span, however, it must match an actual chart
-        // bar exactly; silently skipping an interior hole would shift security
-        // state across the chart matrix.
-        if (label < first_chart_key || label > last_chart_key) {
-            continue;
-        }
-        while (chart_index + 1 < static_cast<std::size_t>(n_chart)
-               && chart_route_keys[chart_index] < label) {
-            ++chart_index;
-        }
-        if (chart_route_keys[chart_index] != label) {
-            throw std::runtime_error(
-                "auxiliary request.security bar does not map to a native chart bar");
-        }
+    auto record_aux = [&](std::size_t aux_index) {
         if (aux_security_chart_begin_[chart_index] == missing) {
             aux_security_chart_begin_[chart_index] = aux_index;
         }
         aux_security_chart_end_[chart_index] = aux_index + 1;
+    };
+    if (calendar_chart) {
+        const int64_t first_chart_timestamp = chart_bars[0].timestamp;
+        for (std::size_t aux_index = 0;
+             aux_index < aux_security_bars_.size(); ++aux_index) {
+            const int64_t aux_timestamp =
+                aux_security_bars_[aux_index].timestamp;
+            const int64_t period_key = session_period_open_ms(
+                aux_timestamp, syminfo_.timezone, syminfo_.session,
+                chart_period);
+            if (period_key < first_chart_key || period_key > last_chart_key
+                || aux_timestamp < first_chart_timestamp) {
+                continue;
+            }
+            while (chart_index + 1 < static_cast<std::size_t>(n_chart)
+                   && chart_bars[chart_index + 1].timestamp <= aux_timestamp) {
+                ++chart_index;
+            }
+            record_aux(aux_index);
+        }
+    } else {
+        for (std::size_t aux_index = 0;
+             aux_index < aux_security_bars_.size(); ++aux_index) {
+            const int64_t label = chart_router.bar_label_ms(
+                aux_security_bars_[aux_index].timestamp);
+            // Intraday native bars remain exact session-grid labels.  Wider
+            // leading/trailing coverage is inert, but an interior grid hole
+            // must fail closed rather than attach to a neighbouring bar.
+            if (label < first_chart_key || label > last_chart_key) {
+                continue;
+            }
+            while (chart_index + 1 < static_cast<std::size_t>(n_chart)
+                   && chart_route_keys[chart_index] < label) {
+                ++chart_index;
+            }
+            if (chart_route_keys[chart_index] != label) {
+                throw std::runtime_error(
+                    "auxiliary request.security bar does not map to a native chart bar");
+            }
+            record_aux(aux_index);
+        }
     }
     for (int i = 0; i < n_chart; ++i) {
         if (aux_security_chart_begin_[static_cast<std::size_t>(i)] == missing) {

--- a/src/engine_aux_security.cpp
+++ b/src/engine_aux_security.cpp
@@ -1,0 +1,239 @@
+/*
+ * engine_aux_security.cpp — native-chart / request.security feed separation
+ */
+
+#include "engine_internal.hpp"
+
+#include <pineforge/ta.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace pineforge {
+
+#ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+
+bool BacktestEngine::set_aux_security_feed(const Bar* bars, int n,
+                                           const std::string& input_tf) {
+    if (n == 0) {
+        aux_security_bars_.clear();
+        aux_security_input_tf_.clear();
+        clear_aux_security_chart_ranges();
+        return true;
+    }
+    if (n < 0 || bars == nullptr || input_tf.empty()) {
+        last_error_ =
+            "auxiliary request.security feed requires bars, a positive count, and input_tf";
+        return false;
+    }
+    int seconds = 0;
+    try {
+        seconds = tf_to_seconds(input_tf);
+    } catch (...) {
+        seconds = 0;
+    }
+    if (seconds <= 0) {
+        last_error_ =
+            "auxiliary request.security feed requires a fixed positive input_tf";
+        return false;
+    }
+    for (int i = 1; i < n; ++i) {
+        if (bars[i].timestamp <= bars[i - 1].timestamp) {
+            last_error_ =
+                "auxiliary request.security feed timestamps must be strictly increasing";
+            return false;
+        }
+    }
+    aux_security_bars_.assign(bars, bars + n);
+    aux_security_input_tf_ = input_tf;
+    clear_aux_security_chart_ranges();
+    last_error_.clear();
+    return true;
+}
+
+
+void BacktestEngine::clear_aux_security_chart_ranges() {
+    aux_security_chart_begin_.clear();
+    aux_security_chart_end_.clear();
+}
+
+
+void BacktestEngine::prepare_aux_security_chart_ranges(
+        const Bar* chart_bars, int n_chart, const std::string& chart_tf) {
+    clear_aux_security_chart_ranges();
+    if (!aux_security_feed_enabled()) return;
+    if (chart_bars == nullptr || n_chart <= 0) {
+        throw std::runtime_error(
+            "auxiliary request.security feed requires at least one native chart bar");
+    }
+
+    int chart_seconds = 0;
+    int aux_seconds = 0;
+    try {
+        chart_seconds = tf_to_seconds(chart_tf);
+        aux_seconds = tf_to_seconds(aux_security_input_tf_);
+    } catch (...) {
+        chart_seconds = 0;
+        aux_seconds = 0;
+    }
+    if (chart_seconds <= 0 || aux_seconds <= 0
+        || aux_seconds >= chart_seconds) {
+        throw std::runtime_error(
+            "auxiliary request.security feed input_tf must be fixed and strictly finer than the native chart timeframe");
+    }
+    if (chart_seconds % aux_seconds != 0) {
+        throw std::runtime_error(
+            "auxiliary request.security feed input_tf must evenly divide the native chart timeframe");
+    }
+    for (int i = 1; i < n_chart; ++i) {
+        if (chart_bars[i].timestamp <= chart_bars[i - 1].timestamp) {
+            throw std::runtime_error(
+                "native chart feed timestamps must be strictly increasing with an auxiliary security feed");
+        }
+    }
+
+    const std::size_t missing = std::numeric_limits<std::size_t>::max();
+    aux_security_chart_begin_.assign(static_cast<std::size_t>(n_chart), missing);
+    aux_security_chart_end_.assign(static_cast<std::size_t>(n_chart), missing);
+    TimeframeAggregator chart_router(chart_tf, aux_security_input_tf_,
+                                     syminfo_.timezone, syminfo_.session);
+    const int64_t first_chart_label = chart_bars[0].timestamp;
+    const int64_t last_chart_label = chart_bars[n_chart - 1].timestamp;
+    std::size_t chart_index = 0;
+    for (std::size_t aux_index = 0; aux_index < aux_security_bars_.size();
+         ++aux_index) {
+        const int64_t label = chart_router.bar_label_ms(
+            aux_security_bars_[aux_index].timestamp);
+        // Evidence feeds may intentionally cover a wider history than the
+        // native chart tape. Those leading/trailing buckets are inert. Once a
+        // label enters the native span, however, it must match an actual chart
+        // bar exactly; silently skipping an interior hole would shift security
+        // state across the chart matrix.
+        if (label < first_chart_label || label > last_chart_label) {
+            continue;
+        }
+        while (chart_index + 1 < static_cast<std::size_t>(n_chart)
+               && chart_bars[chart_index].timestamp < label) {
+            ++chart_index;
+        }
+        if (chart_bars[chart_index].timestamp != label) {
+            throw std::runtime_error(
+                "auxiliary request.security bar does not map to a native chart bar");
+        }
+        if (aux_security_chart_begin_[chart_index] == missing) {
+            aux_security_chart_begin_[chart_index] = aux_index;
+        }
+        aux_security_chart_end_[chart_index] = aux_index + 1;
+    }
+    for (int i = 0; i < n_chart; ++i) {
+        if (aux_security_chart_begin_[static_cast<std::size_t>(i)] == missing) {
+            throw std::runtime_error(
+                "native chart bar has no matching auxiliary request.security bars");
+        }
+    }
+}
+
+
+void BacktestEngine::feed_aux_security_for_chart_bar(int chart_index) {
+    const std::size_t idx = static_cast<std::size_t>(chart_index);
+    if (idx >= aux_security_chart_begin_.size()
+        || idx >= aux_security_chart_end_.size()) {
+        throw std::runtime_error(
+            "auxiliary request.security chart routing is not initialized");
+    }
+    const std::size_t begin = aux_security_chart_begin_[idx];
+    const std::size_t end = aux_security_chart_end_[idx];
+
+    // Lower-TF arrays belong to the native chart slice, not a raw UTC bucket.
+    // Accumulate the entire symbol-clock-aligned slice here and publish it only
+    // after its final auxiliary bar. This keeps an overnight 17:00-17:00 daily
+    // bar as one array even though its raw timestamps cross UTC midnight.
+    for (std::size_t i = begin; i < end; ++i) {
+        const Bar& aux_bar = aux_security_bars_[i];
+        const bool calling_bar_complete = (i + 1 == end);
+        for (auto& state : security_eval_states_) {
+            if (!state.lower_tf_array_requested) {
+                feed_security_at_calling_bar_boundary(
+                    state, aux_bar, calling_bar_complete);
+                continue;
+            }
+            if (security_input_precedes_range_start(state, aux_bar.timestamp)) {
+                continue;
+            }
+            if (state.lower_tf_use_input) {
+                state.lower_tf_input_buffer.push_back(aux_bar);
+            } else if (state.lower_tf_emulation) {
+                std::vector<Bar> synthetic = internal::synthesize_lower_tf_bars(
+                    aux_bar, state.lower_tf_ratio, state.lower_tf_seconds);
+                if (synthetic.empty()) {
+                    throw std::runtime_error(
+                        "request.security_lower_tf could not synthesize auxiliary sub-bars");
+                }
+                state.lower_tf_input_buffer.insert(
+                    state.lower_tf_input_buffer.end(),
+                    synthetic.begin(), synthetic.end());
+            } else {
+                throw std::runtime_error(
+                    "request.security_lower_tf auxiliary routing is not initialized");
+            }
+        }
+    }
+
+    struct SecurityNaWarmupScope {
+        bool previous;
+        explicit SecurityNaWarmupScope(bool enabled)
+            : previous(ta::ema_na_warmup_flag()) {
+            ta::ema_na_warmup_flag() = enabled;
+        }
+        ~SecurityNaWarmupScope() { ta::ema_na_warmup_flag() = previous; }
+    } warmup_scope(security_range_start_na_warmup_);
+
+    for (auto& state : security_eval_states_) {
+        if (!state.lower_tf_array_requested) continue;
+        int aggregate_ratio = state.lower_tf_emulation
+            ? 1 : state.lower_tf_input_aggregation_ratio;
+        if (aggregate_ratio < 1) aggregate_ratio = 1;
+        const int count = static_cast<int>(state.lower_tf_input_buffer.size());
+        std::vector<Bar> requested_bars;
+        requested_bars.reserve(
+            static_cast<std::size_t>(count / aggregate_ratio + 1));
+        if (aggregate_ratio == 1) {
+            requested_bars.assign(state.lower_tf_input_buffer.begin(),
+                                  state.lower_tf_input_buffer.end());
+        } else {
+            for (int i = 0; i + aggregate_ratio <= count;
+                 i += aggregate_ratio) {
+                Bar aggregate = state.lower_tf_input_buffer[
+                    static_cast<std::size_t>(i)];
+                double volume = aggregate.volume;
+                for (int j = 1; j < aggregate_ratio; ++j) {
+                    const Bar& next = state.lower_tf_input_buffer[
+                        static_cast<std::size_t>(i + j)];
+                    aggregate.high = std::max(aggregate.high, next.high);
+                    aggregate.low = std::min(aggregate.low, next.low);
+                    aggregate.close = next.close;
+                    volume += next.volume;
+                }
+                aggregate.volume = volume;
+                requested_bars.push_back(aggregate);
+            }
+        }
+
+        state.lower_tf_sub_bar_index = 0;
+        for (const Bar& bar : requested_bars) {
+            state.feed_count++;
+            state.current_bar = bar;
+            state.current_sub_bar_count = 1;
+            state.eval_complete_count++;
+            evaluate_security(state.sec_id, bar, true);
+            state.lower_tf_sub_bar_index++;
+        }
+        state.lower_tf_input_buffer.clear();
+    }
+}
+
+#endif  // PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+
+}  // namespace pineforge

--- a/src/engine_aux_security.cpp
+++ b/src/engine_aux_security.cpp
@@ -99,26 +99,53 @@ void BacktestEngine::prepare_aux_security_chart_ranges(
     aux_security_chart_end_.assign(static_cast<std::size_t>(n_chart), missing);
     TimeframeAggregator chart_router(chart_tf, aux_security_input_tf_,
                                      syminfo_.timezone, syminfo_.session);
-    const int64_t first_chart_label = chart_bars[0].timestamp;
-    const int64_t last_chart_label = chart_bars[n_chart - 1].timestamp;
+    const CalendarPeriod chart_period = calendar_period_for(chart_tf);
+    const bool calendar_chart = chart_period != CalendarPeriod::NONE;
+    // Calendar chart timestamps are the ACTUAL exchange bar opens.  Most
+    // sessions open at syminfo.session's nominal start, but special sessions
+    // can open at another time on the same trading date (NSE Muhurat is the
+    // pinned example).  Route calendar bars by their unique trading-period
+    // identity, then retain the native bar index/timestamp for chart and
+    // broker semantics.  Requiring timestamp equality here incorrectly turns
+    // a shifted special-session open into an interior missing-bar failure.
+    std::vector<int64_t> chart_route_keys;
+    chart_route_keys.reserve(static_cast<std::size_t>(n_chart));
+    for (int i = 0; i < n_chart; ++i) {
+        const int64_t key = calendar_chart
+            ? session_period_open_ms(chart_bars[i].timestamp,
+                                     syminfo_.timezone, syminfo_.session,
+                                     chart_period)
+            : chart_bars[i].timestamp;
+        if (!chart_route_keys.empty() && key <= chart_route_keys.back()) {
+            throw std::runtime_error(
+                "native chart feed trading-period identities must be unique and strictly increasing with an auxiliary security feed");
+        }
+        chart_route_keys.push_back(key);
+    }
+    const int64_t first_chart_key = chart_route_keys.front();
+    const int64_t last_chart_key = chart_route_keys.back();
     std::size_t chart_index = 0;
     for (std::size_t aux_index = 0; aux_index < aux_security_bars_.size();
          ++aux_index) {
-        const int64_t label = chart_router.bar_label_ms(
-            aux_security_bars_[aux_index].timestamp);
+        const int64_t label = calendar_chart
+            ? session_period_open_ms(aux_security_bars_[aux_index].timestamp,
+                                     syminfo_.timezone, syminfo_.session,
+                                     chart_period)
+            : chart_router.bar_label_ms(
+                  aux_security_bars_[aux_index].timestamp);
         // Evidence feeds may intentionally cover a wider history than the
         // native chart tape. Those leading/trailing buckets are inert. Once a
         // label enters the native span, however, it must match an actual chart
         // bar exactly; silently skipping an interior hole would shift security
         // state across the chart matrix.
-        if (label < first_chart_label || label > last_chart_label) {
+        if (label < first_chart_key || label > last_chart_key) {
             continue;
         }
         while (chart_index + 1 < static_cast<std::size_t>(n_chart)
-               && chart_bars[chart_index].timestamp < label) {
+               && chart_route_keys[chart_index] < label) {
             ++chart_index;
         }
-        if (chart_bars[chart_index].timestamp != label) {
+        if (chart_route_keys[chart_index] != label) {
             throw std::runtime_error(
                 "auxiliary request.security bar does not map to a native chart bar");
         }

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -4561,7 +4561,7 @@ void BacktestEngine::apply_filled_order_to_state(
         }
         if (!pyramid_entries_.empty()) {
             reconcile_deferred_layered_exits(
-                pyramid_entries_.back().entry_id);
+                pyramid_entries_.back().entry_id, filled_indices);
         }
     }
 
@@ -4576,7 +4576,7 @@ void BacktestEngine::apply_filled_order_to_state(
         && (order.type == OrderType::MARKET
             || order.type == OrderType::ENTRY
             || order.type == OrderType::RAW_ORDER)) {
-        reconcile_deferred_layered_exits(order.id);
+        reconcile_deferred_layered_exits(order.id, filled_indices);
     }
 
     if (position_side_ == PositionSide::FLAT) {
@@ -5129,7 +5129,9 @@ void BacktestEngine::apply_exit_order_fill(PendingOrder& order, double fill_pric
     }
 }
 
-void BacktestEngine::reconcile_deferred_layered_exits(const std::string& entry_id) {
+void BacktestEngine::reconcile_deferred_layered_exits(
+        const std::string& entry_id,
+        std::vector<std::size_t>& zero_reservation_indices) {
     if (entry_id.empty()) return;
     const double live_pos = position_qty_;
     if (live_pos <= kQtyEpsilon) return;
@@ -5158,7 +5160,8 @@ void BacktestEngine::reconcile_deferred_layered_exits(const std::string& entry_i
     // fires first. Legs that already carry an explicit qty (reconciled at arm
     // time) are left as-is but still consume reservation capacity.
     double reserved = 0.0;
-    for (auto& o : pending_orders_) {
+    for (std::size_t i = 0; i < pending_orders_.size(); ++i) {
+        auto& o = pending_orders_[i];
         if (o.type != OrderType::EXIT) continue;
         if (o.from_entry != entry_id) continue;
         double oqp = std::isnan(o.qty_percent)
@@ -5169,9 +5172,27 @@ void BacktestEngine::reconcile_deferred_layered_exits(const std::string& entry_i
         }
         double avail = std::max(0.0, live_pos - reserved);
         double requested = live_pos * (oqp / 100.0);
-        if (oqp < 100.0 - kFullPercentEps) requested = apply_exit_qty_step(requested);
+        if (oqp < 100.0 - kFullPercentEps) {
+            requested = apply_percent_exit_qty_step(requested, avail);
+        }
         double res = std::min(requested, avail);
-        if (res <= kQtyEpsilon) continue;  // nothing left to reserve; leave deferred
+        if (res <= kQtyEpsilon) {
+            // The live-placement path declines this zero-capacity sibling.
+            // Deferred legs already exist in pending_orders_, so neutralize
+            // the doomed object for the remainder of this broker scan and
+            // compact it at the caller's normal safe point.
+            o.qty = 0.0;
+            o.qty_percent = 0.0;
+            o.limit_price = std::numeric_limits<double>::quiet_NaN();
+            o.stop_price = std::numeric_limits<double>::quiet_NaN();
+            o.profit_ticks = std::numeric_limits<double>::quiet_NaN();
+            o.loss_ticks = std::numeric_limits<double>::quiet_NaN();
+            o.trail_points = std::numeric_limits<double>::quiet_NaN();
+            o.trail_price = std::numeric_limits<double>::quiet_NaN();
+            o.trail_offset = std::numeric_limits<double>::quiet_NaN();
+            zero_reservation_indices.push_back(i);
+            continue;
+        }
         o.qty = res;
         // Keep qty_percent consistent with the qty we just froze. A deferred
         // 100% sibling capped here to the remaining slice must not keep

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -790,10 +790,13 @@ void BacktestEngine::run(const Bar* bars, int n) {
 
 
 // --- run_magnified_bar ---
-void BacktestEngine::run_magnified_bar(const std::vector<Bar>& sub_bars, int64_t script_bar_ts) {
+void BacktestEngine::run_magnified_bar(
+        const std::vector<Bar>& sub_bars, int64_t script_bar_ts,
+        bool caller_completed_on_boundary) {
     if (sub_bars.empty()) return;
     if (calc_on_order_fills_) {
-        run_magnified_bar_calc_on_order_fills(sub_bars, script_bar_ts);
+        run_magnified_bar_calc_on_order_fills(
+            sub_bars, script_bar_ts, caller_completed_on_boundary);
         return;
     }
 
@@ -851,7 +854,18 @@ void BacktestEngine::run_magnified_bar(const std::vector<Bar>& sub_bars, int64_t
 
         // Feed security evaluators with each sub-bar
         for (auto& state : security_eval_states_) {
-            feed_security_eval_state(state, sb);
+            if (caller_completed_on_boundary
+                && state.publish_gate_tf_seconds > 0
+                && si == total_sub - 1) {
+                // This retained input belongs to the next caller. The outer
+                // loop feeds it after the completed chart body dispatches.
+                continue;
+            }
+            feed_security_eval_state(
+                state, sb,
+                caller_completed_on_boundary
+                    ? si == total_sub - 2
+                    : si == total_sub - 1);
         }
 
         if (real_bar_magnifier_mode) {
@@ -935,7 +949,8 @@ void BacktestEngine::run_magnified_bar(const std::vector<Bar>& sub_bars, int64_t
 
 void BacktestEngine::run_magnified_bar_calc_on_order_fills(
         const std::vector<Bar>& sub_bars,
-        int64_t script_bar_ts) {
+        int64_t script_bar_ts,
+        bool caller_completed_on_boundary) {
     if (sub_bars.empty()) return;
 
     struct BrokerTick {
@@ -972,13 +987,23 @@ void BacktestEngine::run_magnified_bar_calc_on_order_fills(
 
     std::vector<BrokerTick> ticks;
     std::vector<double> samples;
-    for (const Bar& sb : sub_bars) {
+    for (int si = 0; si < total_sub; ++si) {
+        const Bar& sb = sub_bars[static_cast<std::size_t>(si)];
         // Historical script executions see the completed security state for
         // the script bar. Feeding all committed lower-TF bars before taking
         // the script-state checkpoint mirrors the standard path, where
         // security evaluators are fed before dispatch_bar.
         for (auto& state : security_eval_states_) {
-            feed_security_eval_state(state, sb);
+            if (caller_completed_on_boundary
+                && state.publish_gate_tf_seconds > 0
+                && si == total_sub - 1) {
+                continue;
+            }
+            feed_security_eval_state(
+                state, sb,
+                caller_completed_on_boundary
+                    ? si == total_sub - 2
+                    : si == total_sub - 1);
         }
 
         if (real_lower_tf) {
@@ -1198,6 +1223,25 @@ void BacktestEngine::run(const Bar* input_bars, int n_input,
     // script_tf defaults to input_tf if not provided (strategy runs on the data's timeframe)
     std::string effective_script_tf = script_tf.empty() ? effective_input_tf : script_tf;
 
+#ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+    if (aux_security_feed_enabled()) {
+        if (bar_magnifier) {
+            throw std::runtime_error(
+                "auxiliary request.security feed cannot share the bar-magnifier path");
+        }
+        if (effective_input_tf.empty() || effective_script_tf.empty()
+            || effective_input_tf != effective_script_tf) {
+            throw std::runtime_error(
+                "auxiliary request.security feed requires native chart input_tf == script_tf");
+        }
+        security_input_tf_ = aux_security_input_tf_;
+    } else {
+        security_input_tf_ = effective_input_tf;
+    }
+#else
+    security_input_tf_ = effective_input_tf;
+#endif
+
     // Store parameters
     input_tf_ = effective_input_tf;
     script_tf_ = effective_script_tf;
@@ -1246,11 +1290,19 @@ void BacktestEngine::run(const Bar* input_bars, int n_input,
     // any future reset that releases).
     equity_curve_.reserve((size_t)std::max(expected_script_bars, 0));
 
-    validate_security_timeframes(effective_input_tf);
+    validate_security_timeframes(security_input_tf_);
 
-    init_security_eval_states_for_run(effective_input_tf);
-    prepare_historical_security_lookahead_projections(
-        input_bars, n_input, effective_input_tf);
+    init_security_eval_states_for_run(security_input_tf_);
+#ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+    if (aux_security_feed_enabled()) {
+        prepare_aux_security_chart_ranges(input_bars, n_input,
+                                          effective_script_tf);
+    } else
+#endif
+    {
+        prepare_historical_security_lookahead_projections(
+            input_bars, n_input, effective_input_tf);
+    }
 
     if (!needs_aggregation && !bar_magnifier) {
         run_simple_bar_loop(input_bars, n_input);
@@ -1259,11 +1311,20 @@ void BacktestEngine::run(const Bar* input_bars, int n_input,
                                  expected_script_bars);
     }
     clear_historical_security_lookahead_projections();
+#ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+    clear_aux_security_chart_ranges();
+#endif
     } catch (const std::exception& e) {
         clear_historical_security_lookahead_projections();
+#ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+        clear_aux_security_chart_ranges();
+#endif
         last_error_ = e.what();
     } catch (...) {
         clear_historical_security_lookahead_projections();
+#ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+        clear_aux_security_chart_ranges();
+#endif
         last_error_ = "unknown error during BacktestEngine::run";
     }
 }
@@ -1483,9 +1544,18 @@ void BacktestEngine::run_simple_bar_loop(const Bar* input_bars, int n_input) {
         // chain is wiped after the first fire).
         pending_close_qty_in_bar_ = 0.0;
 
-        // Feed security evaluators
-        for (auto& state : security_eval_states_) {
-            feed_security_eval_state(state, input_bars[i]);
+        // Feed security evaluators. On the split-feed path only the finer
+        // auxiliary slice advances request.security; the native chart bar is
+        // never passed to a security evaluator.
+#ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+        if (aux_security_feed_enabled()) {
+            feed_aux_security_for_chart_bar(i);
+        } else
+#endif
+        {
+            for (auto& state : security_eval_states_) {
+                feed_security_eval_state(state, input_bars[i]);
+            }
         }
 
         // Update session predicates for session.ismarket / isfirstbar / islastbar.
@@ -1537,13 +1607,25 @@ void BacktestEngine::run_aggregation_bar_loop(const Bar* input_bars, int n_input
     int emitted_script_bars = 0;
 
     for (int i = 0; i < n_input; ++i) {
+        // Finer lookahead_on publication needs the chart aggregator's real
+        // completion event. Eager completion feeds the current child normally;
+        // boundary fallback replays the completed caller before the retained
+        // next-caller child is evaluated.
+        AggregatedBar ab = script_tf_agg_.feed(input_bars[i]);
+        const bool completed_on_boundary = ab.is_complete
+            && tf_change(ab.bar.timestamp, input_bars[i].timestamp, script_tf_,
+                         syminfo_.timezone, syminfo_.session);
         if (!bar_magnifier) {
             for (auto& state : security_eval_states_) {
-                feed_security_eval_state(state, input_bars[i]);
+                if (completed_on_boundary
+                    && state.publish_gate_tf_seconds > 0) {
+                    publish_security_eval_state_at_calling_boundary(state);
+                } else {
+                    feed_security_eval_state(
+                        state, input_bars[i], ab.is_complete);
+                }
             }
         }
-
-        AggregatedBar ab = script_tf_agg_.feed(input_bars[i]);
 
         if (bar_magnifier) {
             group_sub_bars.push_back(input_bars[i]);
@@ -1583,7 +1665,8 @@ void BacktestEngine::run_aggregation_bar_loop(const Bar* input_bars, int n_input
                                                             group_sub_bars.front().timestamp);
                 session_isfirstbar_ = session_ismarket_ && !prev_in_session_;
                 session_islastbar_  = false;  // not deterministic in magnifier mode without lookahead
-                run_magnified_bar(group_sub_bars, script_bar_ts);
+                run_magnified_bar(
+                    group_sub_bars, script_bar_ts, completed_on_boundary);
                 prev_in_session_ = session_ismarket_;
                 group_sub_bars.clear();
             } else {
@@ -1612,6 +1695,19 @@ void BacktestEngine::run_aggregation_bar_loop(const Bar* input_bars, int n_input
             update_equity_extremes();
             record_equity_point(script_bar_ts);
             prev_bar_timestamp_ = current_bar_.timestamp;
+        }
+        if (completed_on_boundary) {
+            // The boundary-triggering input was retained by the chart
+            // aggregator for the next caller. Feed it only after the completed
+            // caller's chart body, and only to the finer lookahead_on states
+            // that were replayed/deferred above. Other security states kept
+            // their established feed order and cadence.
+            for (auto& state : security_eval_states_) {
+                if (state.publish_gate_tf_seconds > 0) {
+                    feed_security_eval_state(
+                        state, input_bars[i], /*calling_bar_complete=*/false);
+                }
+            }
         }
     }
 }

--- a/src/engine_security.cpp
+++ b/src/engine_security.cpp
@@ -4,7 +4,6 @@
 
 #include "engine_internal.hpp"
 
-#include <pineforge/session_time.hpp>
 #include <pineforge/ta.hpp>
 #include <pineforge/timeframe.hpp>
 
@@ -15,29 +14,6 @@
 #include <unordered_set>
 
 namespace pineforge {
-namespace {
-// Mirror of the aggregator's intraday clock in timeframe.cpp: ms that the
-// symbol clock (tz + session open) has removed from the epoch grid at `ts`.
-// Must stay arithmetic-identical to TimeframeAggregator's intraday_clock_ms().
-int64_t syminfo_clock_shift_ms(int64_t ts, const std::string& tz,
-                               const std::string& session) {
-    if ((tz.empty() || tz == "UTC" || tz == "Etc/UTC")
-        && (session.empty() || session == "24x7")) return 0;
-    int64_t day_open = calendar_day_open_local_ms(ts, tz);
-    int64_t shift = day_open - (day_open / kMsPerDay) * kMsPerDay;
-    if (!(session.empty() || session == "24x7")) {
-        int digits = 0, value = 0;
-        for (char c : session) {
-            if (c >= '0' && c <= '9') {
-                value = value * 10 + (c - '0');
-                if (++digits >= 4) break;
-            } else if (digits > 0) break;
-        }
-        shift -= static_cast<int64_t>((value / 100) * 60 + (value % 100)) * 60000;
-    }
-    return shift;
-}
-}  // namespace
 
 using namespace internal;
 
@@ -54,22 +30,25 @@ void BacktestEngine::register_security_eval(int sec_id, const std::string& reque
     state.lookahead_on = lookahead_on;
     state.heikinashi = heikinashi;
 
-    if (!input_tf.empty()) {
+    const std::string& evaluator_input_tf =
+        security_input_tf_.empty() ? input_tf : security_input_tf_;
+    if (!evaluator_input_tf.empty()) {
         int lower_ratio = 0;
         int lower_seconds = 0;
-        if (supports_lower_tf_emulation(input_tf, requested_tf, &lower_ratio, &lower_seconds)) {
+        if (supports_lower_tf_emulation(evaluator_input_tf, requested_tf,
+                                        &lower_ratio, &lower_seconds)) {
             ensure_supported_lower_tf_emulation_flags(lookahead_on, gaps_on);
             state.lower_tf_requested = true;
             state.lower_tf_emulation = true;
             state.lower_tf_ratio = lower_ratio;
             state.lower_tf_seconds = lower_seconds;
         } else {
-            int ratio = tf_ratio(input_tf, requested_tf);
+            int ratio = tf_ratio(evaluator_input_tf, requested_tf);
             if (ratio > 1) {
-                state.aggregator = TimeframeAggregator(requested_tf, input_tf,
+                state.aggregator = TimeframeAggregator(requested_tf, evaluator_input_tf,
                     syminfo_.timezone, syminfo_.session);
             } else if (ratio == -1) {
-                state.aggregator = TimeframeAggregator(requested_tf, input_tf,
+                state.aggregator = TimeframeAggregator(requested_tf, evaluator_input_tf,
                     syminfo_.timezone, syminfo_.session);
             }
             // ratio <= 0: passthrough (same or unsupported lower TF)
@@ -288,6 +267,9 @@ void BacktestEngine::validate_security_timeframes(const std::string& input_tf) {
 
 
 bool BacktestEngine::security_series_slot_is_new(int sec_id) const {
+    if (security_history_publication_replay_) {
+        return false;
+    }
     for (const auto& state : security_eval_states_) {
         if (state.sec_id != sec_id) {
             continue;
@@ -295,6 +277,29 @@ bool BacktestEngine::security_series_slot_is_new(int sec_id) const {
         return !state.lookahead_on || state.current_sub_bar_count <= 1;
     }
     return true;
+}
+
+
+void BacktestEngine::publish_security_eval_state_at_calling_boundary(
+        SecurityEvalState& state) {
+    if (state.publish_gate_tf_seconds <= 0 || state.feed_count <= 0) {
+        return;
+    }
+
+    struct ReplayScope {
+        bool& active;
+        bool previous;
+        explicit ReplayScope(bool& flag)
+            : active(flag), previous(flag) { active = true; }
+        ~ReplayScope() { active = previous; }
+    } replay_scope(security_history_publication_replay_);
+
+    // The boundary-triggering input belongs to the next calling bar. Publish
+    // the final requested value that was already evaluated for the completed
+    // caller, before the chart body runs and before that retained input is fed.
+    // security_series_slot_is_new() returns false in this scope, so generated
+    // TA sites recompute the current slot instead of advancing their cadence.
+    evaluate_security(state.sec_id, state.current_bar, true);
 }
 
 
@@ -319,7 +324,9 @@ bool BacktestEngine::security_input_precedes_range_start(
 }
 
 
-void BacktestEngine::feed_security_eval_state(SecurityEvalState& state, const Bar& input_bar) {
+void BacktestEngine::feed_security_eval_state(
+        SecurityEvalState& state, const Bar& input_bar,
+        bool calling_bar_complete) {
     // Opt-in KI-55 HTF warmup parity (security_range_start_na_warmup run flag):
     //   (a) start every request.security aggregation at range_start_ms, not the
     //       feed start — drop every input bar whose HTF bucket opened before
@@ -384,7 +391,7 @@ void BacktestEngine::feed_security_eval_state(SecurityEvalState& state, const Ba
         // of 15). Pure count-based dispatch is preserved as a
         // secondary trigger so dense gap-free feeds still flush
         // promptly when the chunk fills.
-        int input_seconds = tf_to_seconds(input_tf_);
+        int input_seconds = tf_to_seconds(security_input_tf_);
         int script_seconds = script_tf_seconds_;
         if (input_seconds <= 0 || script_seconds <= 0) {
             // Cannot compute bucket math — fall back to original
@@ -479,7 +486,7 @@ void BacktestEngine::feed_security_eval_state(SecurityEvalState& state, const Ba
         if (synthetic_bars.empty()) {
             throw std::runtime_error(
                 "request.security lower TF emulation could not synthesize bars for requested "
-                + state.tf + " from input timeframe " + input_tf_
+                + state.tf + " from input timeframe " + security_input_tf_
             );
         }
         // Reset the sub-bar counter at the start of every chart bar's
@@ -562,22 +569,25 @@ void BacktestEngine::feed_security_eval_state(SecurityEvalState& state, const Ba
         // bookkeeping above stays driven by the real completion.
         bool publish = true;
         if (state.publish_gate_tf_seconds > 0 && script_tf_seconds_ > 0) {
-            // Anchor on the symbol clock (the same clock as the aggregators):
-            // exchange-tz seconds since local-midnight+session-open. With
-            // tz=UTC and no session the shift is zero, reducing to the
-            // previous epoch math bit-for-bit.
-            int64_t shifted = ab.bar.timestamp - syminfo_clock_shift_ms(
-                ab.bar.timestamp, syminfo_.timezone, syminfo_.session);
-            int64_t bucket_end_sec =
-                shifted / 1000 + state.publish_gate_tf_seconds;
-            publish = (bucket_end_sec % script_tf_seconds_) == 0;
+            // Merge finer-context history on the event that the calling chart
+            // aggregator actually completes. Unlike a fixed seconds modulus,
+            // this includes session-clipped calling bars.
+            // The requested-context evaluator still runs once
+            // per input update; only its is_complete publication signal is
+            // replaced.
+            publish = calling_bar_complete;
         }
         evaluate_security(state.sec_id, ab.bar, publish);
     } else if (state.lookahead_on) {
         if (state.heikinashi) apply_ha(ab.bar, /*commit=*/false);
         state.current_bar = ab.bar;
         state.eval_partial_count++;
-        evaluate_security(state.sec_id, ab.bar, false);
+        // A shortened calling bar can complete while the finer requested
+        // bucket is partial. Publish that current requested-context value to
+        // merged history without adding a second evaluator/TA dispatch.
+        const bool publish = state.publish_gate_tf_seconds > 0
+            && calling_bar_complete;
+        evaluate_security(state.sec_id, ab.bar, publish);
     } else {
         state.current_bar = ab.bar;
         if (state.gaps_on) {

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -2513,15 +2513,14 @@ bool BacktestEngine::compute_exit_reserved_qty(const std::string& from_entry,
         double requested_qty = live_pos_qty * (qp_io / 100.0);
         // TV floors each percent-derived PARTIAL exit lot to the
         // instrument lot step at placement (apply_exit_qty_step doc has
-        // the row-level evidence); the sub-step remainder stays open as
-        // a dust position instead of being closed by the final bracket
-        // leg. A dust-sized request that floors to zero is simply not
-        // placed (the kQtyEpsilon check below aborts), which is also
-        // TV's behaviour: dust positions carry no TP bracket and only
-        // ever close via reversal/close_all/margin call. Full-position
+        // the row-level evidence). Fractional-lot sub-step requests become
+        // zero and leave dust open. On integer-lot symbols, however, any
+        // positive request gets one minimum step while that capacity remains:
+        // a one-contract 50/50 pair reserves 1 + 0, not 0 + 0. Full-position
         // exits (qp == 100%) are left exact so they always flatten.
         if (qp_io < 100.0 - kFullPercentEps) {
-            requested_qty = apply_exit_qty_step(requested_qty);
+            requested_qty = apply_percent_exit_qty_step(
+                requested_qty, available_qty);
         }
         reserved_qty_out = std::min(requested_qty, available_qty);
     }

--- a/src/engine_stream.cpp
+++ b/src/engine_stream.cpp
@@ -29,6 +29,12 @@ bool BacktestEngine::stream_begin(const Bar* warmup_bars, int n_warmup,
             throw std::runtime_error(
                 "timestamped account-currency FX is not supported by streaming");
         }
+#ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+        if (aux_security_feed_enabled()) {
+            throw std::runtime_error(
+                "auxiliary request.security feed supports historical native-chart runs only");
+        }
+#endif
         if (stream_phase_ == StreamPhase::REALTIME) {
             throw std::runtime_error("stream is already realtime");
         }
@@ -288,19 +294,45 @@ void BacktestEngine::stream_feed_input_bar(const Bar& bar, bool had_tick) {
     ++diag_input_bars_processed_;
     last_bar_time_ = bar.timestamp;
 
-    for (auto& state : security_eval_states_) {
-        feed_security_eval_state(state, bar);
-    }
-
     if (!diag_needs_aggregation_) {
+        for (auto& state : security_eval_states_) {
+            feed_security_eval_state(state, bar);
+        }
         stream_dispatch_script_bar(bar, had_tick);
         return;
     }
 
+    // Feed the chart aggregator first so finer lookahead_on history receives
+    // the same real completion event that drives stream_dispatch_script_bar.
     AggregatedBar ab = script_tf_agg_.feed(bar);
     const bool completed_on_boundary = ab.is_complete
         && tf_change(ab.bar.timestamp, bar.timestamp, script_tf_,
                      syminfo_.timezone, syminfo_.session);
+    if (completed_on_boundary) {
+        for (auto& state : security_eval_states_) {
+            if (state.publish_gate_tf_seconds > 0) {
+                publish_security_eval_state_at_calling_boundary(state);
+            } else {
+                feed_security_eval_state(state, bar, ab.is_complete);
+            }
+        }
+
+        // The current input opened the next caller. Dispatch the completed
+        // caller while its actual final requested child is still visible,
+        // then evaluate the retained input for the next caller.
+        stream_dispatch_script_bar(ab.bar, stream_script_bar_had_tick_);
+        stream_script_bar_had_tick_ = had_tick;
+        for (auto& state : security_eval_states_) {
+            if (state.publish_gate_tf_seconds > 0) {
+                feed_security_eval_state(
+                    state, bar, /*calling_bar_complete=*/false);
+            }
+        }
+        return;
+    }
+    for (auto& state : security_eval_states_) {
+        feed_security_eval_state(state, bar, ab.is_complete);
+    }
     if (completed_on_boundary) {
         // The current input bar opened the next bucket; the aggregator emitted
         // the preceding partial bucket before retaining this bar as its new

--- a/src/timeframe.cpp
+++ b/src/timeframe.cpp
@@ -683,8 +683,33 @@ AggregatedBar feed_ratio_mode(const Bar& input_bar, FeedState s,
         if (boundary) {
             if (s.current_emitted_complete) {
                 feed_reset_current(s, input_bar);
+                // The incoming bar can be both the first child of a fresh HTF
+                // bucket and the final chart bar of a declared session.  The
+                // normal session-close check below is reached only after a
+                // same-bucket merge, so this singleton shape used to remain
+                // partial until the next session's first bar crossed the
+                // boundary.  TradingView finalizes the clipped HTF bucket on
+                // this caller.  Keep the eager path limited to a genuinely
+                // coarser fixed intraday target on a real session; equal-TF,
+                // 24x7 and calendar aggregation retain their existing paths.
+                bool singleton_session_final = false;
+                if (ratio > 1 && input_seconds > 0
+                    && target_seconds < kSecPerDay
+                    && has_trading_session(asess)) {
+                    const int64_t next_ms =
+                        input_bar.timestamp + input_seconds * 1000;
+                    singleton_session_final =
+                        next_ms >= session_period_last_traded_close_ms(
+                            input_bar.timestamp, atz, asess,
+                            CalendarPeriod::DAY);
+                }
+                if (singleton_session_final) {
+                    s.last_completed_bar = s.current_bar;
+                    s.has_completed = true;
+                    s.current_emitted_complete = true;
+                }
                 result.bar = s.current_bar;
-                result.is_complete = false;
+                result.is_complete = singleton_session_final;
                 result.sub_bar_count = s.sub_bar_count;
                 return result;
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,7 @@ set(TEST_SOURCES
     test_c_abi_setters
     test_fills_edge
     test_default_qty_signal_freeze
+    test_qty_step_epsilon_floor
     test_margin_admission_gate
     test_reversal_admission_float_guard
     test_direct_short_reversal_affordability

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,7 @@ set(TEST_SOURCES
     test_multi_tier_exit_precedence
     test_same_tick_multi_entry_race
     test_full_close_while_pyramiding
+    test_integer_lot_percent_exit_min_step
     test_deferred_flip_carry_close_only
     test_close_all_coqueued_entry
     test_same_bar_add_exit_coverage

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_SOURCES
     test_dmi_parity
     test_integration
     test_request_security
+    test_aux_security_feed
     test_historical_security_lookahead_projection
     test_pooc_global_full_exit
     test_security_range_start_na_warmup
@@ -168,6 +169,12 @@ add_test(
     NAME test_run_strategy_identity
     COMMAND ${Python3_EXECUTABLE}
             ${PROJECT_SOURCE_DIR}/scripts/test_run_strategy_identity.py
+)
+
+add_test(
+    NAME test_run_strategy_aux_feed
+    COMMAND ${Python3_EXECUTABLE}
+            ${PROJECT_SOURCE_DIR}/scripts/test_run_strategy_aux_feed.py
 )
 
 # When PINEFORGE_ENABLE_COVERAGE is ON we also instrument the test

--- a/tests/test_aux_security_feed.cpp
+++ b/tests/test_aux_security_feed.cpp
@@ -1,0 +1,226 @@
+#include <pineforge/pineforge.h>
+#include <pineforge/engine.hpp>
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using namespace pineforge;
+
+#ifndef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
+#error "auxiliary security feed test requires the V1 feature probe"
+#endif
+
+namespace {
+
+class SplitFeedProbe final : public BacktestEngine {
+public:
+    std::vector<int> chart_indexes;
+    std::vector<double> chart_closes;
+    std::vector<double> security_closes;
+    std::vector<double> security_at_chart_close;
+    std::vector<double> lower_tf_current;
+    std::vector<std::vector<double>> lower_tf_at_chart_close;
+    std::vector<int> completion_publishes_at_chart_close;
+    int completion_publish_count = 0;
+    double latest_security_close = na<double>();
+
+    void configure_security_evaluators() override {
+        security_eval_states_.clear();
+        // The generated form still passes input_tf_ here. The runtime must
+        // redirect registration to the installed auxiliary TF.
+        register_security_eval(0, "1", input_tf_, false, false);
+        register_security_lower_tf_eval(1, "1", input_tf_);
+        register_security_eval(2, "1", input_tf_, true, false);
+    }
+
+    void evaluate_security(int sec_id, const Bar& bar,
+                           bool is_complete) override {
+        if (sec_id == 0) {
+            if (!is_complete) return;
+            latest_security_close = bar.close;
+            security_closes.push_back(bar.close);
+        } else if (sec_id == 1) {
+            if (!is_complete) return;
+            if (security_lower_tf_sub_bar_index(1) == 0) {
+                lower_tf_current.clear();
+            }
+            lower_tf_current.push_back(bar.close);
+        } else if (sec_id == 2 && is_complete) {
+            completion_publish_count++;
+        }
+    }
+
+    void on_bar(const Bar& bar) override {
+        chart_indexes.push_back(bar_index_);
+        chart_closes.push_back(bar.close);
+        security_at_chart_close.push_back(latest_security_close);
+        lower_tf_at_chart_close.push_back(lower_tf_current);
+        completion_publishes_at_chart_close.push_back(
+            completion_publish_count);
+        if (bar_index_ == 0) strategy_entry("L", true);
+        if (bar_index_ == 1) strategy_close_all();
+    }
+
+};
+
+
+class OvernightLowerTfProbe final : public BacktestEngine {
+public:
+    std::vector<double> current;
+    std::vector<double> chart_array;
+
+    void configure_security_evaluators() override {
+        security_eval_states_.clear();
+        register_security_lower_tf_eval(0, "1", input_tf_);
+    }
+
+    void evaluate_security(int sec_id, const Bar& bar,
+                           bool is_complete) override {
+        if (sec_id != 0 || !is_complete) return;
+        if (security_lower_tf_sub_bar_index(0) == 0) current.clear();
+        current.push_back(bar.close);
+    }
+
+    void on_bar(const Bar&) override { chart_array = current; }
+};
+
+
+class RoutingOnlyProbe final : public BacktestEngine {
+public:
+    void on_bar(const Bar&) override {}
+};
+
+bool near(double a, double b) {
+    return std::abs(a - b) < 1e-9;
+}
+
+void test_native_chart_and_auxiliary_security_are_isolated() {
+    constexpr int64_t day1 = 1704205800000;  // 2024-01-02 09:30 America/New_York
+    constexpr int64_t day2 = 1704292200000;
+    constexpr int64_t day3 = 1704378600000;
+    constexpr int64_t day = 86400000;
+    constexpr int64_t minute = 60000;
+
+    const Bar chart[] = {
+        {100.0, 160.0, 90.0, 150.0, 1000.0, day1},
+        {200.0, 260.0, 190.0, 250.0, 2000.0, day2},
+        {300.0, 360.0, 290.0, 350.0, 3000.0, day3},
+    };
+    const Bar aux[] = {
+        {90.0, 90.0, 90.0, 90.0, 1.0, day1 - day},
+        {10.0, 11.5, 9.5, 11.0, 10.0, day1},
+        {11.0, 12.5, 10.5, 12.0, 11.0, day1 + minute},
+        {20.0, 21.5, 19.5, 21.0, 20.0, day2},
+        {21.0, 22.5, 20.5, 22.0, 21.0, day2 + minute},
+        {30.0, 31.5, 29.5, 31.0, 30.0, day3},
+        {31.0, 32.5, 30.5, 32.0, 31.0, day3 + minute},
+        {80.0, 80.0, 80.0, 80.0, 1.0, day3 + day},
+    };
+
+    SplitFeedProbe probe;
+    strategy_set_syminfo_timezone(
+        static_cast<pf_strategy_t>(&probe), "America/New_York");
+    strategy_set_syminfo_session(
+        static_cast<pf_strategy_t>(&probe), "0930-1600:23456");
+    const int installed = strategy_set_aux_security_feed(
+        static_cast<pf_strategy_t>(&probe),
+        reinterpret_cast<const pf_bar_t*>(aux), 8, "1");
+    assert(installed == 0);
+
+    probe.run(chart, 3, "1D", "1D", false, 4,
+              MagnifierDistribution::ENDPOINTS);
+    assert(probe.last_error().empty());
+
+    assert((probe.chart_indexes == std::vector<int>{0, 1, 2}));
+    assert((probe.chart_closes == std::vector<double>{150.0, 250.0, 350.0}));
+    assert((probe.security_closes
+            == std::vector<double>{11.0, 12.0, 21.0, 22.0, 31.0, 32.0}));
+    assert((probe.security_at_chart_close
+            == std::vector<double>{12.0, 22.0, 32.0}));
+    assert((probe.lower_tf_at_chart_close
+            == std::vector<std::vector<double>>{
+                {11.0, 12.0}, {21.0, 22.0}, {31.0, 32.0}}));
+    // Completion-aware security publication receives exactly the final
+    // auxiliary event of each native chart slice through the neutral bridge.
+    assert((probe.completion_publishes_at_chart_close
+            == std::vector<int>{1, 2, 3}));
+
+    // Orders created on chart bars fill at the next native chart opens. If
+    // the auxiliary feed contaminated the broker, these would be 20/30.
+    assert(probe.trade_count() == 1);
+    assert(near(probe.get_trade(0).entry_price, 200.0));
+    assert(near(probe.get_trade(0).exit_price, 300.0));
+    assert(probe.get_trade(0).entry_bar_index == 1);
+    assert(probe.get_trade(0).exit_bar_index == 2);
+}
+
+
+void test_aux_label_inside_native_span_without_chart_bar_fails() {
+    constexpr int64_t day1 = 1704205800000;
+    constexpr int64_t day2 = 1704292200000;
+    constexpr int64_t day3 = 1704378600000;
+    const Bar chart[] = {
+        {100.0, 101.0, 99.0, 100.0, 10.0, day1},
+        {300.0, 301.0, 299.0, 300.0, 10.0, day3},
+    };
+    const Bar aux[] = {
+        {1.0, 1.0, 1.0, 1.0, 1.0, day1},
+        {2.0, 2.0, 2.0, 2.0, 1.0, day2},
+        {3.0, 3.0, 3.0, 3.0, 1.0, day3},
+    };
+
+    RoutingOnlyProbe probe;
+    strategy_set_syminfo_timezone(
+        static_cast<pf_strategy_t>(&probe), "America/New_York");
+    strategy_set_syminfo_session(
+        static_cast<pf_strategy_t>(&probe), "0930-1600:23456");
+    assert(strategy_set_aux_security_feed(
+        static_cast<pf_strategy_t>(&probe),
+        reinterpret_cast<const pf_bar_t*>(aux), 3, "1") == 0);
+
+    probe.run(chart, 2, "1D", "1D", false, 4,
+              MagnifierDistribution::ENDPOINTS);
+    assert(probe.last_error().find(
+        "does not map to a native chart bar") != std::string::npos);
+}
+
+
+void test_overnight_daily_lower_tf_array_does_not_split_at_utc_midnight() {
+    constexpr int64_t session_open = 1704232800000;  // 2024-01-02 17:00 NY
+    constexpr int64_t minute = 60000;
+    const Bar chart[] = {
+        {100.0, 105.0, 95.0, 102.0, 1000.0, session_open},
+    };
+    const Bar aux[] = {
+        {1.0, 1.0, 1.0, 1.0, 1.0, session_open},
+        {2.0, 2.0, 2.0, 2.0, 1.0, session_open + 119 * minute},
+        {3.0, 3.0, 3.0, 3.0, 1.0, session_open + 120 * minute},
+        {4.0, 4.0, 4.0, 4.0, 1.0, session_open + 1439 * minute},
+    };
+
+    OvernightLowerTfProbe probe;
+    strategy_set_syminfo_timezone(
+        static_cast<pf_strategy_t>(&probe), "America/New_York");
+    strategy_set_syminfo_session(
+        static_cast<pf_strategy_t>(&probe), "1700-1700:23456");
+    assert(strategy_set_aux_security_feed(
+        static_cast<pf_strategy_t>(&probe),
+        reinterpret_cast<const pf_bar_t*>(aux), 4, "1") == 0);
+
+    probe.run(chart, 1, "1D", "1D", false, 4,
+              MagnifierDistribution::ENDPOINTS);
+    assert(probe.last_error().empty());
+    assert((probe.chart_array == std::vector<double>{1.0, 2.0, 3.0, 4.0}));
+}
+
+}  // namespace
+
+int main() {
+    test_native_chart_and_auxiliary_security_are_isolated();
+    test_aux_label_inside_native_span_without_chart_bar_fails();
+    test_overnight_daily_lower_tf_array_does_not_split_at_utc_midnight();
+    return 0;
+}

--- a/tests/test_aux_security_feed.cpp
+++ b/tests/test_aux_security_feed.cpp
@@ -158,18 +158,17 @@ void test_native_chart_and_auxiliary_security_are_isolated() {
 }
 
 
-void test_aux_label_inside_native_span_without_chart_bar_fails() {
-    constexpr int64_t day1 = 1704205800000;
-    constexpr int64_t day2 = 1704292200000;
-    constexpr int64_t day3 = 1704378600000;
+void test_intraday_aux_label_inside_native_span_without_chart_bar_fails() {
+    constexpr int64_t bar1 = 1704205800000;  // 2024-01-02 09:30 New York
+    constexpr int64_t hour = 3600000;
     const Bar chart[] = {
-        {100.0, 101.0, 99.0, 100.0, 10.0, day1},
-        {300.0, 301.0, 299.0, 300.0, 10.0, day3},
+        {100.0, 101.0, 99.0, 100.0, 10.0, bar1},
+        {300.0, 301.0, 299.0, 300.0, 10.0, bar1 + 2 * hour},
     };
     const Bar aux[] = {
-        {1.0, 1.0, 1.0, 1.0, 1.0, day1},
-        {2.0, 2.0, 2.0, 2.0, 1.0, day2},
-        {3.0, 3.0, 3.0, 3.0, 1.0, day3},
+        {1.0, 1.0, 1.0, 1.0, 1.0, bar1},
+        {2.0, 2.0, 2.0, 2.0, 1.0, bar1 + hour},
+        {3.0, 3.0, 3.0, 3.0, 1.0, bar1 + 2 * hour},
     };
 
     RoutingOnlyProbe probe;
@@ -181,7 +180,7 @@ void test_aux_label_inside_native_span_without_chart_bar_fails() {
         static_cast<pf_strategy_t>(&probe),
         reinterpret_cast<const pf_bar_t*>(aux), 3, "1") == 0);
 
-    probe.run(chart, 2, "1D", "1D", false, 4,
+    probe.run(chart, 2, "60", "60", false, 4,
               MagnifierDistribution::ENDPOINTS);
     assert(probe.last_error().find(
         "does not map to a native chart bar") != std::string::npos);
@@ -231,34 +230,43 @@ void test_nifty_muhurat_shifted_open_maps_by_trading_date() {
 }
 
 
-void test_nifty_absent_trading_date_still_fails() {
-    constexpr int64_t regular_day = 1635911100000;  // 2021-11-03 09:15 IST
-    constexpr int64_t next_regular_day = 1636343100000;  // 2021-11-08 09:15 IST
+void test_nq_labor_day_sessions_coalesce_into_native_interval() {
+    constexpr int64_t sunday_native = 1693778400000;  // 2023-09-03 17:00 CDT
+    constexpr int64_t labor_reopen = 1693864800000;  // 2023-09-04 17:00 CDT
+    constexpr int64_t tuesday_native = 1693951200000;  // 2023-09-05 17:00 CDT
+    constexpr int64_t minute = 60000;
     const Bar chart[] = {
-        {100.0, 101.0, 99.0, 100.0, 10.0, regular_day},
-        {300.0, 301.0, 299.0, 300.0, 10.0, next_regular_day},
+        {100.0, 160.0, 90.0, 150.0, 1000.0, sunday_native},
+        {300.0, 360.0, 290.0, 350.0, 3000.0, tuesday_native},
     };
     const Bar aux[] = {
-        {1.0, 1.0, 1.0, 1.0, 1.0, regular_day},
-        // An auxiliary Muhurat trading date with no native chart bar remains
-        // an interior hole and must not be silently attached to a neighbour.
-        {2.0, 2.0, 2.0, 2.0, 1.0, 1636029420000},
-        {3.0, 3.0, 3.0, 3.0, 1.0, next_regular_day},
+        {10.0, 11.5, 9.5, 11.0, 10.0, sunday_native},
+        {11.0, 12.5, 10.5, 12.0, 11.0, sunday_native + minute},
+        // TradingView's native Labor-Day candle legitimately coalesces the
+        // Sunday session and Monday-evening reopen under sunday_native.
+        {20.0, 21.5, 19.5, 21.0, 20.0, labor_reopen},
+        {21.0, 22.5, 20.5, 22.0, 21.0, labor_reopen + minute},
+        {30.0, 31.5, 29.5, 31.0, 30.0, tuesday_native},
+        {31.0, 32.5, 30.5, 32.0, 31.0, tuesday_native + minute},
     };
 
-    RoutingOnlyProbe probe;
+    SplitFeedProbe probe;
     strategy_set_syminfo_timezone(
-        static_cast<pf_strategy_t>(&probe), "Asia/Kolkata");
+        static_cast<pf_strategy_t>(&probe), "America/Chicago");
     strategy_set_syminfo_session(
-        static_cast<pf_strategy_t>(&probe), "0915-1530:23456");
+        static_cast<pf_strategy_t>(&probe), "1700-1600:23456");
     assert(strategy_set_aux_security_feed(
         static_cast<pf_strategy_t>(&probe),
-        reinterpret_cast<const pf_bar_t*>(aux), 3, "1") == 0);
+        reinterpret_cast<const pf_bar_t*>(aux), 6, "1") == 0);
 
     probe.run(chart, 2, "1D", "1D", false, 4,
               MagnifierDistribution::ENDPOINTS);
-    assert(probe.last_error().find(
-        "does not map to a native chart bar") != std::string::npos);
+    assert(probe.last_error().empty());
+    assert((probe.chart_closes == std::vector<double>{150.0, 350.0}));
+    assert((probe.security_at_chart_close == std::vector<double>{22.0, 32.0}));
+    assert((probe.lower_tf_at_chart_close
+            == std::vector<std::vector<double>>{
+                {11.0, 12.0, 21.0, 22.0}, {31.0, 32.0}}));
 }
 
 
@@ -294,9 +302,9 @@ void test_overnight_daily_lower_tf_array_does_not_split_at_utc_midnight() {
 
 int main() {
     test_native_chart_and_auxiliary_security_are_isolated();
-    test_aux_label_inside_native_span_without_chart_bar_fails();
+    test_intraday_aux_label_inside_native_span_without_chart_bar_fails();
     test_nifty_muhurat_shifted_open_maps_by_trading_date();
-    test_nifty_absent_trading_date_still_fails();
+    test_nq_labor_day_sessions_coalesce_into_native_interval();
     test_overnight_daily_lower_tf_array_does_not_split_at_utc_midnight();
     return 0;
 }

--- a/tests/test_aux_security_feed.cpp
+++ b/tests/test_aux_security_feed.cpp
@@ -188,6 +188,80 @@ void test_aux_label_inside_native_span_without_chart_bar_fails() {
 }
 
 
+void test_nifty_muhurat_shifted_open_maps_by_trading_date() {
+    constexpr int64_t regular_day = 1635911100000;  // 2021-11-03 09:15 IST
+    constexpr int64_t muhurat_native = 1636029000000;  // 2021-11-04 18:00 IST
+    constexpr int64_t next_regular_day = 1636343100000;  // 2021-11-08 09:15 IST
+    constexpr int64_t minute = 60000;
+    const Bar chart[] = {
+        {100.0, 160.0, 90.0, 150.0, 1000.0, regular_day},
+        {200.0, 260.0, 190.0, 250.0, 2000.0, muhurat_native},
+        {300.0, 360.0, 290.0, 350.0, 3000.0, next_regular_day},
+    };
+    const Bar aux[] = {
+        {10.0, 11.5, 9.5, 11.0, 10.0, regular_day},
+        {11.0, 12.5, 10.5, 12.0, 11.0, regular_day + minute},
+        // The immutable NSE tape starts seven minutes after the native
+        // Muhurat chart label.  Both belong to the same trading date even
+        // though neither timestamp is the configured 09:15 session open.
+        {20.0, 21.5, 19.5, 21.0, 20.0, 1636029420000},
+        {21.0, 22.5, 20.5, 22.0, 21.0, 1636033620000},
+        {30.0, 31.5, 29.5, 31.0, 30.0, next_regular_day},
+        {31.0, 32.5, 30.5, 32.0, 31.0, next_regular_day + minute},
+    };
+
+    SplitFeedProbe probe;
+    strategy_set_syminfo_timezone(
+        static_cast<pf_strategy_t>(&probe), "Asia/Kolkata");
+    strategy_set_syminfo_session(
+        static_cast<pf_strategy_t>(&probe), "0915-1530:23456");
+    assert(strategy_set_aux_security_feed(
+        static_cast<pf_strategy_t>(&probe),
+        reinterpret_cast<const pf_bar_t*>(aux), 6, "1") == 0);
+
+    probe.run(chart, 3, "1D", "1D", false, 4,
+              MagnifierDistribution::ENDPOINTS);
+    assert(probe.last_error().empty());
+    assert((probe.chart_closes == std::vector<double>{150.0, 250.0, 350.0}));
+    assert((probe.security_at_chart_close
+            == std::vector<double>{12.0, 22.0, 32.0}));
+    assert((probe.lower_tf_at_chart_close
+            == std::vector<std::vector<double>>{
+                {11.0, 12.0}, {21.0, 22.0}, {31.0, 32.0}}));
+}
+
+
+void test_nifty_absent_trading_date_still_fails() {
+    constexpr int64_t regular_day = 1635911100000;  // 2021-11-03 09:15 IST
+    constexpr int64_t next_regular_day = 1636343100000;  // 2021-11-08 09:15 IST
+    const Bar chart[] = {
+        {100.0, 101.0, 99.0, 100.0, 10.0, regular_day},
+        {300.0, 301.0, 299.0, 300.0, 10.0, next_regular_day},
+    };
+    const Bar aux[] = {
+        {1.0, 1.0, 1.0, 1.0, 1.0, regular_day},
+        // An auxiliary Muhurat trading date with no native chart bar remains
+        // an interior hole and must not be silently attached to a neighbour.
+        {2.0, 2.0, 2.0, 2.0, 1.0, 1636029420000},
+        {3.0, 3.0, 3.0, 3.0, 1.0, next_regular_day},
+    };
+
+    RoutingOnlyProbe probe;
+    strategy_set_syminfo_timezone(
+        static_cast<pf_strategy_t>(&probe), "Asia/Kolkata");
+    strategy_set_syminfo_session(
+        static_cast<pf_strategy_t>(&probe), "0915-1530:23456");
+    assert(strategy_set_aux_security_feed(
+        static_cast<pf_strategy_t>(&probe),
+        reinterpret_cast<const pf_bar_t*>(aux), 3, "1") == 0);
+
+    probe.run(chart, 2, "1D", "1D", false, 4,
+              MagnifierDistribution::ENDPOINTS);
+    assert(probe.last_error().find(
+        "does not map to a native chart bar") != std::string::npos);
+}
+
+
 void test_overnight_daily_lower_tf_array_does_not_split_at_utc_midnight() {
     constexpr int64_t session_open = 1704232800000;  // 2024-01-02 17:00 NY
     constexpr int64_t minute = 60000;
@@ -221,6 +295,8 @@ void test_overnight_daily_lower_tf_array_does_not_split_at_utc_midnight() {
 int main() {
     test_native_chart_and_auxiliary_security_are_isolated();
     test_aux_label_inside_native_span_without_chart_bar_fails();
+    test_nifty_muhurat_shifted_open_maps_by_trading_date();
+    test_nifty_absent_trading_date_still_fails();
     test_overnight_daily_lower_tf_array_does_not_split_at_utc_midnight();
     return 0;
 }

--- a/tests/test_default_qty_signal_freeze.cpp
+++ b/tests/test_default_qty_signal_freeze.cpp
@@ -365,8 +365,8 @@ void test_reversal_bracket_binding_survives_freeze() {
 //
 // The raw placement quantity is 6279.0000001 / 1000 = 6.2790000001.  Its
 // first qty_step floor is 6.2790.  In binary64, that result divided by 0.0001
-// is 62789.999999..., so applying the same floor a SECOND time produces
-// 6.2789.  frozen_default_qty is already exchange-quantized at placement;
+// is 62789.999999.... Epsilon-safe regular flooring is now idempotent at that
+// boundary, while frozen_default_qty remains exchange-quantized at placement;
 // dispatch must preserve it in the position, physical lot, and logical id
 // ledger.  Before the C fix, apply_market_order_fill handed the frozen value
 // to enter_market_from_flat as an ordinary FIXED quantity and it was floored
@@ -429,7 +429,7 @@ void test_frozen_true_flat_market_dispatch_is_not_refloored() {
 
     // Pin the test's binary boundary independently of the dispatch result.
     CHECK_NEAR(eng.one_floor_qty(), 6.2790, 1e-12);
-    CHECK_NEAR(eng.two_floor_qty(), 6.2789, 1e-12);
+    CHECK_NEAR(eng.two_floor_qty(), 6.2790, 1e-12);
 
     CHECK(eng.position_side() == PositionSide::LONG);
     CHECK_NEAR(eng.position_qty(), 6.2790, 1e-12);
@@ -515,7 +515,7 @@ void test_frozen_market_reversal_is_not_refloored() {
     eng.run(bars.data(), static_cast<int>(bars.size()));
 
     CHECK_NEAR(eng.one_floor_qty(), 6.2790, 1e-12);
-    CHECK_NEAR(eng.two_floor_qty(), 6.2789, 1e-12);
+    CHECK_NEAR(eng.two_floor_qty(), 6.2790, 1e-12);
     CHECK(eng.position_side() == PositionSide::LONG);
     CHECK_NEAR(eng.position_qty(), 6.2790, 1e-12);
     CHECK(eng.live_lot_count() == 1);

--- a/tests/test_htf_session_close_completion.cpp
+++ b/tests/test_htf_session_close_completion.cpp
@@ -68,9 +68,16 @@ int64_t edt_ms(int y, int m, int d, int h, int mi) {
     return utc_ms(y, m, d, h + 4, mi);
 }
 
+// India Standard Time is fixed UTC+05:30.
+int64_t ist_ms(int y, int m, int d, int h, int mi) {
+    return utc_ms(y, m, d, h, mi) - (5 * 60 + 30) * 60 * 1000;
+}
+
 const std::string NY  = "America/New_York";
 const std::string RTH = "0930-1600";
 const std::string FX  = "1700-1700";
+const std::string IST = "Asia/Kolkata";
+const std::string NIFTY = "0915-1530";
 const int64_t k15m = 15 * 60 * 1000;
 
 Bar bar_at(int64_t ts) {
@@ -100,6 +107,12 @@ std::vector<Completion> drive(TimeframeAggregator& agg, const std::vector<int64_
 // RTH 15m grid for one date: 09:30 .. 15:45 ET (26 bars).
 void rth_day(std::vector<int64_t>& v, int y, int m, int d) {
     for (int i = 0; i < 26; ++i) v.push_back(edt_ms(y, m, d, 9, 30) + i * k15m);
+}
+
+// NSE cash session: 09:15 .. 15:15 IST (25 bars).  On a 60m grid the first
+// six buckets contain four children and the final 15:15 bucket is a singleton.
+void nifty_day(std::vector<int64_t>& v, int y, int m, int d) {
+    for (int i = 0; i < 25; ++i) v.push_back(ist_ms(y, m, d, 9, 15) + i * k15m);
 }
 
 // Forex 15m grid for one session-day: 17:00 ET on (y,m,d) .. 16:45 ET next day.
@@ -163,6 +176,97 @@ static void test_last_traded_close_helper() {
 }
 
 // ─── A: RTH intraday buckets ──────────────────────────────────────────────────
+
+static void test_nifty_60_singleton_session_final_completes_immediately() {
+    std::printf("test_nifty_60_singleton_session_final_completes_immediately\n");
+    TimeframeAggregator agg("60", "15", IST, NIFTY);
+    std::vector<int64_t> ts;
+    nifty_day(ts, 2025, 5, 29);
+    nifty_day(ts, 2025, 5, 30);
+    auto c = drive(agg, ts);
+
+    const Completion* first_final =
+        completion_at(c, ist_ms(2025, 5, 29, 15, 15));
+    CHECK(first_final != nullptr);
+    if (first_final) {
+        CHECK(first_final->subs == 1);
+        CHECK_EQ_MS(first_final->bucket_ts,
+                    ist_ms(2025, 5, 29, 15, 15));
+    }
+    CHECK(!has_completion_at(c, ist_ms(2025, 5, 30, 9, 15)));
+    CHECK(has_completion_at(c, ist_ms(2025, 5, 30, 15, 15)));
+    CHECK(c.size() == 14);
+}
+
+static void test_nifty_60_ordinary_full_hour_unchanged() {
+    std::printf("test_nifty_60_ordinary_full_hour_unchanged\n");
+    TimeframeAggregator agg("60", "15", IST, NIFTY);
+    std::vector<int64_t> ts;
+    nifty_day(ts, 2025, 5, 29);
+    auto c = drive(agg, ts);
+
+    const Completion* first =
+        completion_at(c, ist_ms(2025, 5, 29, 10, 0));
+    CHECK(first != nullptr);
+    if (first) {
+        CHECK(first->subs == 4);
+        CHECK_EQ_MS(first->bucket_ts, ist_ms(2025, 5, 29, 9, 15));
+    }
+    const Completion* last_full =
+        completion_at(c, ist_ms(2025, 5, 29, 15, 0));
+    CHECK(last_full != nullptr);
+    if (last_full) {
+        CHECK(last_full->subs == 4);
+        CHECK_EQ_MS(last_full->bucket_ts,
+                    ist_ms(2025, 5, 29, 14, 15));
+    }
+    CHECK(c.size() == 7);
+}
+
+static void test_aapl_60_two_child_session_final_unchanged() {
+    std::printf("test_aapl_60_two_child_session_final_unchanged\n");
+    TimeframeAggregator agg("60", "15", NY, RTH);
+    std::vector<int64_t> ts;
+    rth_day(ts, 2025, 6, 2);
+    rth_day(ts, 2025, 6, 3);
+    auto c = drive(agg, ts);
+
+    CHECK(!has_completion_at(c, edt_ms(2025, 6, 2, 15, 30)));
+    const Completion* final =
+        completion_at(c, edt_ms(2025, 6, 2, 15, 45));
+    CHECK(final != nullptr);
+    if (final) {
+        CHECK(final->subs == 2);
+        CHECK_EQ_MS(final->bucket_ts, edt_ms(2025, 6, 2, 15, 30));
+    }
+    CHECK(!has_completion_at(c, edt_ms(2025, 6, 3, 9, 30)));
+    CHECK(c.size() == 14);
+}
+
+static void test_24x7_singleton_boundary_remains_lazy() {
+    std::printf("test_24x7_singleton_boundary_remains_lazy\n");
+    TimeframeAggregator agg("60", "15", "UTC", "24x7");
+    const std::vector<int64_t> ts = {
+        utc_ms(2025, 6, 2, 0, 0),
+        utc_ms(2025, 6, 2, 0, 15),
+        utc_ms(2025, 6, 2, 0, 30),
+        utc_ms(2025, 6, 2, 0, 45),
+        utc_ms(2025, 6, 2, 1, 0),
+        utc_ms(2025, 6, 2, 2, 0),
+    };
+    auto c = drive(agg, ts);
+
+    CHECK(has_completion_at(c, utc_ms(2025, 6, 2, 0, 45)));
+    CHECK(!has_completion_at(c, utc_ms(2025, 6, 2, 1, 0)));
+    const Completion* lazy =
+        completion_at(c, utc_ms(2025, 6, 2, 2, 0));
+    CHECK(lazy != nullptr);
+    if (lazy) {
+        CHECK(lazy->subs == 1);
+        CHECK_EQ_MS(lazy->bucket_ts, utc_ms(2025, 6, 2, 1, 0));
+    }
+    CHECK(c.size() == 2);
+}
 
 static void test_rth_240_completes_at_1545() {
     std::printf("test_rth_240_completes_at_1545\n");
@@ -403,6 +507,10 @@ static void test_24x7_identity() {
 
 int main() {
     test_last_traded_close_helper();
+    test_nifty_60_singleton_session_final_completes_immediately();
+    test_nifty_60_ordinary_full_hour_unchanged();
+    test_aapl_60_two_child_session_final_unchanged();
+    test_24x7_singleton_boundary_remains_lazy();
     test_rth_240_completes_at_1545();
     test_rth_60_and_45_complete_at_1545();
     test_rth_week_completes_friday_1545();

--- a/tests/test_integer_lot_percent_exit_min_step.cpp
+++ b/tests/test_integer_lot_percent_exit_min_step.cpp
@@ -1,0 +1,259 @@
+/*
+ * Integer-lot percent-exit reservation.
+ *
+ * TradingView allocates one minimum contract/share to the first positive
+ * qty_percent strategy.exit request when a one-lot position cannot be split.
+ * A later sibling sees the consumed capacity and reserves nothing. The rule
+ * is identical for long/short and for brackets armed before the entry fills,
+ * while fractional lots, explicit qty, full-percent exits and already-on-grid
+ * percent quantities retain their established behavior.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+#include <pineforge/bar.hpp>
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+static constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+static bool near(double a, double b, double tol = 1e-9) {
+    return std::fabs(a - b) <= tol;
+}
+
+static Bar bar(double o, double h, double l, double c, int i) {
+    Bar b;
+    b.open = o;
+    b.high = h;
+    b.low = l;
+    b.close = c;
+    b.volume = 1000.0;
+    b.timestamp = static_cast<int64_t>(i + 1) * 60'000;
+    return b;
+}
+
+class ExitProbe : public BacktestEngine {
+public:
+    enum class Mode {
+        LiveLong,
+        LiveShort,
+        DeferredLong,
+        FractionalLot,
+        ExplicitQty,
+        FullPercent,
+        OnGridPartial,
+    };
+
+    explicit ExitProbe(Mode mode) : mode_(mode) {
+        initial_capital_ = 1'000'000.0;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = mode == Mode::OnGridPartial ? 4.0 : 1.0;
+        qty_step_ = mode == Mode::FractionalLot ? 0.1 : 1.0;
+        syminfo_.qty_step = qty_step_;
+        syminfo_.pointvalue = 1.0;
+        slippage_ = 0;
+        commission_value_ = 0;
+        pyramiding_ = 1;
+    }
+
+    int armed_exit_count = -1;
+    std::vector<double> armed_qty;
+
+    double position() const { return signed_position_size(); }
+
+    void on_bar(const Bar&) override {
+        const bool short_mode = mode_ == Mode::LiveShort;
+        const bool deferred = mode_ == Mode::DeferredLong;
+
+        if (bar_index_ == 0) {
+            strategy_entry("E", !short_mode, kNaN, kNaN, kNaN, "entry");
+            if (deferred) {
+                arm_percent_pair(/*is_short=*/false);
+            }
+        }
+
+        if (bar_index_ == 1) {
+            if (!deferred) {
+                if (mode_ == Mode::ExplicitQty) {
+                    strategy_exit("X", "E", 105.0, kNaN,
+                                  kNaN, kNaN, kNaN, 50.0,
+                                  "explicit", 0.5, "");
+                } else if (mode_ == Mode::FullPercent) {
+                    strategy_exit("X", "E", 105.0, kNaN,
+                                  kNaN, kNaN, kNaN, 100.0,
+                                  "full", kNaN, "");
+                } else if (mode_ == Mode::OnGridPartial) {
+                    strategy_exit("X", "E", 105.0, kNaN,
+                                  kNaN, kNaN, kNaN, 50.0,
+                                  "on-grid", kNaN, "");
+                } else {
+                    arm_percent_pair(short_mode);
+                }
+            }
+            snapshot_exits();
+        }
+    }
+
+private:
+    Mode mode_;
+
+    void arm_percent_pair(bool is_short) {
+        const double first_limit = is_short ? 95.0 : 105.0;
+        const double second_limit = is_short ? 90.0 : 110.0;
+        strategy_exit("TP1", "E", first_limit, kNaN,
+                      kNaN, kNaN, kNaN, 50.0, "tp1", kNaN, "");
+        strategy_exit("TP2", "E", second_limit, kNaN,
+                      kNaN, kNaN, kNaN, 50.0, "tp2", kNaN, "");
+    }
+
+    void snapshot_exits() {
+        armed_exit_count = 0;
+        armed_qty.clear();
+        for (const PendingOrder& order : pending_orders_) {
+            if (order.type != OrderType::EXIT) continue;
+            ++armed_exit_count;
+            armed_qty.push_back(order.qty);
+        }
+    }
+};
+
+static void test_live_one_lot_pair_long() {
+    std::printf("test_live_one_lot_pair_long\n");
+    ExitProbe p(ExitProbe::Mode::LiveLong);
+    const Bar bars[] = {
+        bar(100, 100, 100, 100, 0),
+        bar(100, 100, 100, 100, 1),
+        bar(100, 106, 99, 104, 2),
+    };
+    p.run(bars, 3);
+    CHECK(p.armed_exit_count == 1);
+    CHECK(p.armed_qty.size() == 1);
+    if (!p.armed_qty.empty()) CHECK(near(p.armed_qty[0], 1.0));
+    CHECK(p.trade_count() == 1);
+    if (p.trade_count() == 1) {
+        CHECK(near(p.get_trade(0).qty, 1.0));
+        CHECK(near(p.get_trade(0).exit_price, 105.0));
+    }
+    CHECK(near(p.position(), 0.0));
+}
+
+static void test_live_one_lot_pair_short() {
+    std::printf("test_live_one_lot_pair_short\n");
+    ExitProbe p(ExitProbe::Mode::LiveShort);
+    const Bar bars[] = {
+        bar(100, 100, 100, 100, 0),
+        bar(100, 100, 100, 100, 1),
+        bar(100, 101, 94, 96, 2),
+    };
+    p.run(bars, 3);
+    CHECK(p.armed_exit_count == 1);
+    CHECK(p.armed_qty.size() == 1);
+    if (!p.armed_qty.empty()) CHECK(near(p.armed_qty[0], 1.0));
+    CHECK(p.trade_count() == 1);
+    if (p.trade_count() == 1) {
+        CHECK(near(p.get_trade(0).qty, 1.0));
+        CHECK(near(p.get_trade(0).exit_price, 95.0));
+    }
+    CHECK(near(p.position(), 0.0));
+}
+
+static void test_deferred_one_lot_pair() {
+    std::printf("test_deferred_one_lot_pair\n");
+    ExitProbe p(ExitProbe::Mode::DeferredLong);
+    const Bar bars[] = {
+        bar(100, 100, 100, 100, 0),
+        bar(100, 100, 100, 100, 1),
+        bar(100, 106, 99, 104, 2),
+    };
+    p.run(bars, 3);
+    CHECK(p.armed_exit_count == 1);
+    CHECK(p.armed_qty.size() == 1);
+    if (!p.armed_qty.empty()) CHECK(near(p.armed_qty[0], 1.0));
+    CHECK(p.trade_count() == 1);
+    if (p.trade_count() == 1) {
+        CHECK(near(p.get_trade(0).qty, 1.0));
+        CHECK(near(p.get_trade(0).exit_price, 105.0));
+    }
+    CHECK(near(p.position(), 0.0));
+}
+
+static void test_fractional_lot_keeps_two_half_exits() {
+    std::printf("test_fractional_lot_keeps_two_half_exits\n");
+    ExitProbe p(ExitProbe::Mode::FractionalLot);
+    const Bar bars[] = {
+        bar(100, 100, 100, 100, 0),
+        bar(100, 100, 100, 100, 1),
+        bar(100, 106, 99, 104, 2),
+    };
+    p.run(bars, 3);
+    CHECK(p.armed_exit_count == 2);
+    CHECK(p.armed_qty.size() == 2);
+    if (p.armed_qty.size() == 2) {
+        CHECK(near(p.armed_qty[0], 0.5));
+        CHECK(near(p.armed_qty[1], 0.5));
+    }
+    CHECK(p.trade_count() == 1);
+    if (p.trade_count() == 1) CHECK(near(p.get_trade(0).qty, 0.5));
+    CHECK(near(p.position(), 0.5));
+}
+
+static void test_explicit_full_and_on_grid_controls() {
+    std::printf("test_explicit_full_and_on_grid_controls\n");
+    struct Case {
+        ExitProbe::Mode mode;
+        double expected_armed;
+        double expected_closed;
+        double expected_remaining;
+    };
+    const Case cases[] = {
+        {ExitProbe::Mode::ExplicitQty, 0.5, 0.5, 0.5},
+        {ExitProbe::Mode::FullPercent, 1.0, 1.0, 0.0},
+        {ExitProbe::Mode::OnGridPartial, 2.0, 2.0, 2.0},
+    };
+    for (const Case& c : cases) {
+        ExitProbe p(c.mode);
+        const Bar bars[] = {
+            bar(100, 100, 100, 100, 0),
+            bar(100, 100, 100, 100, 1),
+            bar(100, 106, 99, 104, 2),
+        };
+        p.run(bars, 3);
+        CHECK(p.armed_exit_count == 1);
+        CHECK(p.armed_qty.size() == 1);
+        if (!p.armed_qty.empty()) {
+            CHECK(near(p.armed_qty[0], c.expected_armed));
+        }
+        CHECK(p.trade_count() == 1);
+        if (p.trade_count() == 1) {
+            CHECK(near(p.get_trade(0).qty, c.expected_closed));
+        }
+        CHECK(near(p.position(), c.expected_remaining));
+    }
+}
+
+int main() {
+    test_live_one_lot_pair_long();
+    test_live_one_lot_pair_short();
+    test_deferred_one_lot_pair();
+    test_fractional_lot_keeps_two_half_exits();
+    test_explicit_full_and_on_grid_controls();
+    std::printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_qty_step_epsilon_floor.cpp
+++ b/tests/test_qty_step_epsilon_floor.cpp
@@ -1,0 +1,160 @@
+/*
+ * test_qty_step_epsilon_floor.cpp — regular-order quantity flooring must
+ * absorb only binary64 residue immediately below a lot boundary.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+#include <pineforge/bar.hpp>
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+
+namespace {
+
+int tests_passed = 0;
+int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_NEAR(actual, expected, tolerance)                                \
+    do {                                                                       \
+        const double a_ = (actual);                                            \
+        const double e_ = (expected);                                          \
+        if (!(std::fabs(a_ - e_) <= (tolerance))) {                            \
+            std::printf("  FAIL  %s:%d  %.17g != %.17g\n",                    \
+                        __FILE__, __LINE__, a_, e_);                            \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+class QtyFloorProbe : public BacktestEngine {
+public:
+    void on_bar(const Bar&) override {}
+
+    double regular(double qty, double step) {
+        qty_step_ = step;
+        return apply_qty_step(qty);
+    }
+
+    double partial_exit(double qty, double step) {
+        qty_step_ = step;
+        return apply_exit_qty_step(qty);
+    }
+};
+
+void test_binary_residue_snaps_without_broad_rounding() {
+    std::printf("test_binary_residue_snaps_without_broad_rounding\n");
+    QtyFloorProbe probe;
+
+    // In binary64, 1 / 1e-5 is 99999.99999999999. A plain floor loses one
+    // complete lot and returns 0.99999.
+    CHECK(1.0 / 1e-5 < 100000.0);
+    CHECK_NEAR(probe.regular(1.0, 1e-5), 1.0, 0.0);
+
+    // More than 1e-6 of a lot below the next integer is genuine off-grid
+    // quantity and must still floor, never ceil.
+    constexpr double step = 1e-5;
+    const double outside = (100000.0 - 2e-6) * step;
+    CHECK(100000.0 - outside / step > 1e-6);
+    CHECK_NEAR(probe.regular(outside, step), 99999.0 * step, 1e-15);
+    CHECK(probe.regular(outside, step) < outside);
+}
+
+void test_integer_and_fractional_controls() {
+    std::printf("test_integer_and_fractional_controls\n");
+    QtyFloorProbe probe;
+
+    CHECK_NEAR(probe.regular(7.0, 1.0), 7.0, 0.0);
+    CHECK_NEAR(probe.regular(7.75, 1.0), 7.0, 0.0);
+    CHECK_NEAR(probe.regular(1.234567, 0.0001), 1.2345, 1e-15);
+
+    // Preserve the caller's original representation when flooring is a
+    // no-op; reconstructing 3 * 0.1 would be one ulp larger than 0.3.
+    CHECK(probe.regular(0.3, 0.1) == 0.3);
+
+    // Factor A remains a distinct helper and retains its established
+    // epsilon-safe 50% exit quantity.
+    CHECK_NEAR(probe.partial_exit(0.5, 1e-5), 0.5, 0.0);
+}
+
+class TwoHalfExitProbe : public BacktestEngine {
+public:
+    TwoHalfExitProbe() {
+        initial_capital_ = 1'000'000.0;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        qty_step_ = 1e-5;
+        syminfo_mintick_ = 0.01;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        margin_call_enabled_ = false;
+    }
+
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry("L", true, kNaN, kNaN, 1.0);
+        } else if (bar_index_ == 1 && position_side_ == PositionSide::LONG) {
+            strategy_exit("TP", "L", 110.0, kNaN,
+                          kNaN, kNaN, kNaN, 50.0, "half-limit");
+            strategy_exit("SL", "L", kNaN, 95.0,
+                          kNaN, kNaN, kNaN, 50.0, "half-stop");
+        }
+    }
+
+    double position_qty() const { return position_qty_; }
+};
+
+Bar bar(int64_t timestamp, double open, double high, double low,
+        double close) {
+    return Bar{open, high, low, close, 1000.0, timestamp};
+}
+
+void test_two_half_exits_flat_exactly() {
+    std::printf("test_two_half_exits_flat_exactly\n");
+    TwoHalfExitProbe probe;
+    std::vector<Bar> bars = {
+        bar(1'000, 100.0, 100.0, 100.0, 100.0),
+        bar(2'000, 100.0, 101.0,  99.0, 100.0),
+        bar(3'000, 100.0, 112.0,  94.0, 100.0),
+        bar(4'000, 100.0, 101.0,  99.0, 100.0),
+    };
+    probe.run(bars.data(), static_cast<int>(bars.size()));
+
+    CHECK_NEAR(probe.position_qty(), 0.0, 0.0);
+    CHECK(probe.trade_count() == 2);
+    double closed_qty = 0.0;
+    for (int i = 0; i < probe.trade_count(); ++i) {
+        const Trade& trade = probe.get_trade(i);
+        CHECK_NEAR(trade.qty, 0.5, 0.0);
+        closed_qty += trade.qty;
+    }
+    CHECK_NEAR(closed_qty, 1.0, 0.0);
+}
+
+}  // namespace
+
+int main() {
+    std::printf("--- qty_step_epsilon_floor ---\n");
+    test_binary_residue_snaps_without_broad_rounding();
+    test_integer_and_fractional_controls();
+    test_two_half_exits_flat_exactly();
+    std::printf("\n=== Results: %d passed, %d failed ===\n",
+                tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_request_security.cpp
+++ b/tests/test_request_security.cpp
@@ -570,21 +570,36 @@ void test_request_security_helper_ta_uses_security_local_state() {
 class FinerTfPublishGateHarness : public BacktestEngine {
 public:
     std::vector<int64_t> published_ts;  // bucket-start ts of is_complete evals
+    std::vector<int64_t> evaluated_ts;  // every requested-context evaluation
+    std::vector<int64_t> chart_last_eval_ts;
+    int requested_new_slot_count = 0;
+    int64_t last_evaluated_ts = -1;
 
-    explicit FinerTfPublishGateHarness(bool lookahead_on) {
-        register_security_eval(0, "5", "1", lookahead_on, false);
+    explicit FinerTfPublishGateHarness(bool lookahead_on,
+                                       const char* requested_tf = "5",
+                                       const char* input_tf = "1") {
+        register_security_eval(0, requested_tf, input_tf, lookahead_on, false);
     }
 
     void evaluate_security(int sec_id, const Bar& bar, bool is_complete) override {
-        if (sec_id != 0 || !is_complete) {
+        if (sec_id != 0) {
             return;
         }
-        published_ts.push_back(bar.timestamp);
+        if (security_series_slot_is_new(sec_id)) {
+            ++requested_new_slot_count;
+        }
+        evaluated_ts.push_back(bar.timestamp);
+        last_evaluated_ts = bar.timestamp;
+        if (is_complete) {
+            published_ts.push_back(bar.timestamp);
+        }
     }
 
     void on_bar(const Bar& bar) override {
         (void)bar;
+        chart_last_eval_ts.push_back(last_evaluated_ts);
     }
+
 };
 
 void test_request_security_finer_tf_publish_gate_is_lookahead_only() {
@@ -624,6 +639,140 @@ void test_request_security_finer_tf_publish_gate_is_lookahead_only() {
             + std::to_string(on.published_ts.size()));
 
     std::cout << "test_request_security_finer_tf_publish_gate_is_lookahead_only passed.\n";
+}
+
+void test_request_security_finer_tf_publishes_on_shortened_calling_bar() {
+    // A UTC RTH session has 26 x 15m input bars. On a 60m chart the last
+    // calling bar is session-clipped to 15:30-16:00 and completes on the
+    // 15:45 input bar. Its close is not on the fixed 60m modulus from the
+    // 09:30 session anchor, which is the distinction this factor measures.
+    constexpr int64_t session_open = 9 * 3'600'000 + 30 * 60'000;
+    std::vector<Bar> input_bars;
+    input_bars.reserve(26);
+    for (int i = 0; i < 26; ++i) {
+        const double px = 100.0 + i;
+        input_bars.push_back(
+            {px, px + 1.0, px - 1.0, px + 0.5, 10.0,
+             session_open + static_cast<int64_t>(i) * 900'000});
+    }
+
+    FinerTfPublishGateHarness on(
+        /*lookahead_on=*/true, /*requested_tf=*/"15", /*input_tf=*/"15");
+    on.set_syminfo_timezone("UTC");
+    on.set_syminfo_session("0930-1600:23456");
+    on.run(input_bars.data(), static_cast<int>(input_bars.size()),
+           "15", "60", false, 4, MagnifierDistribution::ENDPOINTS);
+    require(on.last_error().empty(),
+            "shortened-session lookahead_on run should succeed: "
+                + on.last_error());
+    require(on.evaluated_ts.size() == input_bars.size(),
+            "factor A must preserve one requested-context evaluation per "
+            "15m input bar");
+
+    const std::vector<int64_t> regular_calling_closes = {
+        session_open + 3 * 900'000,
+        session_open + 7 * 900'000,
+        session_open + 11 * 900'000,
+        session_open + 15 * 900'000,
+        session_open + 19 * 900'000,
+        session_open + 23 * 900'000,
+    };
+    std::vector<int64_t> expected_on = regular_calling_closes;
+    expected_on.push_back(session_open + 25 * 900'000);
+    require(on.published_ts == expected_on,
+            "lookahead_on history must publish on every real 60m calling-bar "
+            "completion, including the 15:30-16:00 clipped bar");
+
+    FinerTfPublishGateHarness off(
+        /*lookahead_on=*/false, /*requested_tf=*/"15", /*input_tf=*/"15");
+    off.set_syminfo_timezone("UTC");
+    off.set_syminfo_session("0930-1600:23456");
+    off.run(input_bars.data(), static_cast<int>(input_bars.size()),
+            "15", "60", false, 4, MagnifierDistribution::ENDPOINTS);
+    require(off.last_error().empty(),
+            "shortened-session lookahead_off run should succeed: "
+                + off.last_error());
+    require(off.evaluated_ts.size() == input_bars.size(),
+            "lookahead_off requested-context evaluation cadence must remain "
+            "one per 15m input bar");
+    require(off.published_ts == off.evaluated_ts,
+            "lookahead_off must keep publishing every completed finer period");
+
+    std::cout << "test_request_security_finer_tf_publishes_on_shortened_calling_bar passed.\n";
+}
+
+void test_request_security_finer_tf_sparse_boundary_uses_final_caller_child() {
+    // Day 0 deliberately omits hour 23. The first day-1 input therefore makes
+    // the 1D chart aggregator complete day 0 through its boundary fallback
+    // while retaining day1 00:00 as the first child of the next caller. The
+    // merged history publication must use day0 22:00, never the retained bar.
+    constexpr int64_t day0 = 1'704'067'200'000;  // 2024-01-01 00:00 UTC
+    constexpr int64_t hour = 3'600'000;
+    std::vector<Bar> input_bars;
+    input_bars.reserve(24);
+    for (int i = 0; i <= 22; ++i) {
+        const double px = 100.0 + i;
+        input_bars.push_back(
+            {px, px, px, px, 1.0, day0 + static_cast<int64_t>(i) * hour});
+    }
+    input_bars.push_back(
+        {200.0, 200.0, 200.0, 200.0, 1.0, day0 + 24 * hour});
+    const int64_t final_day0_child = day0 + 22 * hour;
+
+    auto check = [&](FinerTfPublishGateHarness& harness,
+                     const std::string& path, bool expects_replay) {
+        require(harness.last_error().empty(),
+                path + " sparse-boundary run should succeed: "
+                    + harness.last_error());
+        require(harness.requested_new_slot_count
+                    == static_cast<int>(input_bars.size()),
+                path + " must advance requested-context TA slots exactly once "
+                    "per real input despite boundary publication");
+        require(harness.published_ts
+                    == std::vector<int64_t>{final_day0_child},
+                path + " must publish day0's actual final child, not day1 00:00");
+        require(harness.chart_last_eval_ts.size() == 1
+                    && harness.chart_last_eval_ts[0] == final_day0_child,
+                path + " chart dispatch must occur before the retained day1 "
+                    "input becomes visible");
+        const std::size_t expected_evals = input_bars.size()
+            + (expects_replay ? 1U : 0U);
+        require(harness.evaluated_ts.size() == expected_evals,
+                path + " boundary replay count must match its execution path");
+    };
+
+    FinerTfPublishGateHarness batch(
+        /*lookahead_on=*/true, /*requested_tf=*/"60", /*input_tf=*/"60");
+    batch.run(input_bars.data(), static_cast<int>(input_bars.size()),
+              "60", "1D", false, 4, MagnifierDistribution::ENDPOINTS);
+    check(batch, "batch", /*expects_replay=*/true);
+
+    FinerTfPublishGateHarness magnified(
+        /*lookahead_on=*/true, /*requested_tf=*/"60", /*input_tf=*/"60");
+    magnified.run(input_bars.data(), static_cast<int>(input_bars.size()),
+                  "60", "1D", true, 4,
+                  MagnifierDistribution::ENDPOINTS);
+    check(magnified, "magnified batch", /*expects_replay=*/false);
+
+    FinerTfPublishGateHarness stream(
+        /*lookahead_on=*/true, /*requested_tf=*/"60", /*input_tf=*/"60");
+    require(stream.stream_begin(input_bars.data(), 23, "60", "1D"),
+            "stream sparse-boundary warmup should succeed: "
+                + stream.last_error());
+    // Keep the already-configured chart/security aggregators on their 24x7
+    // day grid, but tell the normalized stream that the deliberately absent
+    // 23:00 interval is closed so it is not synthesized as a carry bar.
+    stream.set_syminfo_session("0000-2300:1234567");
+    require(stream.stream_push_tick(
+                TradeTick{day0 + 24 * hour, 1, 200.0, 1.0}),
+            "stream sparse-boundary day1 tick should be accepted: "
+                + stream.last_error());
+    require(stream.stream_advance_time(day0 + 25 * hour),
+            "stream sparse-boundary day1 input should finalize: "
+                + stream.last_error());
+    check(stream, "stream", /*expects_replay=*/true);
+
+    std::cout << "test_request_security_finer_tf_sparse_boundary_uses_final_caller_child passed.\n";
 }
 
 // KI-33 cadence guard: on the 1m-magnifier path (input_tf="1",
@@ -812,6 +961,8 @@ int main() {
     test_request_security_hook_dispatches_completed_values();
     test_request_security_magnifier_coarser_tf_cadence();
     test_request_security_finer_tf_publish_gate_is_lookahead_only();
+    test_request_security_finer_tf_publishes_on_shortened_calling_bar();
+    test_request_security_finer_tf_sparse_boundary_uses_final_caller_child();
     test_request_security_lower_tf_requires_finer_input_bars();
     test_request_security_emulates_ratio_divisible_lower_tf();
     test_request_security_lower_tf_emulation_rejects_unsupported_flags();


### PR DESCRIPTION
Engine fixes from the parity campaign's factorial analysis (factors H·A·B fusion): calendar/session auxiliary routing, singleton HTF bucket completion at session close, and integer/epsilon lot flooring.

## Deterministic pr-gate: PASS

Measured on Cloudflare Containers over the pinned parity population, judged against the campaign bootstrap baseline (`pineforge-parity-baseline-20260828`).

| surface | result |
|---|---|
| **hard** — ETHUSDT.P@15 (engine corpus + scraped ETH, 708 probes) | **0 regressions** |
| **target** — every other symbol/timeframe pooled (3495 probes) | **net +32** (62 entered excellent+strong, 30 left) |
| coverage | 4221 / 4221 comparable, 0 unmeasured |
| **verdict** | **PASS** |

- baseline: engine `8103ef752d84b51ad90954b0f517c912909c51ec`, codegen `5575a185a0f27d760c317781de3a84e275e38e17`, snapshot `48577493a02d36af0cea69c1376762159b0d107ae9a698643114ca6d45d1b08e`
- candidate: engine `9d40d287af800761095296a0bb59cea073e6e577` (codegen unchanged), snapshot `efdcf479673677b49343f7695235b5f41e8f038564169e938be297a7d9584bd2`
- gate verdict recorded on the campaign control plane: experiment `pr-gate-pineforge-parity`, event `verdict-9d40d287af80-5575a185a0f2-308878d017a0`

**Follow-up:** the candidate build hit 68 engine-errors (probes where the new code fails to transpile/compile) vs the baseline's ~4 — none on the ETH hard surface, so the gate still passes, but worth a look before the next iteration.

## Commits
- `9d40d28` fix: tolerate binary residue in lot flooring
- `02580b9` fix: reserve minimum integer lot for percent exits
- `24e8535` fix: complete singleton HTF buckets at session close
- `47573c2` fix: route calendar auxiliary feeds by native intervals
- `190ac14` fix: route auxiliary calendar bars by trading period
- `1328721` factorial: e [engine]
