### PR TITLE
fix: key calendar aux routing by the covered session

### DIFF
--- a/include/pineforge/timeframe.hpp
+++ b/include/pineforge/timeframe.hpp
@@ -130,6 +130,15 @@ int64_t session_period_open_ms(int64_t ms, const std::string& tz,
                                const std::string& session,
                                CalendarPeriod period);
 
+/// The session instant a native CALENDAR chart stamp covers. A stamp inside
+/// its session-day returns unchanged. A stamp in the inter-session gap (at
+/// or after its session-day's close) covers the session about to open --
+/// OANDA stamps daily FX/metal bars at the 17:00 ET break under an
+/// 1800-1700 session -- and rolls forward to the next session-day's open.
+/// ""/24x7 sessions have no gap and always return `ms` unchanged.
+int64_t session_covered_instant_ms(int64_t ms, const std::string& tz,
+                                   const std::string& session);
+
 /// Exclusive close (Unix ms) of the symbol's D/W/M bar that contains `ms`:
 /// DAY -> session-day open + session length (16:00 ET on equities, the next
 /// 17:00 ET on forex, next midnight on 24x7); WEEK / MONTH -> the open of

--- a/src/engine_aux_security.cpp
+++ b/src/engine_aux_security.cpp
@@ -111,10 +111,17 @@ void BacktestEngine::prepare_aux_security_chart_ranges(
     std::vector<int64_t> chart_route_keys;
     chart_route_keys.reserve(static_cast<std::size_t>(n_chart));
     for (int i = 0; i < n_chart; ++i) {
+        // Key each native bar by the session it COVERS: OANDA stamps daily
+        // bars at the 17:00 ET break, one hour before the 1800-1700 session
+        // the bar actually carries, and the raw stamp would key one session
+        // too early -- the tail prefilter below would then drop the last
+        // bar's entire slice as beyond last_chart_key.
         const int64_t key = calendar_chart
-            ? session_period_open_ms(chart_bars[i].timestamp,
-                                     syminfo_.timezone, syminfo_.session,
-                                     chart_period)
+            ? session_period_open_ms(
+                  session_covered_instant_ms(chart_bars[i].timestamp,
+                                             syminfo_.timezone,
+                                             syminfo_.session),
+                  syminfo_.timezone, syminfo_.session, chart_period)
             : chart_bars[i].timestamp;
         if (!chart_route_keys.empty() && key <= chart_route_keys.back()) {
             throw std::runtime_error(

--- a/src/timeframe.cpp
+++ b/src/timeframe.cpp
@@ -417,6 +417,17 @@ static int64_t session_day_close_real_ms(int64_t d, const std::string& tz,
          + static_cast<int64_t>(session_length_minutes(session)) * 60000;
 }
 
+int64_t session_covered_instant_ms(int64_t ms, const std::string& tz,
+                                   const std::string& session) {
+    const int64_t d = session_day_index(ms, tz, session);
+    // Inside the session-day (before its exclusive close): covered as-is.
+    // ""/24x7 sessions close exactly at the next open, so the gap is empty
+    // and every timestamp takes this branch.
+    if (ms < session_day_close_real_ms(d, tz, session)) return ms;
+    // In the gap after the close: the stamp covers the next session.
+    return session_day_open_real_ms(d + 1, tz, session);
+}
+
 int64_t session_period_close_ms(int64_t ms, const std::string& tz,
                                 const std::string& session,
                                 CalendarPeriod period) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -197,6 +197,10 @@ foreach(test_name ${TEST_SOURCES})
     # values in tests like test_ta_rma_warmup don't drift due to
     # contracted multiply-adds emitted in the test TU itself.
     target_compile_options(${test_name} PRIVATE -ffp-contract=off)
+    # Tests are assert()-based: strip NDEBUG (appended after the build-type
+    # flags, so it wins over Release's -DNDEBUG) or every assertion in the
+    # suite compiles to a no-op and ctest passes vacuously.
+    target_compile_options(${test_name} PRIVATE -UNDEBUG)
     if(PINEFORGE_ENABLE_COVERAGE)
         target_compile_options(${test_name} PRIVATE ${_pf_cov_test_flags})
     endif()
@@ -213,6 +217,7 @@ target_link_libraries(test_timezone_concurrency PRIVATE Threads::Threads)
 add_executable(test_c_abi test_c_abi.c)
 set_target_properties(test_c_abi PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(test_c_abi PRIVATE pineforge)
+target_compile_options(test_c_abi PRIVATE -UNDEBUG)
 if(PINEFORGE_ENABLE_COVERAGE)
     target_compile_options(test_c_abi PRIVATE ${_pf_cov_test_flags})
 endif()

--- a/tests/test_aux_security_feed.cpp
+++ b/tests/test_aux_security_feed.cpp
@@ -270,6 +270,58 @@ void test_nq_labor_day_sessions_coalesce_into_native_interval() {
 }
 
 
+void test_oanda_break_stamped_daily_bars_route_by_covered_session() {
+    // OANDA XAUUSD: session 1800-1700 ET, but the immutable daily tape stamps
+    // every bar at 17:00 ET -- inside the inter-session break, one hour BEFORE
+    // the session the bar covers.  Keying the stamp by session-day floor maps
+    // it to the PREVIOUS session, so the last chart bar's content rows read as
+    // beyond last_chart_key and the tail prefilter empties the final bar.
+    constexpr int64_t minute = 60000;
+    constexpr int64_t stamp_a = 1704751200000;  // Mon 2024-01-08 17:00 EST
+    constexpr int64_t open_a = 1704754800000;   // Mon 18:00 EST
+    constexpr int64_t stamp_b = 1704837600000;  // Tue 17:00 EST
+    constexpr int64_t open_b = 1704841200000;   // Tue 18:00 EST
+    constexpr int64_t stamp_c = 1704924000000;  // Wed 17:00 EST
+    constexpr int64_t open_c = 1704927600000;   // Wed 18:00 EST
+    constexpr int64_t lead = 1704733200000;     // Mon 12:00 EST (prior session)
+    constexpr int64_t trail = 1705014000000;    // Thu 18:00 EST (next session)
+    const Bar chart[] = {
+        {100.0, 160.0, 90.0, 150.0, 1000.0, stamp_a},
+        {200.0, 260.0, 190.0, 250.0, 2000.0, stamp_b},
+        {300.0, 360.0, 290.0, 350.0, 3000.0, stamp_c},
+    };
+    const Bar aux[] = {
+        {90.0, 90.0, 90.0, 90.0, 1.0, lead},
+        {10.0, 11.5, 9.5, 11.0, 10.0, open_a},
+        {11.0, 12.5, 10.5, 12.0, 11.0, open_a + minute},
+        {20.0, 21.5, 19.5, 21.0, 20.0, open_b},
+        {21.0, 22.5, 20.5, 22.0, 21.0, open_b + minute},
+        {30.0, 31.5, 29.5, 31.0, 30.0, open_c},
+        {31.0, 32.5, 30.5, 32.0, 31.0, open_c + minute},
+        {80.0, 80.0, 80.0, 80.0, 1.0, trail},
+    };
+
+    SplitFeedProbe probe;
+    strategy_set_syminfo_timezone(
+        static_cast<pf_strategy_t>(&probe), "America/New_York");
+    strategy_set_syminfo_session(
+        static_cast<pf_strategy_t>(&probe), "1800-1700");
+    assert(strategy_set_aux_security_feed(
+        static_cast<pf_strategy_t>(&probe),
+        reinterpret_cast<const pf_bar_t*>(aux), 8, "1") == 0);
+
+    probe.run(chart, 3, "1D", "1D", false, 4,
+              MagnifierDistribution::ENDPOINTS);
+    assert(probe.last_error().empty());
+    assert((probe.chart_closes == std::vector<double>{150.0, 250.0, 350.0}));
+    assert((probe.security_at_chart_close
+            == std::vector<double>{12.0, 22.0, 32.0}));
+    assert((probe.lower_tf_at_chart_close
+            == std::vector<std::vector<double>>{
+                {11.0, 12.0}, {21.0, 22.0}, {31.0, 32.0}}));
+}
+
+
 void test_overnight_daily_lower_tf_array_does_not_split_at_utc_midnight() {
     constexpr int64_t session_open = 1704232800000;  // 2024-01-02 17:00 NY
     constexpr int64_t minute = 60000;
@@ -305,6 +357,7 @@ int main() {
     test_intraday_aux_label_inside_native_span_without_chart_bar_fails();
     test_nifty_muhurat_shifted_open_maps_by_trading_date();
     test_nq_labor_day_sessions_coalesce_into_native_interval();
+    test_oanda_break_stamped_daily_bars_route_by_covered_session();
     test_overnight_daily_lower_tf_array_does_not_split_at_utc_midnight();
     return 0;
 }


### PR DESCRIPTION
## Summary
- OANDA stamps daily FX/metal bars at the 17:00 ET break, one hour before the 18:00–17:00 session the bar carries. `session_period_open_ms` floored that stamp into the previous session-day, so the last chart bar's content rows keyed past `last_chart_key` and the tail prefilter dropped the whole slice ("native chart bar has no matching auxiliary request.security bars") on every finer-timeframe `request.security` probe of the lane.
- Adds `session_covered_instant_ms`: a stamp at or after its session-day close rolls forward to the next session-day open; in-session stamps (NSE Muhurat, CME open-stamped, equities, 24x7) are unchanged. Chart route keys go through it.
- `tests/CMakeLists.txt`: append `-UNDEBUG` after the build-type flags so the assert-based test binaries keep their assertions under the documented Release flow (they were passing vacuously).

## Parity gate
Deterministic pr-gate **PASS** for engine `a950ca07` / codegen `9a3f1018` against baseline `pineforge-parity-baseline-20260901-heads-251fdb13` (snapshot `78cb2952`), population `251fdb13`:
- hard (ETHUSDT.P@15): 707 evaluated, **0 regressions**
- target: 3492 evaluated, **+29 entrants, 0 leavers** (all 29 on OANDA:XAUUSD@1D)
- candidate snapshot `f4c080dd`, verdict `981e814e` (gate_candidate execution `gntzm`); the same composite measured on the previous runner image (`gate-cand-baf011a48e7f9cd3`, pr_gate `29drn`) produced identical grades on all 4199 probes and the same +29/0 verdict.

## Test plan
- [x] `ctest` with assertions live (`-UNDEBUG`), incl. the new `test_aux_security_feed` cases
- [x] Cloud Run parity sweep 72/72 cases measured, 4199 observations (22 engine-error unchanged vs baseline, 4177 graded)
- [x] `lab gate status --engine a950ca07… --codegen 9a3f1018…` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXAE7TVTKZYbmtenHDHVJo
