### PR TITLE
fix: freeze default sizing at the mintick-rounded close, as TradingView does

### DIFF
--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -436,9 +436,13 @@ struct PendingOrder {
         std::numeric_limits<double>::quiet_NaN();
     // TV margin-admission snapshot for a FROZEN default-sized market order
     // (KI-54). Captured at the same placement point as frozen_default_qty:
-    //   sizing_equity = current_equity() + open_profit(close(S))
+    //   sizing_equity = current_equity() + open_profit(tick(close(S)))
     //                   - paid commission on surviving open lots [account ccy]
-    //   sizing_price  = close(S) + slippage*mintick*(+1 buy/-1 sell)
+    //   sizing_price  = tick(close(S)) + slippage*mintick*(+1 buy/-1 sell)
+    // where tick(x) = round_to_mintick(x): the broker's sizing basis is the
+    // mintick-ROUNDED signal close, never the raw feed print — see
+    // frozen_sizing_price for the tape census behind that. sizing_mark is
+    // the same tick(close(S)).
     // At fill time the broker re-checks (see the gate in
     // apply_filled_order_to_state for the full evidence trail)
     //   |qty| * admit_price * pointvalue * fx * margin_pct/100
@@ -512,7 +516,9 @@ struct PendingOrder {
     // Captured at the explicit-qty MARKET placement point. NaN = no snapshot.
     double explicit_placement_equity = std::numeric_limits<double>::quiet_NaN();
     // Slipped signal close at placement (frozen_sizing_price convention:
-    // close(S) + slippage*mintick*(+1 buy / -1 sell)). Its |qty|-scaled notional
+    // round_to_mintick(close(S)) + slippage*mintick*(+1 buy / -1 sell) — the
+    // tick basis, so a POOC fill at the rounded close is an exact no-op on a
+    // sub-tick feed too). Its |qty|-scaled notional
     // floors the fill-time decline threshold, so a fill AT/BELOW the slipped
     // signal close — POOC (fill == close(S)+slip both sides), a no-gap open, or a
     // favorable gap — is a structural no-op even with slippage != 0; only an
@@ -1400,7 +1406,9 @@ protected:
     // adverse extreme, a strategy.close at the close / COOF bar-point
     // cursor — books the raw print rounded to the NEAREST tick and only then
     // carries slippage ticks. The FEED is never quantized (indicators consume
-    // the raw sub-tick values); only the fill is on-tick. The directional
+    // the raw sub-tick values); only the fill and the broker's default-sizing
+    // snapshot (calc_qty / frozen_sizing_price, same nearest-tick form) are
+    // on-tick. The directional
     // snap (round_to_mintick_directional) is reserved for COMPUTED stop /
     // limit LEVELS that fall between ticks; applying it to a raw bar price
     // was the finding-432/446 defect (sells floored, buys ceiled — 43 AAPL
@@ -1629,7 +1637,54 @@ protected:
             ? cash / (1.0 + commission_value_ / 100.0) : cash;
     }
 
+    // The broker's sizing arithmetic runs ON-TICK. Both the price the budget
+    // is divided by and the price the open position is marked at for the
+    // equity term are round_to_mintick() of their raw inputs; the FEED itself
+    // stays raw (ta.*, crossovers, plots and every strategy.* metric TV
+    // reports on raw values keep reading current_bar_.close directly — only
+    // this sizing snapshot and the fill are quantized). The evidence is the
+    // same tape family that pinned the signal-bar freeze below:
+    //
+    //   - taro-s-c-c-ma-simplified-2-color replayed over the NYSE:F and
+    //     NASDAQ:AAPL tapes: qty = floor(E / tick(close_S)) with E marked at
+    //     tick(close_S) reproduces 674/674 F and 832/832 AAPL reversals; the
+    //     raw-close divisor fits only 476/674 on F. The same replay matches
+    //     675/675 TV entries by RAW-close crossovers, which is why the signal
+    //     path is left alone.
+    //   - drgunjan-F trade 1: a 9.565 signal close, TV qty 10460 =
+    //     floor(100000 / 9.56) (9.565 / 0.01 = 956.49999... rounds DOWN under
+    //     the census formula, exactly as 228.765 does); the raw divisor gave
+    //     floor(100000 / 9.565) = 10454.
+    //   - The raw basis also DECLINED entries TV filled: when an x.xx5 close
+    //     rounds UP at the fill (bar_fill_price) while the quantity was
+    //     floored against the raw close, qty * fill exceeds the sizing
+    //     equity by ~qty * mintick/2 and the true-flat gap-reject / reversal
+    //     float-guard arms in apply_filled_order_to_state saw a phantom gap.
+    //     463/463 missing taro-F entries were predicted by that mechanism
+    //     with 0 counterexamples; 26/26 drgunjan-F and 6/6 mazi-F missing
+    //     entries had sub-penny signal closes.
+    //
+    // On a price that is already n*tick (bar_fill_price output, a
+    // directionally-snapped level, or the slipped sizing price
+    // frozen_sizing_price builds) round_to_mintick is identical to within
+    // ONE ULP — not an identity: double(tick) is inexact for every decimal
+    // tick, so floor(x/0.01 + 0.5)*0.01 != x for 6,951 of 49,900 decimal-
+    // parsed 2dp prices 1.00..500.00 (always +1 ulp, double(0.01) > 0.01),
+    // for 35,736 of 70,000 5dp prices at tick 1e-5, and for 0 of 12,000 at
+    // the binary-exact 0.25. The ulp is absorbed by apply_qty_step's 1e-6
+    // nudge (0 floor flips of floor(100000/x) across all 49,900 prices) and
+    // by the 1e-9 / 1e-12 float guards on every admission arm, so no
+    // quantity or verdict moves on an on-tick feed: the fill-time legacy
+    // callers and the frozen path reproduce the pre-fix numbers there, and
+    // only sub-tick prints move — to TV's number.
+    //
+    // QtyType::CASH follows percent_of_equity by construction (the same
+    // broker division, only the numerator differs) and is UNPINNED: every
+    // census above is default percent_of_equity sizing, and no strategy.cash
+    // tape discriminating round(close) from close has been replayed. A
+    // future CASH mismatch on a sub-tick feed is traced here first.
     double calc_qty(double fill_price) const {
+        const double basis = round_to_mintick(fill_price);
         switch (default_qty_type_) {
             case QtyType::FIXED:
                 return apply_qty_step(default_qty_value_);
@@ -1638,19 +1693,21 @@ protected:
                 // omitted percent-of-equity add sizes from mark-to-market
                 // equity AFTER the paid percent commission on surviving lots.
                 // This is a ledger rule, independent of pct=100, margin, or
-                // how the already-open position was sized.
-                const double equity =
-                    percent_commission_live_equity(current_bar_.close);
+                // how the already-open position was sized. The open lot is
+                // marked at the ROUNDED close (see above): a sub-tick print
+                // never reaches the broker ledger.
+                const double equity = percent_commission_live_equity(
+                    round_to_mintick(current_bar_.close));
                 if (!std::isfinite(equity)) return 0.0;
                 double cash = reserve_percent_commission(equity * (default_qty_value_ / 100.0)) / active_account_currency_fx();
                 // Reject (qty 0) on a non-finite / non-positive fill price — a
                 // degenerate $0/NaN print must NOT size as the raw % number.
-                return (std::isfinite(fill_price) && fill_price > 0)
-                    ? apply_qty_step(cash / (fill_price * syminfo_.pointvalue)) : 0.0;
+                return (std::isfinite(basis) && basis > 0)
+                    ? apply_qty_step(cash / (basis * syminfo_.pointvalue)) : 0.0;
             }
             case QtyType::CASH:
-                return (std::isfinite(fill_price) && fill_price > 0)
-                    ? apply_qty_step((default_qty_value_ / active_account_currency_fx()) / (fill_price * syminfo_.pointvalue)) : 0.0;
+                return (std::isfinite(basis) && basis > 0)
+                    ? apply_qty_step((default_qty_value_ / active_account_currency_fx()) / (basis * syminfo_.pointvalue)) : 0.0;
         }
         return apply_qty_step(default_qty_value_);
     }
@@ -1659,18 +1716,20 @@ protected:
     // bar — the bar whose on_bar issued the strategy.entry/strategy.order
     // call — not at the fill:
     //
+    //   tick(x)      = round_to_mintick(x)          // nearest tick, census form
     //   equity_S     = initial_capital + realized net profit
-    //                  + open_profit(close(S))     // position may still be OPEN
-    //   sizing_price = close(S) + slippage*mintick*(+1 buy / -1 sell)
+    //                  + open_profit(tick(close(S)))  // position may still be OPEN
+    //   sizing_price = tick(close(S)) + slippage*mintick*(+1 buy / -1 sell)
     //   qty          = floor_step( reserve_percent_commission(budget)
     //                              / fx / (sizing_price * pointvalue) )
     //
     // The market order then fills at the NEXT bar's open carrying this frozen
     // quantity. calc_qty(price) implements exactly that shape when evaluated
     // AT SIGNAL TIME (current_bar_ IS the signal bar: open_profit marks at
