### PR TITLE
ci: add a `build` gate check the branch ruleset can match

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,19 @@ jobs:
           ASAN_OPTIONS: detect_leaks=1:halt_on_error=1:abort_on_error=1
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: ctest --test-dir build-asan --output-on-failure
+
+  # The branch ruleset requires a status check named `build`, but the matrix
+  # job above reports as `build (ubuntu-latest, Release)` and friends -- a bare
+  # `build` context never appears, so the merge stays BLOCKED even with every
+  # check green. This gate carries that exact name and passes only when every
+  # matrix build did, satisfying the ruleset without loosening it.
+  build-gate:
+    name: build
+    needs: [build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every matrix build to have passed
+        run: |
+          echo "matrix build result: ${{ needs.build.result }}"
+          test "${{ needs.build.result }}" = "success"


### PR DESCRIPTION
## Why
`main`'s ruleset requires a status check named **`build`**, but `ci.yml`'s build job is a matrix, so it reports as `build (ubuntu-latest, Release)`, `build (macos-latest, Debug)`, etc. There is no bare `build` context, so GitHub waits forever for it and PRs sit **BLOCKED** even with every check green — e.g. **#167** (all 7 checks SUCCESS, `mergeStateStatus: BLOCKED`).

## What
A tiny `build-gate` job named `build` that `needs: [build]` and passes only when the matrix build succeeded (`if: always()` so it always *reports*). This makes the required `build` context exist without loosening the rule or touching the matrix.

After this merges, existing PRs (#167) pick up the gate on their next sync and unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAQsvZ3d6FsBUU6Y253SYg