-    // close(S) and the divisor is the argument), so the freeze is simply
-    // calc_qty(slipped signal close) captured at placement. Evaluating the
-    // same expression at FILL time — the pre-freeze behavior — was wrong in
+    // tick(close(S)) and the divisor is the rounded argument), so the freeze
+    // is simply calc_qty(slipped rounded signal close) captured at
+    // placement. Evaluating the same expression at FILL time — the
+    // pre-freeze behavior — was wrong in
     // three separable ways on a reversal/gap: it double-counted the just-
     // closed position's PnL (current_equity() already realized the exit while
     // position_* still held the stale lot for open_profit), it marked open
@@ -1689,8 +1748,20 @@ protected:
     // The sizing price of the frozen rule above, exposed separately so the
     // placement sites can persist it on the order (PendingOrder::sizing_price)
     // for the fill-time margin-admission re-check.
+    //
+    // The basis is the mintick-ROUNDED signal close. Rounding happens BEFORE
+    // the slippage ticks are added so the result is n*tick for any feed
+    // print, exactly as a bar_fill_price fill carries its slippage: TV's
+    // broker never sees the sub-tick close Pine sees (674/674 F, 832/832
+    // AAPL reversals on the taro tapes fit tick(close_S); the raw close fits
+    // 476/674 — see calc_qty). A feed that is already on-tick is unaffected
+    // in every quantity and verdict, though not bit-for-bit: round_to_mintick
+    // returns the n*tick double to within one ulp (double(tick) is inexact
+    // for decimal ticks — the measurement is in calc_qty's comment), and
+    // that ulp is absorbed by apply_qty_step's 1e-6 nudge and by the
+    // admission arms' float guards.
     double frozen_sizing_price(bool is_buy) const {
-        double sizing_price = current_bar_.close;
+        double sizing_price = round_to_mintick(current_bar_.close);
         if (slippage_ != 0 && syminfo_mintick_ > 0.0) {
             sizing_price += (is_buy ? 1.0 : -1.0) * slippage_ * syminfo_mintick_;
         }
@@ -1724,8 +1795,11 @@ protected:
             if (o.created_bar != bar_index_) continue;
             o.frozen_default_qty = calc_qty(o.sizing_price);
             if (!std::isnan(o.sizing_equity)) {
-                o.sizing_equity =
-                    percent_commission_live_equity(current_bar_.close);
+                // Same on-tick mark the placement sites took
+                // (engine_strategy_commands.cpp): the re-freeze must land on
+                // the number placement would have produced post-liquidation.
+                o.sizing_equity = percent_commission_live_equity(
+                    round_to_mintick(current_bar_.close));
             }
             o.sizing_fx = active_account_currency_fx();
         }

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -896,8 +896,48 @@ void BacktestEngine::process_margin_call(const Bar& bar) {
         // account-currency values, so quote-currency price PnL/notional must
         // carry the configured FX multiplier on this path just as they do in
         // the opening-budget branch above. FX=1 preserves the old arithmetic.
+        //
+        // The SHORT cascade marks equity and required margin at the mintick-
+        // ROUNDED high, the same tick the slice will fill at (finding-446:
+        // the adverse extreme is a raw bar price, bar_fill_price rounds it
+        // nearest). Evidence is MEDIUM, not the census grade of the sizing
+        // basis: on the NYSE:F tape the rounded high reproduces 32 TV margin-
+        // call slices where the raw high reproduces 0, and that is one tape
+        // with sub-penny highs. It travels with the sizing-basis fix because
+        // it is the same broker rule — the ledger is marked at tick prices —
+        // and because a raw-high mark can fire a slice on a sub-tick excursion
+        // the on-tick ledger never saw. The LONG side keeps the raw low on
+        // purpose: every leveraged-long cascade pin we hold (the ETHUSDT.P
+        // alpha-wizard-channel 14-nibble bit-exact fit, the p2/5x probes) was
+        // taken on on-tick feeds where the rounding is an identity, so there
+        // is no evidence either way and the fitted arithmetic must not move
+        // on a medium-grade extrapolation. syminfo_mintick_ <= 0 makes the
+        // rounding a no-op (round_to_mintick guards it).
+        //
+        // Three short floor-zero pins in tests/test_margin_call.cpp moved
+        // with this mark — exact_one_step_roundoff_keeps_four_x_nibble,
+        // just_below_step_slices_one_contract, and RED-2
+        // commission_free_short_floor_zero_closes_one_contract (the 166-
+        // event class). Each built its deficit from a SYNTHETIC sub-tick
+        // high, 2000 / (20 - k*step) = 100.0005... over a 10 @ 100 short,
+        // chosen for the arithmetic (q_min lands exactly at / just below /
+        // half of one 0.0001 lot), and the finding-446 comment beside them
+        // said only that the slice BOOKS at the nearest tick — the mark
+        // itself was silently raw. On the on-tick ledger that print is
+        // 100.00, exactly the liquidation price, and the cascade correctly
+        // fires nothing (test_sizing_basis_mintick.cpp E1 pins that
+        // shape). The lot rules they measure are unchanged, so the pins
+        // were re-derived on on-tick highs of the same q_min shape: one
+        // penny of adverse move from a 1999.99 / 2000.00 / 3999.99 entry
+        // (q_min = 20 * tick / adverse = one lot with the quotient one
+        // 2e-11 below 1 / one lot minus 5e-6 / half a lot). The
+        // chronological copy of this test, margin_call_slice_before_priced_
+        // exit, takes the same mark so the ledger does not depend on
+        // whether a priced exit happens to be resting on the bar.
         const double adverse =
-            (position_side_ == PositionSide::LONG) ? bar.low : bar.high;
+            (position_side_ == PositionSide::LONG)
+                ? bar.low
+                : round_to_mintick(bar.high);
         if (!std::isfinite(adverse) || !(adverse > 0.0)) return;
         const double fx = active_account_currency_fx();
         if (!std::isfinite(fx) || !(fx > 0.0)) return;
@@ -910,7 +950,8 @@ void BacktestEngine::process_margin_call(const Bar& bar) {
         const double req_margin_adv = qty * margin_per_unit_adv;
         if (equity_adv >= req_margin_adv) return;
         q_min = qty - equity_adv / margin_per_unit_adv;
-        // finding-446: the adverse extreme is a raw bar price.
+        // finding-446: the adverse extreme is a raw bar price (an identity
+        // on the short side, whose mark above is already the rounded high).
         raw_exit_fill_base = bar_fill_price(adverse);
     }
 
@@ -1241,12 +1282,26 @@ bool BacktestEngine::margin_call_slice_before_priced_exit(
 
     // (c) Pre-fill deficit at the extreme: the same fee-net eq/req
     // arithmetic as the adverse cascade (the position state is pre-fill
-    // because the triggering exit has not been applied yet).
+    // because the triggering exit has not been applied yet). The MARK is
+    // process_margin_call's: a short is marked at the mintick-ROUNDED high
+    // (the broker ledger is on-tick; 32 vs 0 reproduced slices on the
+    // NYSE:F tape — medium evidence, see the cascade comment), a long at
+    // the raw low. `adverse` itself stays RAW above and below: the
+    // chronology test in (b) is a path point on the synthesized OHLC walk,
+    // not a ledger value, and bar_fill_price does its own nearest-tick
+    // rounding of the raw print (finding-446). Marking here at the raw
+    // high while the end-of-bar cascade marks at the rounded one would
+    // make a sub-tick excursion fire a slice only when a priced exit
+    // happens to be resting on the bar — the same ledger must answer the
+    // same question on both paths (test_sizing_basis_mintick.cpp E3).
+    const double adverse_mark =
+        (position_side_ == PositionSide::LONG) ? adverse
+                                                : round_to_mintick(adverse);
     const double fx = active_account_currency_fx();
     if (!std::isfinite(fx) || !(fx > 0.0)) return false;
-    const double equity_adv = percent_commission_live_equity(adverse);
+    const double equity_adv = percent_commission_live_equity(adverse_mark);
     if (!std::isfinite(equity_adv)) return false;
-    const double margin_per_unit_adv = adverse * pv * fx * m;
+    const double margin_per_unit_adv = adverse_mark * pv * fx * m;
     const double req_margin_adv = qty * margin_per_unit_adv;
     if (equity_adv >= req_margin_adv) return false;
     double q_min = qty - equity_adv / margin_per_unit_adv;
@@ -3778,6 +3833,26 @@ void BacktestEngine::apply_filled_order_to_state(
         //   - process_orders_on_close: the signal bar IS the fill bar, so
         //     slipped_fill == sizing_price and the frozen qty was floored to
         //     fit sizing_equity — the shortfall is structurally 0 (no-op).
+        //     That equality holds because the sizing basis is the mintick-
+        //     ROUNDED close (frozen_sizing_price / calc_qty, engine.hpp),
+        //     the same tick bar_fill_price books. It was FALSE while sizing
+        //     divided by the raw close: on a sub-tick x.xx5 print the fill
+        //     rounded up, the quantity had been floored against the lower
+        //     raw price, and this arm declined a zero-gap fill by
+        //     ~qty * mintick/2 — the mechanism behind 463/463 missing
+        //     taro-F entries (0 counterexamples) and every one of the
+        //     26 drgunjan-F / 6 mazi-F missing entries, all on sub-penny
+        //     signal closes. With the basis on-tick, a fill AT the signal
+        //     close yields a shortfall that is identically zero at
+        //     slippage 0 (sizing_price and the fill are the same
+        //     round_to_mintick double) and within the float guard
+        //     otherwise: with slippage ticks the sizing price is
+        //     round(c) + s*tick while the slipped fill is
+        //     ceil((round(c) + s*tick)/tick - 1e-9)*tick, which differ by
+        //     one ulp on 42,656 of 149,700 (price, slippage 1..3) 2dp
+        //     combos, a qty*ulp (~1e-11) shortfall the max(1e-9, E*1e-12)
+        //     guard below absorbs. Either way this gate only ever sees a
+        //     genuine close->open gap.
         if (order.opening_affordability_exemption_candidate
             && position_side_ == PositionSide::FLAT
             && !same_dir && !reversal
@@ -3883,7 +3958,24 @@ void BacktestEngine::apply_filled_order_to_state(
             // reversal arm the way it does to the others, because there the
             // frozen quantity was floored against the PREVIOUS bar's close while
             // the order fills at THIS bar's open: the overshoot is an observable
-            // gap, not floor luck. The flat-open and same-direction-add arms
+            // gap, not floor luck. That statement is only true when the
+            // previous close the quantity was floored against is the SAME
+            // tick the fill books — which it is now that the sizing basis is
+            // round_to_mintick(close(S)) (frozen_sizing_price, engine.hpp).
+            // While the basis was the raw close, a sub-tick x.xx5 signal
+            // print that rounds UP at the open handed this arm a phantom
+            // "gap" of half a tick on a flat open (qty floored on the lower
+            // raw price times the higher rounded fill), and a float-guard
+            // epsilon is precisely the width that turns half a tick of
+            // notional into a decline: the raw basis is what the taro-F
+            // replay (463/463 missing entries predicted) and the drgunjan-F
+            // / mazi-F sub-penny censuses (26/26, 6/6) were measuring, not
+            // this gate. With the basis on-tick, a fill at the rounded
+            // signal close reproduces |qty| * sizing_price <= sizing_equity
+            // exactly (the floor invariant), the shortfall of a flat open is
+            // identically zero, and the epsilon below is asked only about a
+            // real close->open gap — the question the ETHUSDT.P dossier
+            // answered. The flat-open and same-direction-add arms
             // keep the one-lot term — each is separately TV-pinned, nothing has
             // falsified their premise, and the flat-open arm is undeclinable by
             // the floor invariant anyway (it prices at the sizing notional).

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -29,27 +29,38 @@ double BacktestEngine::calc_qty_for_type(double fill_price, double qty_value, in
     if (qty_type < 0 || qty_type == static_cast<int>(QtyType::FIXED)) {
         return apply_qty_step(qty_value);
     }
+    // The explicit percent_of_equity / cash branches below run on the SAME
+    // on-tick basis as calc_qty (engine.hpp): the open lot is marked and the
+    // budget is divided at round_to_mintick of the price, never at a raw
+    // sub-tick print, so the two sizing consumers cannot diverge on a
+    // sub-penny feed. Reachability note: order.qty_type is set only from
+    // strategy_entry's per-call qty_type parameter (default -1); the corpus'
+    // generated code only ever sets default_qty_type_ and pineforge.h exposes
+    // no per-call qty_type, so this path is reached by direct C++ callers
+    // only — it is kept on the rounded basis for consistency, not because a
+    // tape pinned it (calc_qty carries the F / AAPL census).
+    const double basis = round_to_mintick(fill_price);
     if (qty_type == static_cast<int>(QtyType::PERCENT_OF_EQUITY)) {
-        const double equity =
-            percent_commission_live_equity(current_bar_.close);
+        const double equity = percent_commission_live_equity(
+            round_to_mintick(current_bar_.close));
         if (!std::isfinite(equity)) return 0.0;
         double cash = reserve_percent_commission(equity * (qty_value / 100.0));
         // Reject (qty 0) on a non-finite / non-positive fill price — a degenerate
         // $0/NaN print must NOT size as the raw % number (silent wrong-qty bug).
-        // One contract's currency exposure is fill_price × pointvalue (1.0 for
+        // One contract's currency exposure is basis × pointvalue (1.0 for
         // crypto/equity — legacy math unchanged; futures divide the budget by
         // the full per-contract notional). cash is account-currency (equity is);
         // convert to quote currency via account_currency_fx_ before dividing by
-        // the quote-currency fill_price — same convention as calc_qty() in
+        // the quote-currency basis — same convention as calc_qty() in
         // engine.hpp. fx=1.0 is a no-op.
-        return (std::isfinite(fill_price) && fill_price > 0.0)
+        return (std::isfinite(basis) && basis > 0.0)
             ? apply_qty_step((cash / active_account_currency_fx())
-                             / (fill_price * syminfo_.pointvalue)) : 0.0;
+                             / (basis * syminfo_.pointvalue)) : 0.0;
     }
     if (qty_type == static_cast<int>(QtyType::CASH)) {
-        return (std::isfinite(fill_price) && fill_price > 0.0)
+        return (std::isfinite(basis) && basis > 0.0)
             ? apply_qty_step((qty_value / active_account_currency_fx())
-                             / (fill_price * syminfo_.pointvalue)) : 0.0;
+                             / (basis * syminfo_.pointvalue)) : 0.0;
     }
     return apply_qty_step(qty_value);
 }

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -407,7 +407,12 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
         // frozen_default_market_qty (engine.hpp) for the rule and the
         // empirical basis. current_bar_.close is close(S) right here, so
         // placement is the one point where the frozen computation is
-        // naturally correct (no double count, no fill-bar look-ahead).
+        // naturally correct (no double count, no fill-bar look-ahead). The
+        // broker's basis is round_to_mintick(close(S)) — the tick the fill
+        // will book, not the sub-tick print Pine's signal path just read
+        // (calc_qty documents the F/AAPL census) — and every member of the
+        // snapshot (price, equity mark, sizing_mark) is taken on that same
+        // rounded price so the fill-time admission compares like with like.
         // FIXED default sizing needs no freeze: its fill-time value is
         // identical. The frozen quantity goes in frozen_default_qty, NOT in
         // order.qty — order.qty must stay NaN so every isnan(order.qty)-keyed
@@ -422,9 +427,9 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
             // admission re-check (see PendingOrder::sizing_equity in
             // engine.hpp and the gate in apply_filled_order_to_state).
             order.sizing_price = frozen_sizing_price(/*is_buy=*/is_long);
+            order.sizing_mark = round_to_mintick(current_bar_.close);
             order.sizing_equity =
-                percent_commission_live_equity(current_bar_.close);
-            order.sizing_mark = current_bar_.close;
+                percent_commission_live_equity(order.sizing_mark);
             order.sizing_fx = active_account_currency_fx();
             // Direction-neutral: two fill-time consumers read this flag.
             //   1. KI-61 long entry-bar affordability trim
@@ -2101,8 +2106,9 @@ void BacktestEngine::strategy_order(const std::string& id, bool is_long, double 
         // Same signal-time freeze as strategy_entry's MARKET branch: a
         // default-sized strategy.order market order runs through the same
         // TV default-sizing engine, so its quantity is frozen at this
-        // (signal) bar's close too. Stored off to the side (order.qty stays
-        // NaN) for the same reason as in strategy_entry.
+        // (signal) bar's close too — on the mintick-ROUNDED close, the same
+        // basis as strategy_entry (calc_qty, engine.hpp). Stored off to the
+        // side (order.qty stays NaN) for the same reason as in strategy_entry.
         if (std::isnan(qty)
             && (default_qty_type_ == QtyType::PERCENT_OF_EQUITY
                 || default_qty_type_ == QtyType::CASH)
@@ -2113,9 +2119,9 @@ void BacktestEngine::strategy_order(const std::string& id, bool is_long, double 
             // (they only close the position) — see
             // apply_filled_order_to_state.
             order.sizing_price = frozen_sizing_price(/*is_buy=*/is_long);
+            order.sizing_mark = round_to_mintick(current_bar_.close);
             order.sizing_equity =
-                percent_commission_live_equity(current_bar_.close);
-            order.sizing_mark = current_bar_.close;
+                percent_commission_live_equity(order.sizing_mark);
             order.sizing_fx = active_account_currency_fx();
         }
     } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,7 @@ set(TEST_SOURCES
     test_c_abi_setters
     test_fills_edge
     test_default_qty_signal_freeze
+    test_sizing_basis_mintick
     test_qty_step_epsilon_floor
     test_margin_admission_gate
     test_reversal_admission_float_guard

--- a/tests/test_margin_call.cpp
+++ b/tests/test_margin_call.cpp
@@ -94,8 +94,9 @@ class ShortLiqProbe : public MCEngine {
 public:
     bool disable_mc_ = false;
     explicit ShortLiqProbe(bool disable_mc = false, double qty_step = 0.0,
-                           double account_fx = 1.0) {
-        initial_capital_ = 1000.0;
+                           double account_fx = 1.0,
+                           double initial_capital = 1000.0) {
+        initial_capital_ = initial_capital;
         default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
         default_qty_value_ = 100.0;          // size the short at 100% of equity
         commission_type_ = CommissionType::PERCENT;
@@ -316,42 +317,59 @@ static void test_short_margin_call_zero_cover_closes_sub_one_residual() {
 static void test_short_margin_call_exact_one_step_roundoff_keeps_four_x_nibble() {
     std::printf("test_short_margin_call_exact_one_step_roundoff_keeps_four_x_nibble\n");
     constexpr double step = 0.0001;
-    // For a 10@100 all-in short, q_min = 20 - 2000/adverse. This adverse is
-    // mathematically exactly one step, but the engine's equivalent arithmetic
-    // represents the quotient just below 1. A bare floor would erase the lot
-    // and incorrectly enter the zero-cover full-close fallback.
-    const double adverse = 2000.0 / (20.0 - step);
-    const double equity_at_high = 1000.0 - (adverse - 100.0) * 10.0;
+    // An all-in short of 10 @ entry from 10*entry of equity leaves
+    //   q_min = 20 * (adverse - entry) / adverse
+    // at the adverse high. The short cascade marks that deficit at the
+    // mintick-ROUNDED high (process_margin_call, the sizing-basis fix: the
+    // broker ledger is on-tick, 32 vs 0 reproduced slices on the NYSE:F
+    // tape), so the shape is built on ON-TICK prices where the rounding is
+    // an identity and the pin measures the lot rule alone: one penny of
+    // adverse move at 2000.00 is mathematically exactly one 0.0001 lot,
+    // but the engine's equivalent arithmetic represents the quotient just
+    // below 1 (0.99999999998). A bare floor would erase the lot and
+    // incorrectly enter the zero-cover full-close fallback.
+    //
+    // This case used to sit at 10 @ 100 with a SYNTHETIC sub-tick high of
+    // 2000 / (20 - step) = 100.0005..., marked raw; the on-tick mark reads
+    // that high as 100.00, exactly at the liquidation price, and no slice
+    // fires — which is the E1 pin of test_sizing_basis_mintick.cpp, not a
+    // lot-rule question. The lot rule pinned here is unchanged.
+    const double entry = 1999.99;
+    const double adverse = 2000.00;
+    const double capital = 10.0 * entry;
+    const double equity_at_high = capital - (adverse - entry) * 10.0;
     const double q_min = 10.0 - equity_at_high / adverse;
     const double step_count = q_min / step;
     CHECK(q_min < step);
     CHECK(std::abs(step_count - std::round(step_count)) < 1e-6);
 
     std::vector<Bar> bars = {
-        mk_bar(1000, 100.0, 100.0, 99.0, 100.0, 1.0),
-        mk_bar(2000, 100.0, adverse, 99.0, 100.0, 1.0),
+        mk_bar(1000, entry, entry, entry - 1.0, entry, 1.0),
+        mk_bar(2000, entry, adverse, entry - 1.0, entry, 1.0),
     };
 
     // Without the opt-in metadata the representation jitter is NOT rounded
     // away, so this lands on the generic floor-zero discontinuity and closes
     // one whole contract.
-    ShortLiqProbe default_eng(/*disable_mc=*/false, /*qty_step=*/step);
+    ShortLiqProbe default_eng(/*disable_mc=*/false, /*qty_step=*/step,
+                              /*account_fx=*/1.0, capital);
     default_eng.run(bars.data(), (int)bars.size());
     CHECK(default_eng.trade_count() == 1);
     CHECK(default_eng.exit_comment(0) == std::string("Margin call"));
     CHECK(near(default_eng.trade_size(0), 1.0, 1e-12));
     CHECK(near(default_eng.position_size(), -9.0, 1e-12));
 
-    ShortLiqProbe eng(/*disable_mc=*/false, /*qty_step=*/step);
+    ShortLiqProbe eng(/*disable_mc=*/false, /*qty_step=*/step,
+                      /*account_fx=*/1.0, capital);
     eng.set_syminfo_metadata("margin_zero_cover_full_liquidation", 1.0);
     eng.run(bars.data(), (int)bars.size());
 
     CHECK(eng.trade_count() == 1);
     CHECK(eng.exit_comment(0) == std::string("Margin call"));
-    // finding-446: the adverse extreme (100.0005..., a sub-tick synthetic
-    // high) is a RAW BAR PRICE and books at the nearest tick, 100.00 —
-    // no longer the buy-side ceil to 100.01.
-    CHECK(near(eng.exit_price(0), 100.00, 1e-12));
+    // finding-446: the adverse extreme is a RAW BAR PRICE and books at the
+    // nearest tick (an identity on this on-tick high), never the buy-side
+    // ceil.
+    CHECK(near(eng.exit_price(0), adverse, 1e-12));
     CHECK(near(eng.trade_size(0), 4.0 * step, 1e-12));
     CHECK(near(eng.position_size(), -(10.0 - 4.0 * step), 1e-12));
 }
@@ -359,40 +377,50 @@ static void test_short_margin_call_exact_one_step_roundoff_keeps_four_x_nibble()
 static void test_short_margin_call_just_below_step_slices_one_contract() {
     std::printf("test_short_margin_call_just_below_step_slices_one_contract\n");
     constexpr double step = 0.0001;
-    constexpr double below_guard_ratio = 1.0 - 2e-6;
-    // This is genuinely below one step by more than the 1e-6 representation
-    // guard. It must quantize to zero and land on the settled floor-zero
-    // discontinuity: TV closes ONE whole contract and HOLDS the remainder.
-    // The full-residual opt-in no longer overrides that settled slice —
-    // at an eps-scale deficit it used to liquidate the whole ten-contract
-    // position here, an exit TV never prints (finding 279, serhan ADX).
-    const double adverse = 2000.0 / (20.0 - step * below_guard_ratio);
-    const double equity_at_high = 1000.0 - (adverse - 100.0) * 10.0;
+    // Same all-in shape as the exact-one-step case above (q_min =
+    // 20 * (adverse - entry) / adverse, marked at the on-tick high), one
+    // penny of adverse move from a 2000.00 entry: q_min / step =
+    // 2000 / 2000.01 = 0.999995, genuinely below one step by 5e-6 — more
+    // than the 1e-6 representation guard. It must quantize to zero and land
+    // on the settled floor-zero discontinuity: TV closes ONE whole contract
+    // and HOLDS the remainder. The full-residual opt-in no longer overrides
+    // that settled slice — at an eps-scale deficit it used to liquidate the
+    // whole ten-contract position here, an exit TV never prints (finding
+    // 279, serhan ADX). (Formerly a synthetic sub-tick high of
+    // 2000 / (20 - step * (1 - 2e-6)) over a 10 @ 100 short, marked raw;
+    // the on-tick mark reads that print as 100.00 and fires nothing — see
+    // the sibling above.)
+    const double entry = 2000.00;
+    const double adverse = 2000.01;
+    const double capital = 10.0 * entry;
+    const double equity_at_high = capital - (adverse - entry) * 10.0;
     const double q_min = 10.0 - equity_at_high / adverse;
     const double step_count = q_min / step;
     CHECK(q_min < step);
     CHECK(std::abs(step_count - std::round(step_count)) > 1e-6);
 
     std::vector<Bar> bars = {
-        mk_bar(1000, 100.0, 100.0, 99.0, 100.0, 1.0),
-        mk_bar(2000, 100.0, adverse, 99.0, 100.0, 1.0),
+        mk_bar(1000, entry, entry, entry - 1.0, entry, 1.0),
+        mk_bar(2000, entry, adverse, entry - 1.0, entry, 1.0),
     };
 
-    ShortLiqProbe eng(/*disable_mc=*/false, /*qty_step=*/step);
+    ShortLiqProbe eng(/*disable_mc=*/false, /*qty_step=*/step,
+                      /*account_fx=*/1.0, capital);
     eng.set_syminfo_metadata("margin_zero_cover_full_liquidation", 1.0);
     eng.run(bars.data(), (int)bars.size());
 
     CHECK(eng.trade_count() == 1);
     CHECK(eng.exit_comment(0) == std::string("Margin call"));
-    // finding-446: the adverse extreme (100.0005..., a sub-tick synthetic
-    // high) is a RAW BAR PRICE and books at the nearest tick, 100.00 —
-    // no longer the buy-side ceil to 100.01.
-    CHECK(near(eng.exit_price(0), 100.00, 1e-12));
+    // finding-446: the adverse extreme is a RAW BAR PRICE and books at the
+    // nearest tick (an identity on this on-tick high), never the buy-side
+    // ceil.
+    CHECK(near(eng.exit_price(0), adverse, 1e-12));
     CHECK(near(eng.trade_size(0), 1.0, 1e-12));
     CHECK(near(eng.position_size(), -9.0, 1e-12));
 
     // Control: the flag-off engine takes the identical settled slice.
-    ShortLiqProbe default_eng(/*disable_mc=*/false, /*qty_step=*/step);
+    ShortLiqProbe default_eng(/*disable_mc=*/false, /*qty_step=*/step,
+                              /*account_fx=*/1.0, capital);
     default_eng.run(bars.data(), (int)bars.size());
     CHECK(default_eng.trade_count() == 1);
     CHECK(near(default_eng.trade_size(0), 1.0, 1e-12));
@@ -2878,32 +2906,45 @@ static void test_commission_free_long_floor_zero_closes_one_contract() {
 static void test_commission_free_short_floor_zero_closes_one_contract() {
     std::printf("test_commission_free_short_floor_zero_closes_one_contract\n");
     constexpr double step = 0.0001;
-    constexpr double target_q_min = 0.5 * step;   // half a lot -> floors to zero
-    // All-in short of 10 @ 100 from 1000 of equity:
-    //   equity(adverse) = 1000 - (adverse - 100) * 10
-    //   q_min           = 10 - equity(adverse) / adverse = 20 - 2000 / adverse
-    const double adverse = 2000.0 / (20.0 - target_q_min);
-    const double equity_at_high = 1000.0 - (adverse - 100.0) * 10.0;
+    // All-in short of 10 @ 3999.99 from 39999.9 of equity, one penny of
+    // adverse move to an ON-TICK high of 4000.00:
+    //   equity(adverse) = capital - (adverse - entry) * 10
+    //   q_min           = 10 - equity(adverse) / adverse
+    //                   = 20 * (adverse - entry) / adverse = 0.5 * step
+    // — half a lot, floors to zero. The short cascade marks the deficit at
+    // the mintick-ROUNDED high (process_margin_call, the sizing-basis fix),
+    // so the shape is built on-tick where the rounding is an identity and
+    // the pin measures the floor-zero rule alone. The shape used to be a
+    // 10 @ 100 short against a SYNTHETIC sub-tick high of
+    // 2000 / (20 - 0.5 * step) = 100.00025..., marked raw; on the on-tick
+    // ledger that print is 100.00, exactly at liquidation, and fires
+    // nothing (test_sizing_basis_mintick.cpp E1). The 166-event class this
+    // pins is a lot-rule fact and is unchanged by the mark.
+    const double entry = 3999.99;
+    const double adverse = 4000.00;
+    const double capital = 10.0 * entry;
+    const double equity_at_high = capital - (adverse - entry) * 10.0;
     const double q_min = 10.0 - equity_at_high / adverse;
     CHECK(q_min > 0.0);
     CHECK(q_min < step);
+    CHECK(near(q_min, 0.5 * step, 1e-12));
 
     std::vector<Bar> bars = {
-        mk_bar(1000, 100.0, 100.0, 99.0, 100.0, 1.0),   // short 10 fills @100
-        mk_bar(2000, 100.0, adverse, 99.0, 100.0, 1.0),  // adverse high
+        mk_bar(1000, entry, entry, entry - 1.0, entry, 1.0),    // short 10 fills @entry
+        mk_bar(2000, entry, adverse, entry - 1.0, entry, 1.0),  // adverse high
     };
 
     CommissionFreeShortFloorZeroProbe eng(
-        /*initial_capital=*/1000.0, /*qty_step=*/step);
+        /*initial_capital=*/capital, /*qty_step=*/step);
     eng.run(bars.data(), static_cast<int>(bars.size()));
 
     CHECK(eng.trade_count() == 1);
     CHECK(eng.exit_comment(0) == std::string("Margin call"));
-    CHECK(near(eng.entry_price(0), 100.0));
-    // finding-446: the adverse extreme (100.0005..., a sub-tick synthetic
-    // high) is a RAW BAR PRICE and books at the nearest tick, 100.00 —
-    // no longer the buy-side ceil to 100.01.
-    CHECK(near(eng.exit_price(0), 100.00, 1e-12));
+    CHECK(near(eng.entry_price(0), entry));
+    // finding-446: the adverse extreme is a RAW BAR PRICE and books at the
+    // nearest tick (an identity on this on-tick high), never the buy-side
+    // ceil.
+    CHECK(near(eng.exit_price(0), adverse, 1e-12));
     CHECK(near(eng.trade_size(0), 1.0, 1e-9));
     CHECK(near(eng.position_size(), -9.0, 1e-9));
 }

--- a/tests/test_sizing_basis_mintick.cpp
+++ b/tests/test_sizing_basis_mintick.cpp
@@ -1,0 +1,522 @@
+/*
+ * test_sizing_basis_mintick.cpp — TradingView's broker sizes DEFAULT (qty=na)
+ * percent_of_equity / cash market orders on the MINTICK-ROUNDED signal close:
+ *
+ *   basis(S) = round_to_mintick(close(S))            (census form, no epsilon)
+ *   qty      = floor_step( E / basis(S) ),  E marked at basis(S) as well
+ *
+ * Pine's own signal path (ta.*, crossovers) keeps reading the RAW feed close;
+ * only the broker's sizing snapshot and the fill are on-tick. Evidence (the
+ * replay this file pins): 674/674 NYSE:F and 832/832 NASDAQ:AAPL reversals of
+ * taro-s-c-c-ma-simplified-2-color fit the rounded basis while the raw close
+ * fits 476/674 on F; drgunjan-F trade 1 is TV qty 10460 = floor(100000/9.56)
+ * on a 9.565 close where the raw divisor gave 10454; and the raw basis
+ * DECLINED entries TV filled whenever an x.xx5 close rounded UP at the fill
+ * (qty floored on the lower raw price times the higher rounded fill overshot
+ * the sizing equity by ~qty*mintick/2 and tripped the true-flat gap-reject /
+ * reversal float-guard arms): 463/463 missing taro-F entries predicted, 0
+ * counterexamples; 26/26 drgunjan-F and 6/6 mazi-F missing entries sit on
+ * sub-penny signal closes.
+ *
+ * Pins:
+ *   A.  9.565 close, mintick 0.01, capital 100000, pct 100, next open 9.56:
+ *       frozen qty == 10460 (drgunjan-F trade 1) and the entry FILLS.
+ *   A2. 9.585 close (rounds UP to 9.59), next open 9.59: the entry FILLS with
+ *       qty 10427. Pre-fix: qty 10432 floored on 9.585, 10432*9.59 = 100042.88
+ *       > 100000 -> the true-flat zero-commission gap-reject arm DROPPED it on
+ *       a zero-gap open (the 463/463 mechanism).
+ *   A3. The reversal twin of A2: a held long, short signal on a 9.585 close,
+ *       reversal fills at 9.59. Pre-fix the equity mark at the raw 9.585 left
+ *       free_funds 100894.71 against a required 10526*9.59 = 100944.34 and the
+ *       float-guard reversal arm DECLINED; on-tick the mark is 9.59, free
+ *       funds 100947.34, admitted.
+ *   B.  A penny close (9.56) is unchanged in every quantity and verdict:
+ *       basis == close to within one ulp (double(0.01) is inexact, so
+ *       round_to_mintick is not a bit-for-bit identity on decimal ticks —
+ *       the ulp is absorbed by apply_qty_step's 1e-6 nudge and the
+ *       admission float guards), qty 10460, fills.
+ *   C.  mintick 0.25 (futures): a 5000.125 close sizes on 5000.25 (nearest,
+ *       floor(x/tick + 0.5)); capital 100003 floors to 19 lots where the raw
+ *       basis gave 20.
+ *   D.  Slippage ticks are added AFTER rounding: 9.565 with slippage 2 sizes
+ *       a buy on 9.58 and a sell on 9.54 (pre-fix 9.585 / 9.545).
+ *   E1. SHORT margin-call cascade marks at the ROUNDED high (medium evidence:
+ *       32 vs 0 reproduced slices on the F tape): a sub-tick excursion the
+ *       on-tick ledger cannot see (high 100.004 on a short at liq 100.00)
+ *       fires NO slice; pre-fix the raw mark produced a phantom one.
+ *   E2. The slice quantity at a 105.005 high is the 105.01-marked 3.8167794
+ *       (pre-fix 3.8131518 from the raw mark); the fill price was already
+ *       105.01 both ways (bar_fill_price, finding-446).
+ *   E3. The chronological copy of the cascade (margin_call_slice_before_
+ *       priced_exit, the slice taken BEFORE a same-bar priced exit) marks at
+ *       the same rounded high: E1's 100.004 excursion with a TP limit
+ *       resting on the bar fires NO slice and the TP closes the full lot
+ *       (pre-fix that path marked raw and fired a phantom 0.0016 slice only
+ *       when an exit happened to be resting); the on-tick control high
+ *       100.01 with the same TP slices 4*(10 - 999.9/100.01) @ 100.01 first
+ *       and the TP closes the remainder, proving the path is live.
+ *   F.  Sanity on the helper itself: round_to_mintick on the drgunjan close
+ *       and idempotence on its own output.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <pineforge/bar.hpp>
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_NEAR(a, b, tol)                                                  \
+    do {                                                                       \
+        double _a = (a), _b = (b);                                             \
+        if (!(std::fabs(_a - _b) <= (tol))) {                                  \
+            std::printf("  FAIL  %s:%d  %s == %.10f, expected %.10f\n",        \
+                        __FILE__, __LINE__, #a, _a, _b);                       \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+static constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+static Bar mk_bar(int64_t ts, double o, double h, double l, double c) {
+    Bar b;
+    b.open = o; b.high = h; b.low = l; b.close = c;
+    b.volume = 1.0; b.timestamp = ts;
+    return b;
+}
+
+namespace {
+
+// Scripted stock-shaped probe: whole-share lots (qty_step 1), zero
+// commission, 1x margin both sides, margin-call emulation OFF so the sizing
+// basis and the fill-time admission arms are the only mechanisms in play.
+// The feed is deliberately NOT on-tick — that is the point of the file.
+class Probe : public BacktestEngine {
+public:
+    Probe(double capital, double mintick, int slippage_ticks) {
+        initial_capital_ = capital;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100.0;
+        commission_type_ = CommissionType::PERCENT;
+        commission_value_ = 0.0;
+        margin_long_ = 100.0;
+        margin_short_ = 100.0;
+        qty_step_ = 1.0;
+        process_orders_on_close_ = false;
+        slippage_ = slippage_ticks;
+        set_syminfo_mintick(mintick);
+        margin_call_enabled_ = false;
+    }
+    // 'L' = default-sized long entry, 'S' = default-sized short entry,
+    // 'C' = close all, '.' = nothing. Every placement also records the
+    // frozen basis / qty the broker snapshot took on that bar.
+    std::string script;
+    std::vector<double> basis_buy, basis_sell, frozen_qty;
+    void on_bar(const Bar& /*bar*/) override {
+        if (bar_index_ < 0 || bar_index_ >= (int)script.size()) return;
+        const char a = script[bar_index_];
+        if (a == 'L' || a == 'S') {
+            basis_buy.push_back(frozen_sizing_price(/*is_buy=*/true));
+            basis_sell.push_back(frozen_sizing_price(/*is_buy=*/false));
+            frozen_qty.push_back(frozen_default_market_qty(a == 'L'));
+        }
+        switch (a) {
+            case 'L': strategy_entry("L", true); break;
+            case 'S': strategy_entry("S", false); break;
+            case 'C': strategy_close_all(); break;
+            default: break;
+        }
+    }
+    double nearest(double p) const { return round_to_mintick(p); }
+    using BacktestEngine::position_qty_;
+    using BacktestEngine::position_side_;
+    const std::vector<Trade>& all_trades() const { return trades_; }
+};
+
+// A. drgunjan-F trade 1. The signal bar closes at 9.565; 9.565 / 0.01 lands
+//    at 956.49999... in binary, so the census form rounds it DOWN to 9.56
+//    (the same way 228.765 -> 228.76). TV sized floor(100000 / 9.56) =
+//    10460; the raw divisor gave floor(100000 / 9.565) = 10454. The next bar
+//    opens exactly on the rounded close, so the fill is 9.56 and the frozen
+//    lot is affordable on both bases (10460 * 9.56 = 99997.60 <= 100000).
+//
+//    Pre-fix expectation (kept for the record): qty 10454 @ 9.56, filled.
+//    This bar shape does not reach the decline arms — a DOWN-rounded close
+//    leaves qty * fill below equity; A2/A3 cover the UP-rounded shape that
+//    declined.
+void test_sub_penny_close_rounds_down_sizes_on_tick() {
+    std::printf("-- A: 9.565 close sizes on 9.56 -> 10460, fills --\n");
+    Probe eng(100000.0, 0.01, 0);
+    eng.script = "L.C.";
+    std::vector<Bar> bars = {
+        mk_bar(1000, 9.50, 9.60, 9.45, 9.565),   // S: basis 9.56, qty 10460
+        mk_bar(2000, 9.56, 9.60, 9.50, 9.58),    // fill @ open 9.56
+        mk_bar(3000, 9.58, 9.60, 9.55, 9.58),    // close_all
+        mk_bar(4000, 9.58, 9.60, 9.55, 9.58),    // exit @ 9.58
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.basis_buy.size() == 1);
+    if (!eng.basis_buy.empty()) {
+        CHECK_NEAR(eng.basis_buy[0], 9.56, 1e-12);
+        CHECK_NEAR(eng.frozen_qty[0], 10460.0, 1e-9);   // pre-fix: 10454
+    }
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() == 1) {
+        const Trade& t = eng.all_trades()[0];
+        CHECK(t.is_long);
+        CHECK_NEAR(t.entry_price, 9.56, 1e-9);
+        CHECK_NEAR(t.qty, 10460.0, 1e-9);
+        CHECK_NEAR(t.exit_price, 9.58, 1e-9);
+    }
+    CHECK(eng.position_side_ == PositionSide::FLAT);
+}
+
+// A2. The declining shape. 9.585 / 0.01 = 958.5000... rounds UP to 9.59.
+//     On-tick: qty = floor(100000 / 9.59) = 10427, fill @ 9.59 ->
+//     10427 * 9.59 = 99994.93 <= 100000, admitted (flat arm prices at the
+//     sizing notional; gap-reject sees a zero gap).
+//     Pre-fix: qty = floor(100000 / 9.585) = 10432 and the fill rounded to
+//     9.59 -> 10432 * 9.59 = 100042.88 > 100000 + float_guard, so the
+//     true-flat zero-commission gap-reject arm silently DROPPED the entry
+//     (position FLAT, no trade row) although the open did not gap at all.
+void test_sub_penny_close_rounds_up_fills_instead_of_gap_reject() {
+    std::printf("-- A2: 9.585 close (-> 9.59) fills, no phantom gap-reject --\n");
+    Probe eng(100000.0, 0.01, 0);
+    eng.script = "L.C.";
+    std::vector<Bar> bars = {
+        mk_bar(1000, 9.50, 9.60, 9.45, 9.585),   // S: basis 9.59, qty 10427
+        mk_bar(2000, 9.59, 9.62, 9.55, 9.60),    // fill @ open 9.59 (no gap)
+        mk_bar(3000, 9.60, 9.62, 9.58, 9.60),
+        mk_bar(4000, 9.60, 9.62, 9.58, 9.60),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.basis_buy.size() == 1);
+    if (!eng.basis_buy.empty()) {
+        CHECK_NEAR(eng.basis_buy[0], 9.59, 1e-12);
+        CHECK_NEAR(eng.frozen_qty[0], 10427.0, 1e-9);   // pre-fix: 10432
+    }
+    CHECK(eng.trade_count() == 1);                      // pre-fix: 0 (dropped)
+    if (eng.trade_count() == 1) {
+        const Trade& t = eng.all_trades()[0];
+        CHECK(t.is_long);
+        CHECK_NEAR(t.entry_price, 9.59, 1e-9);
+        CHECK_NEAR(t.qty, 10427.0, 1e-9);
+    }
+    CHECK(eng.position_side_ == PositionSide::FLAT);
+}
+
+// A3. Reversal twin (design-reversal-admission-float-guard arm).
+//   bar0  9.50/9.55/9.45/9.50   on_bar: L — basis 9.50, qty floor(100000/9.5)
+//                               = 10526
+//   bar1  9.50/9.60/9.45/9.585  long fills @ 9.50 x 10526. on_bar: S — the
+//                               SIGNAL bar. On-tick: E = 100000 +
+//                               (9.59 - 9.50) * 10526 = 100947.34, qty =
+//                               floor(100947.34 / 9.59) = 10526.
+//   bar2  9.59/9.62/9.55/9.60   reversal @ 9.59: long closes (+947.34),
+//                               short admission on the float-guard arm:
+//                               required 10526 * 9.59 = 100944.34 <=
+//                               free_funds 100947.34 -> ADMITTED.
+//                               Pre-fix: E marked at the raw 9.585 =
+//                               100894.71 (same qty 10526), required
+//                               100944.34 > 100894.71 + 1e-7 -> DECLINED,
+//                               the close leg suppressed, the long held.
+//   bar3  close_all; bar4 exit.
+void test_sub_penny_reversal_admitted_on_float_guard_arm() {
+    std::printf("-- A3: sub-penny reversal admitted on the float-guard arm --\n");
+    Probe eng(100000.0, 0.01, 0);
+    eng.script = "LS.C.";
+    std::vector<Bar> bars = {
+        mk_bar(1000, 9.50, 9.55, 9.45, 9.50),
+        mk_bar(2000, 9.50, 9.60, 9.45, 9.585),
+        mk_bar(3000, 9.59, 9.62, 9.55, 9.60),
+        mk_bar(4000, 9.60, 9.62, 9.58, 9.60),
+        mk_bar(5000, 9.60, 9.62, 9.58, 9.60),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.basis_sell.size() == 2);
+    if (eng.basis_sell.size() == 2) {
+        CHECK_NEAR(eng.basis_sell[1], 9.59, 1e-12);
+        CHECK_NEAR(eng.frozen_qty[1], 10526.0, 1e-9);
+    }
+    CHECK(eng.trade_count() == 2);                      // pre-fix: 1 (declined)
+    if (eng.trade_count() == 2) {
+        const Trade& t0 = eng.all_trades()[0];
+        CHECK(t0.is_long);
+        CHECK_NEAR(t0.entry_price, 9.50, 1e-9);
+        CHECK_NEAR(t0.qty, 10526.0, 1e-9);
+        CHECK_NEAR(t0.exit_price, 9.59, 1e-9);
+        const Trade& t1 = eng.all_trades()[1];
+        CHECK(!t1.is_long);
+        CHECK_NEAR(t1.entry_price, 9.59, 1e-9);
+        CHECK_NEAR(t1.qty, 10526.0, 1e-9);
+        CHECK_NEAR(t1.exit_price, 9.60, 1e-9);
+    }
+    CHECK(eng.position_side_ == PositionSide::FLAT);
+}
+
+// B. A penny close is unchanged: the basis IS the close (to within one ulp —
+//    double(0.01) is inexact, so round_to_mintick is not bit-for-bit on a
+//    decimal tick; the 1e-12 tolerance below is the honest statement) and
+//    the quantity is the pre-fix number.
+void test_penny_close_unchanged() {
+    std::printf("-- B: penny close unchanged --\n");
+    Probe eng(100000.0, 0.01, 0);
+    eng.script = "L.C.";
+    std::vector<Bar> bars = {
+        mk_bar(1000, 9.50, 9.60, 9.45, 9.56),
+        mk_bar(2000, 9.56, 9.60, 9.50, 9.58),
+        mk_bar(3000, 9.58, 9.60, 9.55, 9.58),
+        mk_bar(4000, 9.58, 9.60, 9.55, 9.58),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.basis_buy.size() == 1);
+    if (!eng.basis_buy.empty()) {
+        CHECK_NEAR(eng.basis_buy[0], 9.56, 1e-12);
+        CHECK_NEAR(eng.basis_sell[0], 9.56, 1e-12);
+        CHECK_NEAR(eng.frozen_qty[0], 10460.0, 1e-9);
+    }
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() == 1) {
+        CHECK_NEAR(eng.all_trades()[0].qty, 10460.0, 1e-9);
+        CHECK_NEAR(eng.all_trades()[0].entry_price, 9.56, 1e-9);
+    }
+}
+
+// C. Futures tick 0.25: 5000.125 / 0.25 = 20000.5 -> floor(20001.0) ->
+//    5000.25 (nearest, up on this exact binary midpoint). Capital 100003
+//    discriminates the divisor: floor(100003 / 5000.25) = 19 on-tick,
+//    floor(100003 / 5000.125) = 20 on the raw close.
+void test_quarter_tick_basis() {
+    std::printf("-- C: mintick 0.25 sizes on 5000.25 --\n");
+    Probe eng(100003.0, 0.25, 0);
+    eng.script = "L.C.";
+    std::vector<Bar> bars = {
+        mk_bar(1000, 4999.00, 5001.00, 4998.00, 5000.125),
+        mk_bar(2000, 5000.25, 5002.00, 4999.00, 5001.00),
+        mk_bar(3000, 5001.00, 5002.00, 4999.00, 5001.00),
+        mk_bar(4000, 5001.00, 5002.00, 4999.00, 5001.00),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK_NEAR(eng.nearest(5000.125), 5000.25, 1e-9);
+    CHECK_NEAR(eng.nearest(4999.875), 5000.00, 1e-9);
+    CHECK(eng.basis_buy.size() == 1);
+    if (!eng.basis_buy.empty()) {
+        CHECK_NEAR(eng.basis_buy[0], 5000.25, 1e-9);
+        CHECK_NEAR(eng.frozen_qty[0], 19.0, 1e-9);      // pre-fix: 20
+    }
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() == 1) {
+        CHECK_NEAR(eng.all_trades()[0].qty, 19.0, 1e-9);
+        CHECK_NEAR(eng.all_trades()[0].entry_price, 5000.25, 1e-9);
+    }
+}
+
+// D. Slippage ticks ride on the ROUNDED basis: 9.565 -> 9.56, then +/-2
+//    ticks -> 9.58 (buy) / 9.54 (sell). Pre-fix: 9.585 / 9.545. The frozen
+//    buy qty is floor(100000 / 9.58) = 10438 and the slipped fill at the
+//    9.56 open is 9.58, so the lot is affordable and fills.
+void test_slippage_added_after_rounding() {
+    std::printf("-- D: slippage ticks added after rounding --\n");
+    Probe eng(100000.0, 0.01, 2);
+    eng.script = "L.C.";
+    std::vector<Bar> bars = {
+        mk_bar(1000, 9.50, 9.60, 9.45, 9.565),
+        mk_bar(2000, 9.56, 9.60, 9.50, 9.58),
+        mk_bar(3000, 9.58, 9.60, 9.55, 9.58),
+        mk_bar(4000, 9.58, 9.60, 9.55, 9.58),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.basis_buy.size() == 1);
+    if (!eng.basis_buy.empty()) {
+        CHECK_NEAR(eng.basis_buy[0], 9.58, 1e-12);      // pre-fix: 9.585
+        CHECK_NEAR(eng.basis_sell[0], 9.54, 1e-12);     // pre-fix: 9.545
+        CHECK_NEAR(eng.frozen_qty[0], 10438.0, 1e-9);   // pre-fix: 10432
+    }
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() == 1) {
+        CHECK_NEAR(eng.all_trades()[0].entry_price, 9.58, 1e-9);
+        CHECK_NEAR(eng.all_trades()[0].qty, 10438.0, 1e-9);
+    }
+}
+
+// Short-cascade probe, the test_margin_call.cpp "A" shape: 1000 capital, 100%
+// short at 1x fills on the bar-0 close (POC), never exits; the adverse
+// cascade is the only mechanism (continuous lots, qty_step 0).
+class ShortCascadeProbe : public BacktestEngine {
+public:
+    ShortCascadeProbe() {
+        initial_capital_ = 1000.0;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100.0;
+        commission_type_ = CommissionType::PERCENT;
+        commission_value_ = 0.0;
+        margin_short_ = 100.0;
+        process_orders_on_close_ = true;
+        qty_step_ = 0.0;
+        set_syminfo_mintick(0.01);
+    }
+    // E3: a take-profit limit armed on bar 1 (position live) so it RESTS on
+    // bar 2 and routes the deficit test through the chronological hook.
+    double tp_limit = kNaN;
+    void on_bar(const Bar& /*bar*/) override {
+        if (bar_index_ == 0) strategy_entry("S", false, kNaN, kNaN, kNaN);
+        if (bar_index_ == 1 && std::isfinite(tp_limit)) {
+            strategy_exit("X", "S", tp_limit, kNaN, kNaN, kNaN, kNaN,
+                          100.0, "", kNaN, "");
+        }
+    }
+    std::string exit_comment(int i) const { return closed_trade_exit_comment(i); }
+    double exit_price(int i) const { return closed_trade_exit_price(i); }
+    double trade_size(int i) const { return closed_trade_size(i); }
+    using BacktestEngine::position_side_;
+    using BacktestEngine::position_qty_;
+};
+
+// E1. Short 10 @ 100 (liq 100.00). bar1 prints a high of 100.004: the
+//     rounded mark is 100.00, equity 1000 == required 1000, NO slice. The
+//     raw mark (pre-fix) read equity 999.96 < required 1000.04 and produced
+//     a phantom 4x(0.0004) slice the on-tick ledger cannot hold.
+void test_short_cascade_ignores_sub_tick_excursion() {
+    std::printf("-- E1: short cascade ignores a sub-tick excursion --\n");
+    std::vector<Bar> bars = {
+        mk_bar(1000, 100.0, 100.0,   99.0, 100.0),   // short 10 @ 100
+        mk_bar(2000, 100.0, 100.004, 99.5,  99.9),   // high rounds to 100.00
+        mk_bar(3000,  99.9, 100.0,   99.0,  99.5),
+    };
+    ShortCascadeProbe eng;
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.trade_count() == 0);                      // pre-fix: 1 phantom
+    CHECK(eng.position_side_ == PositionSide::SHORT);
+    CHECK_NEAR(eng.position_qty_, 10.0, 1e-9);
+}
+
+// E2. Same shape, bar1 high 105.005 (rounds UP to 105.01). Slice at the
+//     rounded mark: q_min = 20 - 2000/105.01 = 0.95419, x4 = 3.8167794.
+//     Pre-fix (raw 105.005 mark): 3.8131518. The fill price was 105.01 on
+//     both bases (bar_fill_price rounds the raw extreme, finding-446).
+void test_short_cascade_slices_at_rounded_high() {
+    std::printf("-- E2: short cascade slice sized at the rounded high --\n");
+    std::vector<Bar> bars = {
+        mk_bar(1000, 100.0, 100.0,    99.0, 100.0),
+        mk_bar(2000, 100.0, 105.005,  99.5, 104.0),
+        mk_bar(3000, 104.0, 104.0,   103.0, 103.5),
+    };
+    ShortCascadeProbe eng;
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.trade_count() >= 1);
+    if (eng.trade_count() >= 1) {
+        CHECK(eng.exit_comment(0) == std::string("Margin call"));
+        CHECK_NEAR(eng.exit_price(0), 105.01, 1e-9);
+        CHECK_NEAR(eng.trade_size(0), 4.0 * (20.0 - 2000.0 / 105.01), 1e-6);
+        // pre-fix: 4.0 * (20.0 - 2000.0 / 105.005) = 3.8131518
+    }
+}
+
+// E3. The chronological copy of the cascade takes the same mark. Bars:
+//   bar0  100/100/99/100      short 10 @ 100 (POC fill at the close)
+//   bar1  100/100/99.5/99.9   on_bar arms a TP limit at 99.60 (rests)
+//   bar2  100/H/99.5/99.9     HIGH-first (|H - 100| < 0.5): O -> H -> L -> C,
+//                             the adverse high precedes the TP fill on the
+//                             H -> L leg, so margin_call_slice_before_priced_
+//                             exit asks the deficit question at H BEFORE the
+//                             TP fills.
+// (a) H = 100.004, the E1 excursion: the rounded mark is 100.00, equity
+//     1000 == required 1000, NO slice; the TP closes the full 10 @ 99.60.
+//     Pre-fix this path marked at the raw 100.004 (equity 999.96 <
+//     required 1000.04) and fired a 4 * 0.0004 = 0.0016 phantom slice —
+//     but ONLY because an exit was resting: the end-of-bar cascade (E1)
+//     already read the rounded high. The ledger cannot depend on that.
+// (b) H = 100.01, on-tick control: equity 999.9 < required 1000.1, q_min =
+//     10 - 999.9 / 100.01 = 0.0019998, slice 4x = 0.0079992 @ 100.01 first
+//     (continuous lots), then the TP closes the 9.9920008 remainder. The
+//     path is live; (a) is silent because of the mark, not eligibility.
+void test_short_chronological_slice_marks_at_rounded_high() {
+    std::printf("-- E3: chronological pre-exit slice marks at the rounded high --\n");
+    {
+        std::vector<Bar> bars = {
+            mk_bar(1000, 100.0, 100.0,   99.0, 100.0),
+            mk_bar(2000, 100.0, 100.0,   99.5,  99.9),
+            mk_bar(3000, 100.0, 100.004, 99.5,  99.9),
+        };
+        ShortCascadeProbe eng;
+        eng.tp_limit = 99.60;
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.trade_count() == 1);                  // pre-fix: 2 (phantom slice + TP)
+        if (eng.trade_count() >= 1) {
+            CHECK(eng.exit_comment(0) != std::string("Margin call"));
+            CHECK_NEAR(eng.exit_price(0), 99.60, 1e-9);
+            CHECK_NEAR(eng.trade_size(0), 10.0, 1e-9);
+        }
+        CHECK(eng.position_side_ == PositionSide::FLAT);
+    }
+    {
+        std::vector<Bar> bars = {
+            mk_bar(1000, 100.0, 100.0,  99.0, 100.0),
+            mk_bar(2000, 100.0, 100.0,  99.5,  99.9),
+            mk_bar(3000, 100.0, 100.01, 99.5,  99.9),
+        };
+        ShortCascadeProbe eng;
+        eng.tp_limit = 99.60;
+        eng.run(bars.data(), (int)bars.size());
+        const double q_min = 10.0 - (1000.0 - 0.01 * 10.0) / 100.01;
+        CHECK(eng.trade_count() == 2);
+        if (eng.trade_count() == 2) {
+            CHECK(eng.exit_comment(0) == std::string("Margin call"));
+            CHECK_NEAR(eng.exit_price(0), 100.01, 1e-9);
+            CHECK_NEAR(eng.trade_size(0), 4.0 * q_min, 1e-9);
+            CHECK(eng.exit_comment(1) != std::string("Margin call"));
+            CHECK_NEAR(eng.exit_price(1), 99.60, 1e-9);
+            CHECK_NEAR(eng.trade_size(1), 10.0 - 4.0 * q_min, 1e-9);
+        }
+        CHECK(eng.position_side_ == PositionSide::FLAT);
+    }
+}
+
+// F. The helper on the census closes: the rounding this file depends on.
+void test_helper_census_values() {
+    std::printf("-- F: round_to_mintick on the census closes --\n");
+    Probe eng(100000.0, 0.01, 0);
+    CHECK_NEAR(eng.nearest(9.565), 9.56, 1e-12);        // down (binary quotient)
+    CHECK_NEAR(eng.nearest(9.585), 9.59, 1e-12);        // up
+    CHECK_NEAR(eng.nearest(228.765), 228.76, 1e-12);    // the AAPL down case
+    CHECK_NEAR(eng.nearest(214.385), 214.39, 1e-12);    // the AAPL up case
+    CHECK(eng.nearest(9.56) == eng.nearest(eng.nearest(9.56)));   // idempotent
+}
+
+}  // namespace
+
+int main() {
+    std::printf("--- sizing_basis_mintick ---\n");
+    test_sub_penny_close_rounds_down_sizes_on_tick();
+    test_sub_penny_close_rounds_up_fills_instead_of_gap_reject();
+    test_sub_penny_reversal_admitted_on_float_guard_arm();
+    test_penny_close_unchanged();
+    test_quarter_tick_basis();
+    test_slippage_added_after_rounding();
+    test_short_cascade_ignores_sub_tick_excursion();
+    test_short_cascade_slices_at_rounded_high();
+    test_short_chronological_slice_marks_at_rounded_high();
+    test_helper_census_values();
+    std::printf("\n=== Results: %d passed, %d failed ===\n",
+                tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
TradingView sizes a default `percent_of_equity` (and `cash`) order from a snapshot at the signal bar's close **rounded to `syminfo.mintick`** — `qty = floor(E / round_to_mintick(close))`, equity marked at the same rounded close. The engine froze that snapshot at the raw close. Fills were already on-tick in both, so on a sub-tick close the frozen qty × rounded fill exceeded the sizing equity by ~qty × ½ tick and the reversal float-guard / zero-commission gap-reject declined the entry as a phantom adverse gap.

Symbol-specific magnitude: 55% of NYSE:F 15m closes are half-penny (5% on AAPL); shortfall/remainder ≈ E·0.005/price² ≈ 50 on a $10 stock vs 0.1 on a $200 one. Replay over TradingView tapes: 463/463 missing F entries predicted, 0 counterexamples; TV quantities fit `floor(E / rounded close)` on 674/674 F and 832/832 AAPL reversals (raw close: 476/674).

**Changes**: `frozen_sizing_price` rounds before slippage ticks; `calc_qty` marks/divides at the rounded basis; both strategy-command sizing snapshots and `calc_qty_for_type`'s explicit branch follow; the short margin-call cascade marks its deficit at the rounded adverse high on both cascade paths (chronology keeps the raw high as a path point). Gate comments state the true invariant (zero shortfall at slippage 0, one ulp otherwise, inside the float guard). Three `test_margin_call` pins re-derived on on-tick highs of the same q_min shape; new `tests/test_sizing_basis_mintick.cpp`.

## Measurement (Cloud Run, dirty tree `d0de6820` = this commit's tree)
NYSE:F@15 (`exp-f-sizing-basis-20260902`) vs the current baseline sweep, the 12 probes that were weak only on F:

| probe | before (tier, match, engine/TV) | after |
|---|---|---|
| taro-s-c-c-ma-simplified-2-color | weak 35.4% 490/1092 | strong 100% 1095/1092 |
| willowsportz-…-ut-williams | weak 39.9% 916/1937 | excellent 99.9% 1937/1937 |
| winthetrade-ema-9-vwap-…-atr-trailing-stop | weak 45.1% 244/500 | moderate 100% 513/500 |
| markittick-intra-candle-pressure | weak 47.5% 673/1142 | excellent 99.9% 1142/1142 |
| shojiy940207-atr-big-candle-alert-v2 | weak 49.6% 165/271 | excellent 99.3% 270/271 |
| elistools-fvg-toolkit-smart-money | weak 49.7% 419/674 | excellent 99.7% 671/674 |
| artificialintelligencealgo-algoai-ema-rsi | weak 50% 203/375 | excellent 99.6% 375/375 |
| tradingfinder-vwap-choppy-market-detector | weak 54.2% 108/181 | excellent 99.1% 180/181 |
| cntvxiao-smc-vsa-oi | weak 57.1% 93/153 | excellent 100% 153/153 |
| drgunjanpupadhyay-swing-trend-…-nifty-500 | weak 58.1% 44/62 | excellent 100% 62/62 |
| jake-theboss-master-trend-strategy-v1-0 | weak 58.6% 88/147 | strong 99.2% 149/147 |
| maziblend35-market-bias-30m | weak 60% 12/15 | (case resubmitted after a Cloud Run task failed to start) |

NASDAQ:AAPL@15 control (`exp-aapl-sizing-basis-20260902`): nothing fell; taro 91.5→100, willowsportz 90→99.9, markittick 91.2→100, jake 95.7→100.

## Test plan
- [x] engine `ctest` 148/148 with `-UNDEBUG`; `test_margin_call` 463/0; `test_sizing_basis_mintick` 77/0
- [x] Cloud Run lane experiments above
- [ ] full-population `gate_candidate` PASS recorded (in progress; futures/forex lanes are the regression control for the coarse-tick sizing change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXAE7TVTKZYbmtenHDHVJo