### PR TITLE
fix: TradingView range-end accounting for open positions; pad the TV-entry gate by the feed's previous bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ int main(void) {
 | `pf_version_string`                      | Full runtime version string                   |
 
 
-POD types (`pf_bar_t`, `pf_trade_tick_t`, `pf_trade_t`, `pf_report_t`, `pf_security_diag_t`, `pf_trace_entry_t`, `pf_version_t`, and — since ABI v2 — `pf_trade_stats_t`, `pf_equity_stats_t`, `pf_metrics_t`, `pf_equity_point_t`) and the `pf_magnifier_distribution_t` enum complete the surface. ABI v2 (`PF_ABI_VERSION == 2`, exported as `pf_abi_version()`) appends computed trading metrics and a per-script-bar equity curve to `pf_report_t`; callers must verify the version before running since the report struct is caller-allocated.
+POD types (`pf_bar_t`, `pf_trade_tick_t`, `pf_trade_t`, `pf_report_t`, `pf_security_diag_t`, `pf_trace_entry_t`, `pf_version_t`, and — since ABI v2 — `pf_trade_stats_t`, `pf_equity_stats_t`, `pf_metrics_t`, `pf_equity_point_t`) and the `pf_magnifier_distribution_t` enum complete the surface. ABI v2 appends computed trading metrics and a per-script-bar equity curve to `pf_report_t`; ABI v3 (`PF_ABI_VERSION == 3`, exported as `pf_abi_version()`) appends `pf_trade_t::open_at_end`, the flag on the range-end close of a position still open after the final bar (TradingView's deep-backtest accounting). Callers must verify the version before running since the report struct is caller-allocated and the trades array stride grew.
 
 **Stability guarantee:** within the same `PINEFORGE_VERSION_MAJOR`, struct layouts and `extern "C"` signatures are append-only. New fields may be appended; existing fields are never reordered, removed, or retyped. New functions may be added; existing functions are never removed or signature-changed. Compile-time `static_assert`s in `src/c_abi.cpp` pin the layouts against drift.
 

--- a/benchmarks/throughput/grid_search_repro.py
+++ b/benchmarks/throughput/grid_search_repro.py
@@ -29,6 +29,7 @@ class pf_trade_t(ctypes.Structure):
         ("commission", ctypes.c_double),
         ("entry_bar_index", ctypes.c_int32),
         ("exit_bar_index", ctypes.c_int32),
+        ("open_at_end", ctypes.c_int32),   # ABI v3: range-end close row
     ]
 
 class pf_trade_stats_t(ctypes.Structure):
@@ -127,7 +128,7 @@ class pf_report_t(ctypes.Structure):
 
 # pf_report_t is caller-allocated; a layout mismatch means the runtime
 # writes past this script's report buffer. Verify the ABI before running.
-EXPECTED_PF_ABI = 2
+EXPECTED_PF_ABI = 3
 
 def check_abi(lib):
     try:

--- a/docker/run_json.py
+++ b/docker/run_json.py
@@ -42,6 +42,8 @@ Schema:
           "commission":      float,   # ABI v2
           "entry_bar_index": int,     # ABI v2: script-bar index of entry fill
           "exit_bar_index":  int,     # ABI v2: script-bar index of exit fill
+          "open_at_end":     bool,    # ABI v3: range-end close of a position still
+                                      # open after the final bar (TV accounting)
           "entry_incarnation": int    # run-scoped physical-entry provenance;
                                         # 0 when the strategy lacks the accessor
         },
@@ -575,6 +577,7 @@ class TradeC(ctypes.Structure):
         ("commission",      ctypes.c_double),
         ("entry_bar_index", ctypes.c_int32),
         ("exit_bar_index",  ctypes.c_int32),
+        ("open_at_end",     ctypes.c_int32),   # ABI v3: range-end close row
     ]
 
 
@@ -701,7 +704,7 @@ def engine_version(lib: ctypes.CDLL) -> dict:
 
 # pf_report_t is CALLER-allocated: a .so built against a different ABI
 # writes past (or short of) our ReportC buffer. Assert version up front.
-EXPECTED_PF_ABI = 2
+EXPECTED_PF_ABI = 3
 
 
 def check_abi(lib: ctypes.CDLL) -> None:
@@ -869,6 +872,7 @@ def build_report_dict(report: ReportC, ohlcv_path: Path,
             "commission":      float(t.commission),
             "entry_bar_index": int(t.entry_bar_index),
             "exit_bar_index":  int(t.exit_bar_index),
+            "open_at_end":     bool(t.open_at_end),
             "entry_incarnation": (
                 int(trade_entry_incarnations[i])
                 if trade_entry_incarnations is not None

--- a/docs/pages/examples-rust.md
+++ b/docs/pages/examples-rust.md
@@ -60,6 +60,9 @@ struct PfTrade {
     commission: f64,
     entry_bar_index: i32,
     exit_bar_index: i32,
+    // ABI v3: 1 on the range-end close of a position still open after the
+    // final bar (TradingView's deep-backtest accounting)
+    open_at_end: i32,
 }
 
 // ── ABI v2 metrics PODs ──────────────────────────────────────────────
@@ -165,7 +168,7 @@ struct PfReport {
 const PF_MAGNIFIER_ENDPOINTS: c_int = 3;
 
 // PfReport is CALLER-allocated: before any run, resolve `pf_abi_version`
-// via libloading and assert it returns 2 (PF_ABI_VERSION) — an old .so
+// via libloading and assert it returns 3 (PF_ABI_VERSION) — an old .so
 // writing into this larger struct (or vice versa) corrupts memory silently.
 
 // ── Safe wrapper ──────────────────────────────────────────────────────

--- a/docs/pages/ffi-python.md
+++ b/docs/pages/ffi-python.md
@@ -48,6 +48,7 @@ class pf_trade_t(ctypes.Structure):
         ("commission",      ctypes.c_double),   # ABI v2
         ("entry_bar_index", ctypes.c_int32),    # ABI v2
         ("exit_bar_index",  ctypes.c_int32),    # ABI v2
+        ("open_at_end",     ctypes.c_int32),    # ABI v3: range-end close row
     ]
 
 class pf_trade_stats_t(ctypes.Structure):
@@ -177,7 +178,7 @@ lib = ctypes.CDLL("./my_strategy.so")
 # ABI guard — pf_report_t is CALLER-allocated, so running an old .so
 # against the v2 mirror above (or vice versa) silently corrupts memory.
 # Verify the .so's layout version before any run:
-EXPECTED_PF_ABI = 2   # PF_ABI_VERSION in <pineforge/pineforge.h>
+EXPECTED_PF_ABI = 3   # PF_ABI_VERSION in <pineforge/pineforge.h>
 try:
     lib.pf_abi_version.restype = ctypes.c_int
     abi = lib.pf_abi_version()

--- a/docs/pages/report-schema.md
+++ b/docs/pages/report-schema.md
@@ -58,8 +58,10 @@ typedef struct pf_report_s {
 
 @note The `metrics` / `equity_curve` fields were appended in **ABI
 version 2** (`PF_ABI_VERSION`). `pf_report_t` is caller-allocated, so
-consumers must check `pf_abi_version() == 2` before running — a `.so`
+consumers must check `pf_abi_version() == 3` before running — a `.so`
 with no `pf_abi_version` symbol is ABI v1 and predates these fields.
+**ABI version 3** appends `pf_trade_t::open_at_end`, the range-end close
+flag; a v2 reader would misindex the trades array.
 
 ## Trade fields
 
@@ -88,6 +90,9 @@ typedef struct pf_trade_s {
     double  commission;     /* ABI v2: entry+exit commission deducted from pnl */
     int32_t entry_bar_index;/* ABI v2: script-bar index of entry fill (0-based) */
     int32_t exit_bar_index; /* ABI v2: script-bar index of exit fill (0-based) */
+    int32_t open_at_end;    /* ABI v3: 1 on the range-end close of a position still
+                               open after the final bar (TradingView's deep-backtest
+                               accounting: exit = last bar at its close, no Signal) */
 } pf_trade_t;
 ```
 

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -105,6 +105,10 @@ struct Trade {
     // Physical-entry provenance copied from PyramidEntry. This is deliberately
     // separate from entry_id: Pine permits user-visible IDs to be reused.
     uint64_t entry_incarnation = 0;
+    // True for the range-end close of a position still open after the final
+    // bar (record_range_end_close_trades); false for every script-driven
+    // or bracket exit. Mirrors pf_trade_t::open_at_end.
+    bool open_at_end = false;
 };
 
 struct TradeC {
@@ -124,6 +128,7 @@ struct TradeC {
     double commission;           // mirrors pf_trade_t tail; semantics documented in pineforge.h
     int32_t entry_bar_index;
     int32_t exit_bar_index;
+    int32_t open_at_end;         // ABI v3: 1 on the range-end close row (pineforge.h)
 };
 
 struct SecurityDiagC {
@@ -1125,6 +1130,12 @@ protected:
     bool current_fill_is_limit_ = false;
 
     std::vector<Trade> trades_;
+    // TradingView's range-end accounting (record_range_end_close_trades,
+    // engine_orders.cpp): the rows that close a position still open after
+    // the final script bar, at that bar's close. Report-only — they are
+    // merged behind trades_ by fill_trades_section and never enter trades_,
+    // the realized sums, or the live position (a stream continues it).
+    std::vector<Trade> range_end_trades_;
     std::vector<PendingOrder> pending_orders_;
     // A rejected strategy.entry call leaves no PendingOrder behind. The exact
     // collision gate can consume only the immediately preceding source bar, so
@@ -2388,9 +2399,13 @@ protected:
 
     // --- Equity extremes update (called after each on_bar) ---
     // NOTE: the dd/runup walk in src/engine_metrics.cpp (compute_equity_stats)
-    // MUST mirror this trough-reset logic; keep in lockstep.
-    void update_equity_extremes() {
-        double eq = initial_capital_ + net_profit_sum_ + open_profit(current_bar_.close);
+    // MUST mirror this trough-reset logic; keep in lockstep. The fold is
+    // exactly one per script bar and always paired with record_equity_point,
+    // so the curve holds the very values folded here and a re-walk of the
+    // curve through fold_equity_extreme reproduces the scalars bit for bit
+    // — record_range_end_close_trades (engine_orders.cpp) relies on that
+    // when it re-marks the last point.
+    void fold_equity_extreme(double eq) {
         if (eq > max_equity_) {
             max_equity_ = eq;
             min_equity_ = eq;  // reset trough on new peak
@@ -2402,6 +2417,9 @@ protected:
         if (dd > max_drawdown_) max_drawdown_ = dd;
         double ru = eq - min_equity_;
         if (ru > max_runup_) max_runup_ = ru;
+    }
+    void update_equity_extremes() {
+        fold_equity_extreme(initial_capital_ + net_profit_sum_ + open_profit(current_bar_.close));
 
         // --- Update max_contracts_held_* running peaks ---
         double abs_qty = std::abs(position_qty_);
@@ -2578,6 +2596,14 @@ private:
                               bool explicit_qty_prequantized,
                               uint64_t entry_incarnation);
     void execute_market_exit(double fill_price);
+    // Range-end accounting: record the rows that close a position still
+    // open after the final script bar at that bar's close, the way
+    // TradingView's deep-backtest report does (engine_orders.cpp). Called by
+    // every run() overload after its bar loop; a no-op when flat or during
+    // a stream warmup replay. Reporting only: the live position is kept; the
+    // last equity point is re-marked to the flat account and the scalar
+    // drawdown / run-up extremes re-folded from the curve to match.
+    void record_range_end_close_trades();
     void execute_partial_exit_qty(
         double fill_price, double qty_to_close,
         PositionReductionCause cause = PositionReductionCause::SCRIPT_ORDER);
@@ -2818,6 +2844,13 @@ private:
     // engine_orders.cpp).
     void emit_close_trade(const PyramidEntry& pe, double close_qty,
                           double fill_price, bool was_long);
+    // The arithmetic of emit_close_trade without its bookkeeping: the Trade
+    // row a close of ``close_qty`` of ``pe`` at ``fill_price`` on the
+    // current bar would record (pnl, pnl_pct, commission, excursions, bar
+    // indexes). emit_close_trade builds and commits; the range-end close
+    // builds only.
+    Trade build_close_trade(const PyramidEntry& pe, double close_qty,
+                            double fill_price, bool was_long) const;
     // FIFO-drain up to qty_limit from pyramid_entries_, in order, splitting the
     // boundary entry as needed. When from_entry is non-null only entries whose
     // entry_id == *from_entry are eligible (others are kept untouched); null

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -952,6 +952,16 @@ protected:
     // classes no longer write it.
     bool script_has_strategy_close_ = false;
     int64_t trade_start_time_ = std::numeric_limits<int64_t>::min();
+    // Script-bar index of the bar immediately PRECEDING the first script bar
+    // whose timestamp is >= trade_start_time_, computed per run() from the
+    // feed (compute_trade_start_preceding_script_bar); -1 when there is no
+    // gate, no such bar, or nothing precedes it. The validator's gate is
+    // TradingView's first entry bar; the command gate admits this one bar in
+    // front of it whatever calendar gap sits between them — a weekend, a
+    // holiday, a session break — because the signal that TradingView filled
+    // on the first in-window bar was placed on it, and nothing earlier (see
+    // trading_is_active in engine_strategy_commands.cpp).
+    int trade_start_preceding_script_bar_ = -1;
 
     // Cumulative qty of ``strategy.close`` / ``strategy.close_all`` calls
     // issued during the CURRENT on_bar. Reset at the start of every bar
@@ -3080,6 +3090,12 @@ public:
     void set_trade_start_time(int64_t timestamp_ms) {
         trade_start_time_ = timestamp_ms;
     }
+    // Resolve trade_start_preceding_script_bar_ for this feed (engine_run.cpp).
+    // Runs a preview of the script-TF aggregation when the feed is aggregated
+    // so the index it finds is the one the bar loop will assign.
+    void compute_trade_start_preceding_script_bar(const Bar* input_bars,
+                                                  int n_input,
+                                                  bool needs_aggregation);
 
     // Set the chart's display timezone. Stored in a dedicated slot so it
     // does NOT clobber ``syminfo_.timezone`` (the symbol/exchange TZ).

--- a/include/pineforge/pineforge.h
+++ b/include/pineforge/pineforge.h
@@ -74,8 +74,10 @@
  *  iterate the trades array with the stale sizeof. Value 2 = first
  *  versioned layout (metrics + equity curve); .so files predating this
  *  macro have no pf_abi_version symbol — treat dlsym failure as
- *  version 1. */
-#define PF_ABI_VERSION 2
+ *  version 1. Value 3 appends pf_trade_t::open_at_end (the range-end
+ *  close flag); a v2 reader iterating trades with the v2 stride would
+ *  misindex every row after the first. */
+#define PF_ABI_VERSION 3
 
 /** Feature probe for the opt-in split chart/request.security feed boundary.
  *  When defined, #strategy_set_aux_security_feed is available. */
@@ -156,6 +158,21 @@ typedef struct pf_trade_s {
                              *   (account currency). pnl is already net of this. */
     int32_t entry_bar_index;/**< Script-bar index of the entry fill (0-based). */
     int32_t exit_bar_index; /**< Script-bar index of the exit fill (0-based). */
+    int32_t open_at_end;    /**< 1 when this row is the RANGE-END close of a position
+                             *   that was still open after the final bar; 0 for an
+                             *   exit the script or a bracket produced. TradingView's
+                             *   deep-backtest report does not leave the last position
+                             *   open: it reports it as a closed trade whose exit leg is
+                             *   the range's last bar at that bar's CLOSE, with an
+                             *   empty exit Signal, and counts it in closedTrades
+                             *   (orb-lite on NYSE:F 1D: Entry short 2026-03-16 @ 11.82,
+                             *   Exit 2026-04-30 @ 12.08 = the last close,
+                             *   closedTrades:1). The engine emulates that row
+                             *   (operator decision 2026-09-02): exit_time is the last
+                             *   script bar's label, exit_price its mintick-rounded
+                             *   close with no slippage, commission per the strategy's
+                             *   rules, pnl/pnl_pct/excursions as for any close.
+                             *   Appended in ABI v3. */
 } pf_trade_t;
 
 /** Trade-level statistics block — computed once each for all / long / short.
@@ -314,8 +331,11 @@ typedef struct pf_trace_entry_s {
 
 typedef struct pf_report_s {
     /* Trades */
-    int             total_trades;       /**< Closed-trade count (== trades_len). */
-    pf_trade_t*     trades;             /**< Heap array of closed trades. */
+    int             total_trades;       /**< Closed-trade count (== trades_len), including
+                                         *   the range-end close of a position still open
+                                         *   after the final bar (pf_trade_t::open_at_end). */
+    pf_trade_t*     trades;             /**< Heap array of closed trades; script-driven exits
+                                         *   first, then the range-end rows (open_at_end=1). */
     int             trades_len;         /**< Length of #trades. */
     double          net_profit;         /**< Sum of all closed-trade PnL. */
 

--- a/scripts/pf_release_run.py
+++ b/scripts/pf_release_run.py
@@ -155,6 +155,7 @@ def report_trades_to_runstrategy_shape(report: dict) -> list[dict]:
             "commission": float(t.get("commission", 0.0)),
             "entry_bar_index": int(t.get("entry_bar_index", -1)),
             "exit_bar_index": int(t.get("exit_bar_index", -1)),
+            "open_at_end": bool(t.get("open_at_end", False)),
             "entry_incarnation": int(t.get("entry_incarnation", 0) or 0),
         })
     return out

--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -665,6 +665,9 @@ class TradeC(ctypes.Structure):
         ("commission", ctypes.c_double),
         ("entry_bar_index", ctypes.c_int32),
         ("exit_bar_index", ctypes.c_int32),
+        # ABI v3: 1 on the range-end close of a position still open after the
+        # final bar (TradingView's deep-backtest accounting; pineforge.h).
+        ("open_at_end", ctypes.c_int32),
     ]
 
 
@@ -767,10 +770,15 @@ class ReportC(ctypes.Structure):
 
 
 # ABI version this harness mirrors (PF_ABI_VERSION in pineforge.h).
-# pf_report_t is CALLER-allocated: running an old .so against the v2
+# pf_report_t is CALLER-allocated: running an old .so against the v3
 # ReportC mirror (or vice versa) silently corrupts memory, so the .so's
-# pf_abi_version() export is asserted before any run.
-EXPECTED_PF_ABI = 2
+# pf_abi_version() export is asserted before any run. v3 appended
+# pf_trade_t::open_at_end (TradeC above); test_run_strategy_range_end.py
+# pins this constant to the header's macro, because the campaign's
+# verifier runs every probe through THIS harness and a stale guard here
+# is a run-error on every slug (the f-1d spark pre-check of 2026-09-02
+# found exactly that: ".so reports 3, harness expects 2" x64).
+EXPECTED_PF_ABI = 3
 
 
 def _check_abi(lib: ctypes.CDLL) -> None:
@@ -1641,6 +1649,11 @@ def _report_to_dict(r: ReportC) -> dict:
             "commission": float(t.commission),
             "entry_bar_index": int(t.entry_bar_index),
             "exit_bar_index": int(t.exit_bar_index),
+            # Range-end close of a position still open after the final bar
+            # (engine_orders.cpp record_range_end_close_trades). Carried
+            # through for JSON consumers; the CSV writer emits the row as an
+            # ordinary exit, which is how the ws-report-v1 tape prints it.
+            "open_at_end": bool(t.open_at_end),
         })
     trace_names: list[str] = []
     for i in range(r.trace_names_len):
@@ -1713,6 +1726,80 @@ def _filter_trace_to_window(trace: list[dict], window: tuple[int, int] | None) -
     ]
 
 
+def _load_tv_range_end_ms(strategy_dir: Path, meta: dict) -> int | None:
+    """The last bar of TradingView's backtest range, as the tape tells it:
+    the latest ``Date and time`` over EVERY row of tv_trades.csv — entries,
+    exits, and the row TV writes for a position still open at the range's
+    end (exit on the last bar at its close; Signal "Open" on a browser
+    export, empty on a ws-report-v1 tape). None without a tape or rows.
+
+    This bounds the feed the engine measures (``ohlcv_end_ms``). The engine
+    books a position still open after its FINAL bar as TradingView's
+    range-end close (record_range_end_close_trades, engine_orders.cpp), so
+    that final bar must be TV's last bar, not the feed's. On the ws-report
+    lanes the two coincide — NYSE:F 1D/15, NASDAQ:AAPL 15, NSE:NIFTY 15 end
+    on the last 2026-04-30 session bar and BINANCE:BTCUSDT, OANDA:XAUUSD,
+    CME_MINI:ES1!, OANDA:EURUSD, CME_MINI:NQ1! on the 2026-05-01 00:00 UTC
+    bar, exactly where the tapes' open-position rows sit (F 1D 04-30 @
+    12.08, XAU 15 @ 4622.71, ES 15 @ 7252.25, BTC 15 @ 76469.81, NIFTY @
+    24043.7, AAPL @ 271). The BINANCE:ETHUSDT.P 15 chart feed does not: it
+    runs on to 2026-05-04 15:00 UTC while every ETH tape ends at 2026-05-01
+    00:00 UTC (286 of 305 tapes with an Open row there, price 2261.44 = that
+    bar's close), and the engine already traded past the range there
+    (roi10x-shiva-lt-ls-blend's baseline tape exits at 05-01 00:15).
+    Unbounded, the range-end row would be booked on 05-04 15:00 @ 2365.09 —
+    a different bar and ~4.6% off TV's row — and pair with TV's Open row on
+    its entry, failing exit/pnl where the row was previously simply absent
+    (review finding on the first cut of this change, 2026-09-02).
+
+    Bounding by the tape's last row hides nothing the emit window did not
+    already hide: engine trades ENTERED after TV's last entry are dropped by
+    _filter_trades_to_window regardless, and the bound sits at or after
+    that entry. What it changes is only where a position still open at TV's
+    last row is marked: on that bar, as TV marks it."""
+    tv_name = str(meta.get("tv_trades_csv", "tv_trades.csv"))
+    tv_path = strategy_dir / tv_name
+    if not tv_path.exists():
+        return None
+    tz_offset = _tv_tzinfo(meta)
+    latest: int | None = None
+    with tv_path.open(encoding="utf-8-sig") as f:
+        for row in csv.DictReader(f):
+            stamp = str(row.get("Date and time", "")).strip()
+            if not stamp:
+                continue
+            ts = _parse_trade_dt(stamp, tz_offset)
+            latest = ts if latest is None else max(latest, ts)
+    return latest
+
+
+def _trim_ohlcv_csv(ohlcv_path: Path, start_ms: int | None, end_ms: int | None) -> Path | None:
+    """Write a copy of ``ohlcv_path`` holding only the bars inside
+    ``[start_ms, end_ms]`` (either bound optional, both inclusive) to a
+    temporary file and return its path; None when neither bound is set.
+    The ctypes runner applies the same bounds in _load_bars; the container
+    runner needs an already-trimmed CSV (M8 — feed the same trimmed feed
+    downstream). The caller unlinks the file."""
+    if start_ms is None and end_ms is None:
+        return None
+    import tempfile
+    fd, p = tempfile.mkstemp(suffix=".csv", prefix="pf_ohlcv_")
+    out = Path(p)
+    with ohlcv_path.open(newline="", encoding="utf-8") as fin, \
+            os.fdopen(fd, "w", newline="") as fout:
+        r = csv.DictReader(fin)
+        w = csv.DictWriter(fout, fieldnames=r.fieldnames)
+        w.writeheader()
+        for row in r:
+            ts = int(row["timestamp"])
+            if start_ms is not None and ts < int(start_ms):
+                continue
+            if end_ms is not None and ts > int(end_ms):
+                continue
+            w.writerow(row)
+    return out
+
+
 def format_trade_qty(qty: float) -> str:
     """Lot-faithful quantity text for the TV-alignable export.
 
@@ -1748,7 +1835,15 @@ def write_engine_trades_csv(trades: list[dict], path: Path) -> None:
     NEGATIVE total-USD drawdown (TV exports e.g. -8579.36). The engine ABI's
     `max_drawdown` stays positive — that mirrors Pine's
     `strategy.*trades.max_drawdown` accessors — so the sign flip happens only
-    here, in the TV-compatible export representation."""
+    here, in the TV-compatible export representation.
+
+    A trade flagged ``open_at_end`` (the engine's range-end close of a
+    position still open after the final bar) is written like any other
+    trade: TradingView's deep-backtest tape reports that position as an
+    ordinary closed trade whose exit row is the last bar at its close with
+    an EMPTY Signal (orb-lite NYSE:F 1D — Exit short 2026-04-30 @ 12.08),
+    so the row must look like every other exit for the verifier to pair it.
+    The flag stays available on the report dict for JSON consumers."""
     cum_pnls: dict[int, float] = {}
     running = 0.0
     for n, t in enumerate(trades, 1):
@@ -1850,8 +1945,9 @@ def _run_via_docker(strategy_dir: Path, ohlcv_path: Path, params: dict,
 
     Mirrors Strategy.run's engine setup exactly: inputs filter, strategy_overrides,
     input_tf/script_tf, magnifier (incl. the VOLUME_WEIGHTED->ENDPOINTS+vw mapping),
-    trade_start_time, chart_timezone, syminfo. ohlcv_start_ms is applied by
-    pre-trimming the CSV fed to the container (the ctypes path trims in _load_bars).
+    trade_start_time, chart_timezone, syminfo. ohlcv_start_ms / ohlcv_end_ms are
+    applied by pre-trimming the CSV fed to the container (the ctypes path trims
+    in _load_bars).
     NEVER re-transpiles .pine (uses the committed cpp, no codegen variance)."""
     import pf_release_run as _rel
     if run_kwargs.get("account_currency_fx_series") is not None:
@@ -1862,24 +1958,13 @@ def _run_via_docker(strategy_dir: Path, ohlcv_path: Path, params: dict,
     if not generated_cpp.exists():
         raise FileNotFoundError(f"generated.cpp not found for --runner docker: {generated_cpp}")
 
-    # ohlcv_start_ms: ctypes trims bars in _load_bars; the container needs an
-    # already-trimmed CSV (M8 — feed the same trimmed feed downstream).
-    ohlcv_for_image = ohlcv_path
-    tmp_ohlcv = None
-    start_ms = run_kwargs.get("ohlcv_start_ms")
-    if start_ms is not None:
-        import tempfile
-        fd, p = tempfile.mkstemp(suffix=".csv", prefix="pf_ohlcv_")
-        tmp_ohlcv = Path(p)
-        with ohlcv_path.open(newline="", encoding="utf-8") as fin, \
-                os.fdopen(fd, "w", newline="") as fout:
-            r = csv.DictReader(fin)
-            w = csv.DictWriter(fout, fieldnames=r.fieldnames)
-            w.writeheader()
-            for row in r:
-                if int(row["timestamp"]) >= int(start_ms):
-                    w.writerow(row)
-        ohlcv_for_image = tmp_ohlcv
+    # ohlcv_start_ms / ohlcv_end_ms: ctypes trims bars in _load_bars; the
+    # container needs an already-trimmed CSV (M8 — feed the same trimmed
+    # feed downstream). The end bound is TradingView's range end, so the
+    # engine's range-end close lands on TV's last bar (_load_tv_range_end_ms).
+    tmp_ohlcv = _trim_ohlcv_csv(ohlcv_path, run_kwargs.get("ohlcv_start_ms"),
+                                run_kwargs.get("ohlcv_end_ms"))
+    ohlcv_for_image = tmp_ohlcv if tmp_ohlcv is not None else ohlcv_path
 
     # Magnifier dist/vw: mirror Strategy.run. 'VOLUME_WEIGHTED' is not a geometric
     # distribution — fall back to ENDPOINTS for the t-grid AND toggle vw.
@@ -2034,6 +2119,17 @@ def main() -> int:
     if emit_window is not None and not args.allow_trading_before_window:
         if tv_window_used or args.disable_trading_before_window:
             trade_start_ms = emit_window[0]
+    # The measurement ends where TradingView's range ends. The engine books
+    # a position still open after its final bar as TV's range-end close
+    # (open_at_end), so the final bar it sees must be TV's last bar: bound
+    # the feed to the tape's last row (_load_tv_range_end_ms — the ETH chart
+    # feed runs three days past every ETH tape). Only with a tape in use;
+    # an explicit --emit-window-ohlcv / --no-trim-output run measures the
+    # feed it was given.
+    if tv_window_used and run_kwargs.get("ohlcv_end_ms") is None:
+        range_end_ms = _load_tv_range_end_ms(strategy_dir, params)
+        if range_end_ms is not None:
+            run_kwargs["ohlcv_end_ms"] = range_end_ms
 
     if args.runner == "docker":
         if args.trace_json is not None:

--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -1907,7 +1907,48 @@ def _parse_trade_dt(s: str, tz) -> int:
     return int(datetime.strptime(s, "%Y-%m-%d %H:%M").replace(tzinfo=tz).timestamp() * 1000)
 
 
-def _load_tv_entry_window(strategy_dir: Path, meta: dict, bar_interval_ms: int) -> tuple[int, int] | None:
+def _load_tv_entry_window(strategy_dir: Path, meta: dict) -> tuple[int, int] | None:
+    """The emit / trade-start window of a probe with a TradingView tape:
+    ``(first TV entry time, last TV entry time)`` in ms, or None without a
+    tape or without entries.
+
+    The window START is TradingView's first entry bar itself. It is the
+    engine's ``trade_start_time`` gate (strategy.* commands before it are
+    dropped so warmup bars do not pollute the comparison) and the lower
+    bound of the trades written to engine_trades.csv, so the engine's tape
+    begins exactly where TV's does.
+
+    It used to be ``min(entries) - bar_interval_ms``: one bar of pad so the
+    SIGNAL bar that produced TV's first entry could place its order. That
+    pad was calendar-blind, and the daily lanes exposed it. The bar before
+    a Monday is Friday, three calendar days back: orb-lite on NYSE:F 1D
+    fires its short on the 2026-03-13 (Friday) bar and TV fills it on
+    2026-03-16 (Monday), its first entry. The window opened on Sunday, the
+    engine's own one-script-TF buffer (trading_is_active,
+    engine_strategy_commands.cpp) reached Saturday, and Friday's
+    strategy.entry was dropped — the probe's whole tape shifted. The same
+    shape hides on every session gap (a Friday-close signal on an intraday
+    equity feed, a holiday, the 17:00 ET forex open whose opening minutes
+    the tape does not print).
+
+    The pad now lives in ONE place, the engine, by INDEX on the feed: the
+    engine resolves the script bar immediately preceding the first script
+    bar at/after the gate (compute_trade_start_preceding_script_bar,
+    engine_run.cpp) and admits exactly that bar in front of the gate,
+    whatever calendar gap sits between them. With the gate on Monday that
+    bar is Friday. Padding here as well would admit TWO bars before the
+    tape (a first cut of this change opened the window on the previous
+    FEED bar, and the engine then admitted the bar before that one), and a
+    strategy firing on both would book an engine-only trade filled on the
+    bar before TV's first entry — which the old ``>= window start`` trade
+    filter would even have kept. Starting the window on the entry itself
+    closes both holes: one pad, in the engine, and no engine trade dated
+    before TV's first.
+
+    On a continuous feed the engine's index pad is the same bar the old
+    interval subtraction named, so 15m crypto windows admit the same
+    signal bar as before; the trades filter merely stops keeping a fill on
+    the bar before TV's first entry, where TV has none."""
     tv_name = str(meta.get("tv_trades_csv", "tv_trades.csv"))
     tv_path = strategy_dir / tv_name
     if not tv_path.exists():
@@ -1921,7 +1962,7 @@ def _load_tv_entry_window(strategy_dir: Path, meta: dict, bar_interval_ms: int) 
                 entries.append(_parse_trade_dt(row["Date and time"], tz_offset))
     if not entries:
         return None
-    return min(entries) - bar_interval_ms, max(entries)
+    return min(entries), max(entries)
 
 
 def _infer_bar_interval_ms(csv_path: Path) -> int:
@@ -2111,7 +2152,7 @@ def main() -> int:
     elif args.emit_window_ohlcv is not None:
         emit_window = _load_window_ms(args.emit_window_ohlcv.resolve())
     else:
-        emit_window = _load_tv_entry_window(strategy_dir, params, _infer_bar_interval_ms(ohlcv_path))
+        emit_window = _load_tv_entry_window(strategy_dir, params)
         tv_window_used = emit_window is not None
         if emit_window is None:
             emit_window = _load_window_ms(REFERENCE_OHLCV)

--- a/scripts/run_stream_corpus.py
+++ b/scripts/run_stream_corpus.py
@@ -239,8 +239,12 @@ def run_stream(strategy: Strategy, warmup, n_warmup: int, ticks,
 
 
 def compare_reports(batch: dict, stream: dict) -> dict:
-    left = batch["trades"]
-    right = stream["trades"]
+    # The batch run's report closes a position still open after its final
+    # bar at that bar's close (TradingView's range-end accounting,
+    # open_at_end); a stream's end is not a range end and books no such row.
+    # Compare the trades the two brokers actually made.
+    left = [t for t in batch["trades"] if not t.get("open_at_end")]
+    right = [t for t in stream["trades"] if not t.get("open_at_end")]
     positional = 0
     for a, b in zip(left, right):
         same_minute = (

--- a/scripts/test_run_strategy_gap_pad.py
+++ b/scripts/test_run_strategy_gap_pad.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""The TV-entry emit / trade-start window opens ON TradingView's first entry
+bar; the one-bar pad for the signal bar lives in the engine, by index on
+the feed (compute_trade_start_preceding_script_bar / trading_is_active).
+
+orb-lite on NYSE:F 1D: the short fires on the 2026-03-13 (Friday) bar and TV
+fills it on 2026-03-16 (Monday), its first entry. The validator used to open
+the window one bar interval early — ``Monday - 1 day`` is Sunday, not a feed
+bar — and the engine's own one-script-TF buffer reached Saturday, so Friday's
+strategy.entry was dropped. Padding here as well as in the engine would admit
+TWO bars before the tape (a first cut opened the window on the previous FEED
+bar, Friday, and the engine then admitted Thursday), so the window now starts
+on the entry itself and the engine admits exactly the bar before it.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from run_strategy import _load_tv_entry_window
+
+DAY = 86_400_000
+FIFTEEN_MIN = 15 * 60 * 1000
+
+
+def _utc_ms(y: int, m: int, d: int, hh: int = 0, mm: int = 0) -> int:
+    return int(datetime(y, m, d, hh, mm, tzinfo=timezone.utc).timestamp() * 1000)
+
+
+def _write_tv_trades(path: Path, entry_times: list[str], *,
+                     exit_times: list[str] | None = None) -> None:
+    exits = exit_times or entry_times
+    with path.open("w", encoding="utf-8-sig") as f:
+        f.write("Trade number,Type,Date and time,Signal,Price USD\n")
+        for n, (t, x) in enumerate(zip(entry_times, exits), 1):
+            f.write(f"{n},Exit short,{x},,12.08\n")
+            f.write(f"{n},Entry short,{t},Short,11.82\n")
+
+
+# NYSE 1D bars are labelled at the 13:30 UTC session open.
+FRI = _utc_ms(2026, 3, 13, 13, 30)
+MON = _utc_ms(2026, 3, 16, 13, 30)
+WED = _utc_ms(2026, 3, 18, 13, 30)
+
+
+class LoadTvEntryWindowTests(unittest.TestCase):
+    def test_daily_tape_window_opens_on_the_first_entry(self) -> None:
+        # orb-lite: first TV entry Monday 03-16. The window starts THERE —
+        # not on Sunday (the old interval pad) and not on Friday (the
+        # first cut's previous-feed-bar pad); the engine admits Friday.
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_tv_trades(d / "tv_trades.csv", ["2026-03-16 13:30", "2026-03-18 13:30"],
+                             exit_times=["2026-03-17 13:30", "2026-04-30 13:30"])
+            window = _load_tv_entry_window(d, {"tv_trades_csv_tz": "utc"})
+            self.assertEqual(window, (MON, WED))
+            assert window is not None
+            self.assertNotEqual(window[0], MON - DAY)
+            self.assertNotEqual(window[0], FRI)
+
+    def test_window_end_is_the_last_entry_not_the_last_exit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_tv_trades(d / "tv_trades.csv", ["2026-03-16 13:30"],
+                             exit_times=["2026-04-30 13:30"])
+            self.assertEqual(_load_tv_entry_window(d, {"tv_trades_csv_tz": "utc"}), (MON, MON))
+
+    def test_intraday_tape_is_unchanged_in_shape(self) -> None:
+        base = _utc_ms(2026, 3, 16, 0, 0)
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_tv_trades(d / "tv_trades.csv", ["2026-03-16 01:45", "2026-03-16 03:00"])
+            self.assertEqual(_load_tv_entry_window(d, {"tv_trades_csv_tz": "utc"}),
+                             (base + 7 * FIFTEEN_MIN, base + 12 * FIFTEEN_MIN))
+
+    def test_tape_timezone_is_honoured(self) -> None:
+        # Taipei-stamped tape (the browser exports): 21:30 +8 is 13:30 UTC.
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_tv_trades(d / "tv_trades.csv", ["2026-03-16 21:30"])
+            self.assertEqual(_load_tv_entry_window(d, {"tv_trades_csv_tz": "utc_plus_8"}),
+                             (MON, MON))
+
+    def test_no_tape_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(_load_tv_entry_window(Path(tmp), {}))
+
+    def test_tape_without_entries_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_tv_trades(d / "tv_trades.csv", [])
+            self.assertIsNone(_load_tv_entry_window(d, {"tv_trades_csv_tz": "utc"}))
+
+    def test_meta_names_the_tape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_tv_trades(d / "other.csv", ["2026-03-16 13:30"])
+            meta = {"tv_trades_csv": "other.csv", "tv_trades_csv_tz": "utc"}
+            self.assertEqual(_load_tv_entry_window(d, meta), (MON, MON))
+            self.assertEqual(json.dumps(meta), json.dumps(meta))  # meta untouched
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_run_strategy_range_end.py
+++ b/scripts/test_run_strategy_range_end.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""The engine's measurement ends where TradingView's range ends.
+
+The engine books a position still open after its FINAL bar as TradingView's
+range-end close (open_at_end, at that bar's close). That final bar must be
+TV's last bar, not the feed's: the BINANCE:ETHUSDT.P 15 chart feed runs on
+to 2026-05-04 15:00 UTC while every ETH tape ends at 2026-05-01 08:00 (+8) =
+05-01 00:00 UTC (286 of 305 with an Open row there @ 2261.44 = that bar's
+close). Unbounded, the row would be booked on 05-04 15:00 @ 2365.09, a
+different bar ~4.6% off TV's, and fail exit/pnl against TV's Open row where
+it was previously simply absent. run_strategy.py therefore bounds the feed
+(``ohlcv_end_ms``) to the latest ``Date and time`` over every tape row —
+entries, exits and the open-position row — on both runners.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+import re
+
+from run_strategy import EXPECTED_PF_ABI, TradeC, _load_bars, _load_tv_range_end_ms, _trim_ohlcv_csv
+
+FIFTEEN_MIN = 15 * 60 * 1000
+
+
+def _utc_ms(y: int, m: int, d: int, hh: int = 0, mm: int = 0) -> int:
+    return int(datetime(y, m, d, hh, mm, tzinfo=timezone.utc).timestamp() * 1000)
+
+
+# The ETH chart feed: 15m bars from 04-30 22:00 UTC past the tape's end to
+# 05-04 15:00 UTC. TV's last bar is 05-01 00:00 UTC (close 2261.44).
+FEED_START = _utc_ms(2026, 4, 30, 22, 0)
+TV_LAST_BAR = _utc_ms(2026, 5, 1, 0, 0)
+FEED_END = _utc_ms(2026, 5, 4, 15, 0)
+
+
+def _write_eth_feed(path: Path) -> list[int]:
+    stamps = list(range(FEED_START, FEED_END + 1, FIFTEEN_MIN))
+    with path.open("w", encoding="utf-8") as f:
+        f.write("timestamp,open,high,low,close,volume\n")
+        for ts in stamps:
+            close = 2261.44 if ts == TV_LAST_BAR else (2365.09 if ts == FEED_END else 2300.0)
+            f.write(f"{ts},2300,2400,2200,{close},1\n")
+    return stamps
+
+
+def _write_tape(path: Path, rows: list[tuple[int, str, str, str, str]]) -> None:
+    with path.open("w", encoding="utf-8-sig") as f:
+        f.write("Trade number,Type,Date and time,Signal,Price USDT\n")
+        for n, typ, when, signal, price in rows:
+            f.write(f"{n},{typ},{when},{signal},{price}\n")
+
+
+class LoadTvRangeEndTests(unittest.TestCase):
+    def test_browser_tape_ends_on_the_open_row(self) -> None:
+        # Taipei-stamped browser export: the Open row at 05-01 08:00 (+8)
+        # is the latest stamp, later than any entry.
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_tape(d / "tv_trades.csv", [
+                (1, "Exit long", "2026-04-29 10:15", "X", "2310.5"),
+                (1, "Entry long", "2026-04-28 09:00", "A", "2290.0"),
+                (2, "Exit long", "2026-05-01 08:00", "Open", "2261.44"),
+                (2, "Entry long", "2026-04-30 20:45", "B", "2280.0"),
+            ])
+            self.assertEqual(_load_tv_range_end_ms(d, {"tv_trades_csv_tz": "utc_plus_8"}),
+                             TV_LAST_BAR)
+
+    def test_ws_tape_ends_on_the_last_exit(self) -> None:
+        # ws-report-v1 (orb-lite NYSE:F 1D): the range-end row has no
+        # Signal; its exit is the last bar, 2026-04-30 13:30 UTC.
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_tape(d / "tv_trades.csv", [
+                (1, "Exit short", "2026-04-30 13:30", "", "12.08"),
+                (1, "Entry short", "2026-03-16 13:30", "Short", "11.82"),
+            ])
+            self.assertEqual(_load_tv_range_end_ms(d, {"tv_trades_csv_tz": "utc"}),
+                             _utc_ms(2026, 4, 30, 13, 30))
+
+    def test_no_tape_or_no_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            self.assertIsNone(_load_tv_range_end_ms(d, {}))
+            _write_tape(d / "tv_trades.csv", [])
+            self.assertIsNone(_load_tv_range_end_ms(d, {"tv_trades_csv_tz": "utc"}))
+
+    def test_meta_names_the_tape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_tape(d / "other.csv", [(1, "Exit long", "2026-05-01 00:00", "Open", "1"),
+                                          (1, "Entry long", "2026-04-30 12:00", "A", "1")])
+            self.assertEqual(
+                _load_tv_range_end_ms(d, {"tv_trades_csv": "other.csv", "tv_trades_csv_tz": "utc"}),
+                TV_LAST_BAR)
+
+
+class HarnessAbiMirrorTests(unittest.TestCase):
+    """The harness's ABI guard and its pf_trade_t mirror follow the header.
+
+    verify-engine-local.py runs every probe through run_strategy.py, so a
+    guard left at the previous ABI is a RuntimeError on every slug rather
+    than a wrong number on one: the f-1d spark pre-check of the range-end
+    change (2026-09-02) failed all 64 probes with ".so reports 3, harness
+    expects 2" because only the docker / tutorial / benchmark mirrors had
+    been bumped. Pin the constant to PF_ABI_VERSION as the header declares
+    it, and the mirror's tail to the v3 field.
+    """
+
+    HEADER = Path(__file__).resolve().parents[1] / "include" / "pineforge" / "pineforge.h"
+
+    def test_expected_abi_is_the_headers_macro(self) -> None:
+        text = self.HEADER.read_text(encoding="utf-8")
+        m = re.search(r"^#define PF_ABI_VERSION (\d+)\s*$", text, re.M)
+        self.assertIsNotNone(m)
+        assert m is not None
+        self.assertEqual(EXPECTED_PF_ABI, int(m.group(1)))
+        self.assertEqual(EXPECTED_PF_ABI, 3)
+
+    def test_trade_mirror_ends_with_open_at_end(self) -> None:
+        names = [name for name, _ in TradeC._fields_]
+        self.assertEqual(names[-3:], ["entry_bar_index", "exit_bar_index", "open_at_end"])
+
+
+class FeedBoundTests(unittest.TestCase):
+    def test_ctypes_feed_ends_on_tv_last_bar(self) -> None:
+        # The ETH shape: unbounded, the engine's last bar is 05-04 15:00;
+        # bounded to the tape's end it is TV's last bar, close 2261.44.
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            stamps = _write_eth_feed(d / "feed.csv")
+            _write_tape(d / "tv_trades.csv", [
+                (1, "Exit long", "2026-05-01 08:00", "Open", "2261.44"),
+                (1, "Entry long", "2026-04-30 22:15", "A", "2300.0"),
+            ])
+            end = _load_tv_range_end_ms(d, {"tv_trades_csv_tz": "utc_plus_8"})
+            self.assertEqual(end, TV_LAST_BAR)
+            full, n_full, sha_full = _load_bars(d / "feed.csv")
+            self.assertEqual(n_full, len(stamps))
+            self.assertEqual(full[n_full - 1].timestamp, FEED_END)
+            bars, n, sha = _load_bars(d / "feed.csv", ohlcv_end_ms=end)
+            self.assertEqual(bars[n - 1].timestamp, TV_LAST_BAR)
+            self.assertAlmostEqual(bars[n - 1].close, 2261.44)
+            self.assertEqual(n, stamps.index(TV_LAST_BAR) + 1)
+            # The source identity is the full tape either way.
+            self.assertEqual(sha, sha_full)
+
+    def test_docker_pretrim_applies_both_bounds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            stamps = _write_eth_feed(d / "feed.csv")
+            start = stamps[3]
+            trimmed = _trim_ohlcv_csv(d / "feed.csv", start, TV_LAST_BAR)
+            self.assertIsNotNone(trimmed)
+            assert trimmed is not None
+            try:
+                kept, n, _ = _load_bars(trimmed)
+                self.assertEqual(kept[0].timestamp, start)
+                self.assertEqual(kept[n - 1].timestamp, TV_LAST_BAR)
+                self.assertEqual(n, stamps.index(TV_LAST_BAR) - 3 + 1)
+            finally:
+                trimmed.unlink()
+            end_only = _trim_ohlcv_csv(d / "feed.csv", None, TV_LAST_BAR)
+            assert end_only is not None
+            try:
+                kept, n, _ = _load_bars(end_only)
+                self.assertEqual(kept[0].timestamp, FEED_START)
+                self.assertEqual(kept[n - 1].timestamp, TV_LAST_BAR)
+            finally:
+                end_only.unlink()
+            # No bound: no copy is made, the feed is used as given.
+            self.assertIsNone(_trim_ohlcv_csv(d / "feed.csv", None, None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_verify_corpus_open_mark.py
+++ b/scripts/test_verify_corpus_open_mark.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""A browser export's "Open" row is a mark, not a fill: when the engine closes
+the same position on the same bar (its range-end close, open_at_end), the
+pair counts and covers but its exit price / PnL are not gated.
+
+Evidence: all 12 sampled OANDA:EURUSD registry tapes end with Signal="Open"
+rows at 2026-05-01 08:00 (+8) @ 1.17256, while the feed's last bar (05-01
+00:00 UTC) is o 1.17289 h 1.17299 l 1.17282 c 1.1729 — the export-time quote,
+outside the bar entirely. The engine's row is priced at the bar's close,
+1.1729; the 0.029% delta exceeds STRICT_EXIT_DELTA (0.01%) and would fail
+exit_ok on every such probe for a number that carries no parity information.
+An engine exit on a DIFFERENT bar is a real divergence (TV held to the end,
+the engine did not) and keeps its deltas. ws-report-v1 tapes write the row
+with no Signal and the last bar's close, and never take this path.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from verify_corpus import STRICT_EXIT_DELTA, analyze_strategy, relative_max
+
+TV_HEADER = "Trade #,Type,Date and time,Signal,Price,Qty,Net PnL\n"
+ENG_HEADER = "Trade #,Type,Date and time,Price,Qty,Net PnL\n"
+
+# Trade 1 closes normally; trade 2 is open at the range's end.
+TV_BROWSER = TV_HEADER + (
+    "1,Exit long,2026-04-28 12:00,X,1.1700,1000,10\n"
+    "1,Entry long,2026-04-27 12:00,A,1.1600,1000,10\n"
+    "2,Exit long,2026-05-01 00:00,Open,1.17256,1000,-2.44\n"
+    "2,Entry long,2026-04-30 12:00,B,1.1750,1000,-2.44\n"
+)
+TV_WS = TV_HEADER + (
+    "1,Exit long,2026-04-28 12:00,X,1.1700,1000,10\n"
+    "1,Entry long,2026-04-27 12:00,A,1.1600,1000,10\n"
+    "2,Exit long,2026-05-01 00:00,,1.1729,1000,-2.1\n"
+    "2,Entry long,2026-04-30 12:00,B,1.1750,1000,-2.1\n"
+)
+ENG_SAME_BAR = ENG_HEADER + (
+    "1,Exit long,2026-04-28 12:00,1.1700,1000,10\n"
+    "1,Entry long,2026-04-27 12:00,1.1600,1000,10\n"
+    "2,Exit long,2026-05-01 00:00,1.1729,1000,-2.1\n"
+    "2,Entry long,2026-04-30 12:00,1.1750,1000,-2.1\n"
+)
+ENG_EARLIER_BAR = ENG_HEADER + (
+    "1,Exit long,2026-04-28 12:00,1.1700,1000,10\n"
+    "1,Entry long,2026-04-27 12:00,1.1600,1000,10\n"
+    "2,Exit long,2026-04-30 18:00,1.1729,1000,-2.1\n"
+    "2,Entry long,2026-04-30 12:00,1.1750,1000,-2.1\n"
+)
+
+
+def _analyze(tv_csv: str, eng_csv: str):
+    with tempfile.TemporaryDirectory() as tmp:
+        strategy = Path(tmp) / "eurusd-probe"
+        strategy.mkdir()
+        (strategy / "inputs.json").write_text(json.dumps({"tv_trades_csv_tz": "utc"}),
+                                              encoding="utf-8")
+        (strategy / "tv_trades.csv").write_text(tv_csv, encoding="utf-8")
+        (strategy / "engine_trades.csv").write_text(eng_csv, encoding="utf-8")
+        return analyze_strategy(strategy)
+
+
+class OpenMarkPairTests(unittest.TestCase):
+    def test_the_mark_itself_is_outside_strict_exit(self) -> None:
+        self.assertGreater(relative_max(1.17256, 1.1729), STRICT_EXIT_DELTA)
+
+    def test_open_row_closed_on_the_same_bar_is_count_only(self) -> None:
+        r = _analyze(TV_BROWSER, ENG_SAME_BAR)
+        self.assertEqual(r.open_mark_pairs, 1)
+        self.assertEqual(r.matched_count, 2)
+        self.assertTrue(r.count_ok)
+        self.assertEqual(r.count_abs_delta, 0)
+        self.assertTrue(r.entry_ok)
+        self.assertTrue(r.exit_ok)            # pre-fix: 0.029% > 0.01%
+        self.assertEqual(r.exit_p90, 0.0)
+        self.assertTrue(r.pnl_ok)
+        self.assertTrue(r.coverage_ok)
+        self.assertEqual(r.coverage, 1.0)
+        self.assertEqual(r.label, "excellent")
+
+    def test_open_row_closed_on_an_earlier_bar_keeps_its_deltas(self) -> None:
+        r = _analyze(TV_BROWSER, ENG_EARLIER_BAR)
+        self.assertEqual(r.open_mark_pairs, 0)
+        self.assertEqual(r.matched_count, 2)
+        self.assertFalse(r.exit_ok)
+        self.assertNotEqual(r.label, "excellent")
+
+    def test_ws_tape_row_never_takes_the_path(self) -> None:
+        r = _analyze(TV_WS, ENG_SAME_BAR)
+        self.assertEqual(r.open_mark_pairs, 0)
+        self.assertTrue(r.exit_ok)
+        self.assertEqual(r.label, "excellent")
+
+    def test_unmatched_open_row_still_leaves_the_coverage_denominator(self) -> None:
+        # The engine never opened trade 2: the Open row is dropped from the
+        # coverage denominator as before, and no pair is an open-mark pair.
+        eng = ENG_HEADER + (
+            "1,Exit long,2026-04-28 12:00,1.1700,1000,10\n"
+            "1,Entry long,2026-04-27 12:00,1.1600,1000,10\n"
+        )
+        r = _analyze(TV_BROWSER, eng)
+        self.assertEqual(r.open_mark_pairs, 0)
+        self.assertEqual(r.coverage_tv_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_corpus.py
+++ b/scripts/verify_corpus.py
@@ -332,6 +332,10 @@ class VerificationResult:
     distinct_entry_identity_ok: bool = True
     distinct_entry_mismatches: int = 0
     unmatched_in_window: int = 0
+    # Matched pairs whose TV row is a browser export's "Open" snapshot and
+    # whose engine exit sits on the same bar: counted and covered, entry
+    # compared, exit/pnl not (a mark against a fill). Report-only.
+    open_mark_pairs: int = 0
     entry_p100: float = 0.0
     exit_p100: float = 0.0
     pnl_p100: float = 0.0
@@ -1101,11 +1105,37 @@ def analyze_strategy(strategy_dir: Path) -> VerificationResult:
         tv_gate, eng_gate, distinct_tv_entry_keys)
     distinct_entry_identity_ok = distinct_entry_mismatches == 0
     entry_deltas = [relative_max(t.entry_price, e.entry_price) for t, e in gating_matched]
-    exit_deltas  = [relative_max(t.exit_price,  e.exit_price)  for t, e in gating_matched]
+    # A TV row whose exit Signal is "Open" is a browser export's snapshot of
+    # a position still open at the range's end, and its exit price is the
+    # quote at EXPORT time, not a bar's print: all 12 sampled OANDA:EURUSD
+    # registry tapes end with such rows at 2026-05-01 08:00 (+8) @ 1.17256
+    # while the feed's last bar (05-01 00:00 UTC) is o 1.17289 h 1.17299
+    # l 1.17282 c 1.1729 — 1.17256 lies outside that bar entirely (246 of
+    # 358 EURUSD tapes end with an Open row; AAPL's happen to print the last
+    # close, 271, because the market was closed at export). The engine now
+    # closes the same position on its final bar at that bar's close
+    # (open_at_end; TradingView's range-end accounting). When the engine's
+    # exit sits on the SAME bar as TV's Open row, the pair is a matched
+    # trade — it counts, it covers, its entry is compared — but its exit
+    # price and PnL are a mark against a fill, so they carry no parity
+    # information and are left out of the exit / pnl gates. An engine exit
+    # on a DIFFERENT bar keeps its deltas: TV held the position to the end
+    # and the engine did not, which is a real divergence. The ws-report-v1
+    # tapes write that row with no Signal at all and its exit at the last
+    # bar's close, so they never take this path.
+    _open_nums = still_open_trade_nums(tv_path)
+    _open_keys = {(t.entry_time, t.entry_price, t.direction)
+                  for t in tv_raw_all if t.trade_num in _open_nums}
+    def _is_open_mark_pair(t, e):
+        return ((t.entry_time, t.entry_price, t.direction) in _open_keys
+                and t.exit_time == e.exit_time)
+    priced_matched = [(t, e) for t, e in gating_matched if not _is_open_mark_pair(t, e)]
+    open_mark_pairs = len(gating_matched) - len(priced_matched)
+    exit_deltas  = [relative_max(t.exit_price,  e.exit_price)  for t, e in priced_matched]
     # PnL p90 uses *relative-to-tv_pnl*, with near-zero trades excluded so
     # scratch trades don't blow up the ratio. Mirrors canonical line ~1136.
     pnl_deltas: list[float] = []
-    for t, e in gating_matched:
+    for t, e in priced_matched:
         if abs(t.pnl) < PNL_NEAR_ZERO_USD:
             continue
         abs_diff = abs(t.pnl - e.pnl)
@@ -1214,9 +1244,7 @@ def analyze_strategy(strategy_dir: Path) -> VerificationResult:
     # open row (engine opened AND closed the position for real past window) is
     # a legitimate matched trade and is kept. This never touches the matcher,
     # the count gate, or entry/exit/pnl -- only the coverage denominator.
-    _open_nums = still_open_trade_nums(tv_path)
-    _open_keys = {(t.entry_time, t.entry_price, t.direction)
-                  for t in tv_raw_all if t.trade_num in _open_nums}
+    # (_open_nums / _open_keys are resolved above, with the exit/pnl deltas.)
     _matched_tv_ids = {id(t) for t, _ in matched}
     def _is_dropped_open(t):
         return ((t.entry_time, t.entry_price, t.direction) in _open_keys
@@ -1320,6 +1348,7 @@ def analyze_strategy(strategy_dir: Path) -> VerificationResult:
         distinct_entry_identity_ok=distinct_entry_identity_ok,
         distinct_entry_mismatches=distinct_entry_mismatches,
         unmatched_in_window=unmatched_in_window,
+        open_mark_pairs=open_mark_pairs,
         entry_p100=entry_p100,
         exit_p100=exit_p100,
         pnl_p100=pnl_p100,
@@ -1378,6 +1407,7 @@ def _print_verification(result: VerificationResult, *, show_diffs: int = 0) -> N
         f"  PnL%  p90/p100 (pts):  {percentile(result.pnlpct_deltas,0.90):.4f} / {result.pnlpct_p100:.4f}\n"
         f"  MFE/MAE p90 delta:     {result.mfe_p90*100:.4f}% / {result.mae_p90*100:.4f}%\n"
         f"  Unmatched-in-window:   {result.unmatched_in_window}\n"
+        f"  Open-mark pairs:       {result.open_mark_pairs}  (TV 'Open' row closed by the engine on the same bar; exit/pnl not gated)\n"
         f"  -> {result.label}"
     )
     if show_diffs > 0:

--- a/src/c_abi.cpp
+++ b/src/c_abi.cpp
@@ -78,6 +78,8 @@ static_assert(offsetof(pf_trade_t, entry_bar_index) == offsetof(pineforge::Trade
               "pf_trade_t::entry_bar_index offset mismatch");
 static_assert(offsetof(pf_trade_t, exit_bar_index) == offsetof(pineforge::TradeC, exit_bar_index),
               "pf_trade_t::exit_bar_index offset mismatch");
+static_assert(offsetof(pf_trade_t, open_at_end) == offsetof(pineforge::TradeC, open_at_end),
+              "pf_trade_t::open_at_end offset mismatch");
 
 /* ── SecurityDiag layout parity ─────────────────────────────────── */
 /* The middle two fields differ in name (complete_count / partial_count

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -183,6 +183,111 @@ void BacktestEngine::execute_market_exit(double fill_price) {
 }
 
 
+// Range-end accounting for a position still open after the final bar.
+//
+// TradingView's deep-backtest report — the ws-report-v1 tape the campaign
+// grades against — does not leave the last position open. It reports it as
+// a CLOSED trade whose exit leg sits on the range's last bar at that bar's
+// close, with an empty exit Signal, and counts it in closedTrades. The
+// orb-lite probe on NYSE:F 1D is the canonical row: Entry short 2026-03-16
+// @ 11.82, Exit 2026-04-30 @ 12.08 — 12.08 is the last close of the range,
+// the Signal cell is empty, metrics say closedTrades:1 (the browser export
+// writes the same row with Signal "Open", which the verifier already
+// recognises; the ws tape gives it no marker at all). On the f-1d spark
+// set 8/10 engine runs hold the same position to the last bar (the
+// engine's bars-in-market is TV's Duration + 1, the entry bar counted) and
+// 7/10 carry a mark-to-market open_pl equal to TV's row to the cent — the
+// row is exactly the engine's open position marked at the last close.
+//
+// The engine exported closed trades only: trades_ grows in emit_close_trade
+// alone, and neither run loop flattened at end of feed, so every such probe
+// was one trade short against the tape and the verifier scored the missing
+// row as an unmatched TV trade. This is the operator-decided (2026-09-02)
+// emulation of TradingView's range-end accounting: after the last script
+// bar has been dispatched and its equity point recorded, the rows that a
+// close of the open position at the last bar's close would record — one
+// per pyramid slice, as every other full close, through the same
+// build_close_trade arithmetic — are written to range_end_trades_, which
+// fill_trades_section merges behind the script's own closed trades.
+//
+// Reporting only. The live position, the pending orders, trades_ and the
+// realized sums are left exactly as the bar loop left them: a stream's
+// realtime bars continue the warmup position (stream_begin), the Pine
+// accessors never see the row (it is dated after the last on_bar), and the
+// broker-mechanics tests keep inspecting the open lot the run ended with.
+// The report is where TradingView's accounting is emulated.
+//
+// Pricing. The row is a mark at the close, not an order the broker
+// emulator fills: it takes the raw close rounded to the NEAREST tick
+// (bar_fill_price, finding-446 — the tape's 12.08 is the on-tick close; a
+// sub-tick print such as 9.565 books 9.56 like any close-priced fill) and
+// NO slippage ticks, because slippage models the fill uncertainty of a
+// market order and TV prices this row at the bar close itself. The exit
+// commission follows the strategy's rules like any close; the one tape in
+// hand has commission 0, so that part is the operator's call rather than a
+// measured one. The exit is dated on the script bar's label (the equity
+// curve's time_ms — magnifier-invariant, the same instant a
+// process_orders_on_close fill on that bar reports).
+//
+// Accounting. The report's closed-trade count, net profit, win/loss
+// tallies and commission paid include the rows (TV counts them in
+// closedTrades, and its netProfit is net of the row's exit commission). The
+// last equity point is re-marked to the flat account — open_profit 0,
+// equity = capital + net profit including the rows — so the documented
+// identity equity == initial_capital + net_profit + open_profit holds on
+// the last bar (test_metrics pins it), as it does on TradingView's own
+// curve, whose last point is the account after that close. The bar loop
+// had already folded that point's GROSS mark into the scalar drawdown /
+// run-up extremes (update_equity_extremes), and the compute_equity_stats
+// curve walk reproduces those scalars only while the curve holds exactly
+// the values that were folded: a first cut of this change re-marked the
+// point and left the scalars alone, which silently broke that identity on
+// every commissioned run whose last bar was the trough or the peak (the
+// fold had seen the gross mark, the walk saw the net one — review finding,
+// 2026-09-02). The fold is one per script bar, paired with the curve
+// point, so the scalars are re-folded from the curve here (fold_equity_
+// extreme over every point, the re-marked last one included): the walk
+// and the scalars agree again, the extremes now read the range-end close
+// the way the curve does, and every earlier point is untouched. The
+// in-market bar count is the loop's (the last bar was in market). A
+// strategy that is flat after the final bar records nothing. The stream
+// warmup replay is not a range end (the realtime bars continue it) and is
+// skipped.
+void BacktestEngine::record_range_end_close_trades() {
+    range_end_trades_.clear();
+    if (stream_warmup_mode_) return;
+    if (position_side_ == PositionSide::FLAT) return;
+    if (equity_curve_.empty()) return;          // no script bar was dispatched
+    if (!std::isfinite(current_bar_.close)) return;
+
+    const bool was_long = (position_side_ == PositionSide::LONG);
+    const double fill_price = bar_fill_price(current_bar_.close);
+    // Date the exit leg on the script bar's label, never a magnifier
+    // sub-bar; the bar itself is restored afterwards.
+    const int64_t bar_ts = current_bar_.timestamp;
+    current_bar_.timestamp = equity_curve_.back().time_ms;
+    double range_end_pnl = 0.0;
+    for (const auto& pe : pyramid_entries_) {
+        Trade row = build_close_trade(pe, pe.qty, fill_price, was_long);
+        row.open_at_end = true;              // exit_id / exit_comment stay empty
+        range_end_pnl += row.pnl;
+        range_end_trades_.push_back(std::move(row));
+    }
+    current_bar_.timestamp = bar_ts;
+
+    pf_equity_point_t& last = equity_curve_.back();
+    last.open_profit = 0.0;
+    last.equity = initial_capital_ + net_profit_sum_ + range_end_pnl;
+    // Re-fold the scalar extremes from the curve so they read the re-marked
+    // last point exactly as the compute_equity_stats walk will.
+    max_equity_ = initial_capital_;
+    min_equity_ = initial_capital_;
+    max_drawdown_ = 0.0;
+    max_runup_ = 0.0;
+    for (const auto& p : equity_curve_) fold_equity_extreme(p.equity);
+}
+
+
 // FIFO-drain up to qty_limit from pyramid_entries_, optionally restricted to a
 // single from_entry id. See engine.hpp for the contract. Mirrors TradingView's
 // per-pyramid trade reporting: one Trade per drained slice. Returns total qty
@@ -460,8 +565,8 @@ void BacktestEngine::purge_exit_orders(bool retain_for_pending_entries) {
 // execute_market_exit, execute_partial_exit_qty, execute_partial_exit_by_entry,
 // execute_partial_exit_by_entry_percent, and the flip branch of
 // execute_market_entry. Mirrors TradingView's per-pyramid trade reporting.
-void BacktestEngine::emit_close_trade(const PyramidEntry& pe, double close_qty,
-                                      double fill_price, bool was_long) {
+Trade BacktestEngine::build_close_trade(const PyramidEntry& pe, double close_qty,
+                                        double fill_price, bool was_long) const {
     // Realized PnL scales by the instrument point value ($ per point per
     // contract). Crypto/equity (pointvalue=1) is unchanged; futures (e.g. ES=50)
     // multiply the price-difference PnL. The price-difference component is in
@@ -573,6 +678,14 @@ void BacktestEngine::emit_close_trade(const PyramidEntry& pe, double close_qty,
         0.0, runup * pv * active_account_currency_fx() - entry_commission);
     trade.max_drawdown = drawdown * pv * active_account_currency_fx()
                          + entry_commission;
+    return trade;
+}
+
+
+void BacktestEngine::emit_close_trade(const PyramidEntry& pe, double close_qty,
+                                      double fill_price, bool was_long) {
+    Trade trade = build_close_trade(pe, close_qty, fill_price, was_long);
+    const double pnl = trade.pnl;
     const double trade_pnl = trade.pnl;
     trades_.push_back(std::move(trade));
     net_profit_sum_ += trade_pnl;

--- a/src/engine_report.cpp
+++ b/src/engine_report.cpp
@@ -57,11 +57,14 @@ void BacktestEngine::fill_report(ReportC* out) const {
 }
 
 
-// Copy ``trades_`` into a freshly heap-allocated TradeC[] on ``out`` and
-// accumulate ``net_profit`` for the report. Owns the allocation; freed by
-// ``free_report``.
+// Copy ``trades_`` — followed by ``range_end_trades_``, TradingView's
+// range-end close of a position still open after the final bar
+// (record_range_end_close_trades) — into a freshly heap-allocated TradeC[]
+// on ``out`` and accumulate ``net_profit`` for the report. Owns the
+// allocation; freed by ``free_report``.
 void BacktestEngine::fill_trades_section(ReportC* out) const {
-    int n = (int)trades_.size();
+    const int n_closed = (int)trades_.size();
+    const int n = n_closed + (int)range_end_trades_.size();
     out->total_trades = n;
     out->trades_len = n;
 
@@ -70,7 +73,8 @@ void BacktestEngine::fill_trades_section(ReportC* out) const {
         double net_profit = 0.0;
 
         for (int i = 0; i < n; i++) {
-            const Trade& t = trades_[i];
+            const Trade& t = (i < n_closed) ? trades_[i]
+                                            : range_end_trades_[i - n_closed];
             out->trades[i].entry_time = t.entry_time;
             out->trades[i].exit_time = t.exit_time;
             out->trades[i].entry_price = t.entry_price;
@@ -84,6 +88,7 @@ void BacktestEngine::fill_trades_section(ReportC* out) const {
             out->trades[i].commission = t.commission;
             out->trades[i].entry_bar_index = t.entry_bar_index;
             out->trades[i].exit_bar_index = t.exit_bar_index;
+            out->trades[i].open_at_end = t.open_at_end ? 1 : 0;
             net_profit += t.pnl;
         }
 
@@ -121,7 +126,8 @@ void BacktestEngine::fill_metrics_section(ReportC* out) const {
         out->trades, out->trades_len, TradeFilter::SHORT, initial_capital_);
     out->metrics.equity = metrics::compute_equity_stats(
         out->equity_curve, n, initial_capital_, chart_timezone_,
-        first_bar_open_, current_bar_.close, bars_in_market_, net_profit_sum_);
+        first_bar_open_, current_bar_.close, bars_in_market_,
+        out->net_profit);   // includes the range-end rows, like the trades
 }
 
 

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -587,6 +587,7 @@ void BacktestEngine::reset_run_state() {
     // Closed-trade list + cached P&L / count accumulators.
     trades_.clear();
     trades_.reserve(256);
+    range_end_trades_.clear();
     net_profit_sum_ = 0.0;
     gross_profit_sum_ = 0.0;
     gross_loss_sum_ = 0.0;
@@ -781,6 +782,11 @@ void BacktestEngine::run(const Bar* bars, int n) {
         record_equity_point(current_bar_.timestamp);  // ts not mutated on this path
         prev_bar_timestamp_ = current_bar_.timestamp;
     }
+    // TradingView's range-end accounting: a position still open after the
+    // last bar is reported as a closed trade at that bar's close
+    // (record_range_end_close_trades, engine_orders.cpp). Report-only:
+    // the live position is untouched.
+    record_range_end_close_trades();
     } catch (const std::exception& e) {
         last_error_ = e.what();
     } catch (...) {
@@ -1310,6 +1316,12 @@ void BacktestEngine::run(const Bar* input_bars, int n_input,
         run_aggregation_bar_loop(input_bars, n_input, bar_magnifier,
                                  expected_script_bars);
     }
+    // TradingView's range-end accounting: a position still open after the
+    // last script bar is reported as a closed trade at that bar's close
+    // (record_range_end_close_trades, engine_orders.cpp). Report-only: the
+    // live position is untouched, and the stream warmup replay, whose bars
+    // are not a range end, is skipped.
+    record_range_end_close_trades();
     clear_historical_security_lookahead_projections();
 #ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
     clear_aux_security_chart_ranges();

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -749,6 +749,9 @@ void BacktestEngine::run(const Bar* bars, int n) {
     input_tf_ = detected_tf;
     script_tf_ = detected_tf;
     script_tf_seconds_ = tf_to_seconds(script_tf_);
+    // The trade-start gate's index-based buffer (the bar before the first
+    // in-window bar, gap or no gap) needs the feed in hand: resolve it here.
+    compute_trade_start_preceding_script_bar(bars, n, /*needs_aggregation=*/false);
 
     // Runtime diagnostics (single-timeframe path)
     diag_input_bars_processed_ = n;
@@ -1291,6 +1294,9 @@ void BacktestEngine::run(const Bar* input_bars, int n_input,
     int expected_script_bars =
         count_expected_script_bars(input_bars, n_input, needs_aggregation);
     last_bar_index_ = expected_script_bars - 1;
+    // The trade-start gate's index-based buffer (the script bar before the
+    // first in-window script bar, gap or no gap) needs the feed in hand.
+    compute_trade_start_preceding_script_bar(input_bars, n_input, needs_aggregation);
     // reset_run_state() already ran above — reserve AFTER it so the capacity
     // hint isn't wiped (clear() retains capacity but order still matters for
     // any future reset that releases).
@@ -1358,6 +1364,61 @@ int BacktestEngine::count_expected_script_bars(const Bar* input_bars, int n_inpu
         }
     }
     return count;
+}
+
+
+// Resolve the script bar the trade-start gate admits by INDEX: the bar
+// immediately preceding the first script bar whose label is >= the gate.
+//
+// The validator sets trade_start_time_ on TradingView's first entry bar,
+// and the signal bar that produced that entry — the one bar in front of the
+// gate — must be allowed to place its order. The gate used to be padded in
+// milliseconds (one bar interval by the validator, one script TF by
+// trading_is_active in engine_strategy_commands.cpp), and both pads were
+// calendar-blind. On a daily feed the bar before Monday is Friday, three
+// calendar days back, so a Friday signal filled on Monday — orb-lite on
+// NYSE:F 1D, signal 2026-03-13, TV entry 2026-03-16 — sat before the
+// buffered gate and the entry was dropped. The feed itself says which bar
+// precedes the first in-window bar; this preview finds it once per run and
+// trading_is_active admits exactly that bar in front of the gate,
+// regardless of the gap (weekend, holiday, session break) between them.
+//
+// The preview aggregates the feed exactly as the bar loop will (same
+// script/input TF, timezone and session) so the index it counts is the
+// bar_index_ the loop assigns; the simple path is the input index itself.
+// A gate before the feed's first bar has no preceding bar (-1: the
+// millisecond rule alone applies, admitting everything from the gate less
+// one script TF), and so does a gate past the feed's end — a stream's
+// warmup, whose realtime bars arrive later, keeps the millisecond rule as
+// before.
+void BacktestEngine::compute_trade_start_preceding_script_bar(
+        const Bar* input_bars, int n_input, bool needs_aggregation) {
+    trade_start_preceding_script_bar_ = -1;
+    if (trade_start_time_ == std::numeric_limits<int64_t>::min()
+        || input_bars == nullptr || n_input <= 0) {
+        return;
+    }
+    if (!needs_aggregation) {
+        for (int i = 0; i < n_input; ++i) {
+            if (input_bars[i].timestamp >= trade_start_time_) {
+                trade_start_preceding_script_bar_ = i - 1;
+                return;
+            }
+        }
+        return;
+    }
+    TimeframeAggregator preview_agg(script_tf_, input_tf_,
+                                    syminfo_.timezone, syminfo_.session);
+    int script_index = 0;
+    for (int i = 0; i < n_input; ++i) {
+        AggregatedBar preview = preview_agg.feed(input_bars[i]);
+        if (!preview.is_complete) continue;
+        if (preview.bar.timestamp >= trade_start_time_) {
+            trade_start_preceding_script_bar_ = script_index - 1;
+            return;
+        }
+        ++script_index;
+    }
 }
 
 

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -43,9 +43,9 @@ namespace {
 // TradingView replays the strategy continuously from the FIRST OHLCV bar.
 // The validator's ``trade_start_time`` gate intentionally suppresses
 // strategy commands during the warmup span so TA / var accumulators
-// converge without polluting comparison output. But the gate is set to
-// ``TV first entry - input bar`` (see _trade_start_time_ms_from_tv in
-// the validator) which, on a 15m strategy fed 1m OHLCV, lands one
+// converge without polluting comparison output. But the gate used to be
+// set to ``TV first entry - input bar`` (the validator's own pad) which,
+// on a 15m strategy fed 1m OHLCV, landed one
 // MINUTE before the first TV trade — far inside the script bar that
 // CONTAINS the first TV trade, but BEFORE the script bar that
 // PRECEDES it.
@@ -67,10 +67,50 @@ namespace {
 // unconditional bypass produces in continuously-firing strategies
 // like basic/volty-expan. The buffer matches TV's chart-bar
 // resolution rather than the validator-chosen input-bar resolution.
+//
+// That millisecond buffer is calendar-blind, and the campaign's daily
+// lanes exposed it. The bar before a Monday is Friday, three calendar
+// days back, not one: orb-lite on NYSE:F 1D fires its short on the
+// 2026-03-13 (Friday) bar and TradingView fills it on 2026-03-16
+// (Monday), its first entry. The validator's window started at Monday
+// minus one bar interval (Sunday), the buffer reached one script TF
+// further (Saturday), and Friday's strategy.entry fell before the gate
+// — the entry was dropped and the probe's whole tape shifted. The same
+// shape hides on every session gap (a Friday-close signal on an
+// intraday equity feed, a holiday, the 17:00 ET forex open).
+//
+// The feed knows which bar precedes the first in-window bar, so the
+// engine resolves that bar by INDEX once per run
+// (compute_trade_start_preceding_script_bar, engine_run.cpp) and, when
+// it resolves, that rule is the whole gate: the preceding script bar is
+// admitted whatever the calendar gap in front of it, every bar at or
+// after the gate is admitted, nothing else is. The validator sets the
+// gate ON TradingView's first entry bar (run_strategy.py
+// _load_tv_entry_window; it used to pad by one bar interval itself),
+// so exactly ONE bar precedes the tape: the signal bar. Stacking the
+// millisecond buffer on top would admit two — with the gate on Monday
+// the buffer reaches Sunday and admits nothing extra, but with a gate
+// on Friday it reaches Thursday, and a strategy that fires on both of
+// the two bars before TV's first entry then books an engine-only trade
+// (review finding on the first cut of this change, 2026-09-02). On a
+// continuous feed the index rule and the millisecond rule name the
+// same bar (the preceding script bar IS one script TF back), so the
+// 1m-feed/15m-script gate of validation/62 is unchanged bar for bar.
+//
+// The millisecond buffer survives only where the index cannot be
+// resolved: no gate inside the feed (a stream's warmup gate lies past
+// its bars — the realtime bars that follow keep the buffer they always
+// had) or a gate before the feed's first bar (nothing precedes it).
 inline bool trading_is_active(int64_t current_ms, int64_t start_ms,
-                              int script_tf_seconds) {
+                              int script_tf_seconds,
+                              int bar_index, int preceding_bar_index) {
     if (start_ms == std::numeric_limits<int64_t>::min()) {
         return true;
+    }
+    if (preceding_bar_index >= 0) {
+        // The bar immediately preceding the first in-window script bar,
+        // found on the feed rather than the calendar, or in-window.
+        return bar_index == preceding_bar_index || current_ms >= start_ms;
     }
     int64_t buffer_ms = (script_tf_seconds > 0)
                            ? static_cast<int64_t>(script_tf_seconds) * 1000
@@ -85,7 +125,8 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
                                      const std::string& comment,
                                      const std::string& oca_name, int oca_type,
                                      int qty_type) {
-    if (!trading_is_active(current_bar_.timestamp, trade_start_time_, script_tf_seconds_)) return;
+    if (!trading_is_active(current_bar_.timestamp, trade_start_time_, script_tf_seconds_,
+                           bar_index_, trade_start_preceding_script_bar_)) return;
 
     NamedEntryCancelContext named_cancel_context;
     const auto named_cancel =
@@ -596,7 +637,8 @@ void BacktestEngine::strategy_close(const std::string& id,
                                     double qty, double qty_percent,
                                     bool immediately,
                                     uint64_t callsite_token) {
-    if (!trading_is_active(current_bar_.timestamp, trade_start_time_, script_tf_seconds_)) return;
+    if (!trading_is_active(current_bar_.timestamp, trade_start_time_, script_tf_seconds_,
+                           bar_index_, trade_start_preceding_script_bar_)) return;
     if (position_side_ == PositionSide::FLAT) {
         return;
     }
@@ -1471,7 +1513,8 @@ void BacktestEngine::strategy_exit(const std::string& id, const std::string& fro
                                     const std::string& comment,
                                     double qty, const std::string& oca_name,
                                     double profit_ticks, double loss_ticks) {
-    if (!trading_is_active(current_bar_.timestamp, trade_start_time_, script_tf_seconds_)) return;
+    if (!trading_is_active(current_bar_.timestamp, trade_start_time_, script_tf_seconds_,
+                           bar_index_, trade_start_preceding_script_bar_)) return;
     const bool has_actionable_exit = !std::isnan(limit_price)
         || !std::isnan(stop_price)
         || !std::isnan(profit_ticks)
@@ -2011,7 +2054,8 @@ void BacktestEngine::strategy_cancel_all() {
 void BacktestEngine::strategy_order(const std::string& id, bool is_long, double qty,
                                      double limit_price, double stop_price,
                                      const std::string& oca_name, int oca_type) {
-    if (!trading_is_active(current_bar_.timestamp, trade_start_time_, script_tf_seconds_)) return;
+    if (!trading_is_active(current_bar_.timestamp, trade_start_time_, script_tf_seconds_,
+                           bar_index_, trade_start_preceding_script_bar_)) return;
     if (default_flat_market_gross_scope_is_live()) {
         // strategy.order is outside the high-level two-entry oracle. Record
         // the call before any same-id replacement or signal-time rejection can

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -139,6 +139,7 @@ set(TEST_SOURCES
     test_short_seed_close_collision
     test_short_seed_collision_percent
     test_exit_bracket_position_cycle_lifetime
+    test_range_end_close
 )
 
 find_package(Threads REQUIRED)
@@ -166,6 +167,18 @@ add_test(
     NAME test_verify_corpus_metrics
     COMMAND ${Python3_EXECUTABLE}
             ${PROJECT_SOURCE_DIR}/scripts/test_verify_corpus_metrics.py
+)
+
+add_test(
+    NAME test_verify_corpus_open_mark
+    COMMAND ${Python3_EXECUTABLE}
+            ${PROJECT_SOURCE_DIR}/scripts/test_verify_corpus_open_mark.py
+)
+
+add_test(
+    NAME test_run_strategy_range_end
+    COMMAND ${Python3_EXECUTABLE}
+            ${PROJECT_SOURCE_DIR}/scripts/test_run_strategy_range_end.py
 )
 
 add_test(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,6 +99,7 @@ set(TEST_SOURCES
     test_limit_fill_slippage
     test_tv_fill_rounding
     test_strategy_commands_extra
+    test_trade_start_gap_pad
     test_multi_tier_exit_precedence
     test_same_tick_multi_entry_race
     test_full_close_while_pyramiding
@@ -191,6 +192,12 @@ add_test(
     NAME test_run_strategy_aux_feed
     COMMAND ${Python3_EXECUTABLE}
             ${PROJECT_SOURCE_DIR}/scripts/test_run_strategy_aux_feed.py
+)
+
+add_test(
+    NAME test_run_strategy_gap_pad
+    COMMAND ${Python3_EXECUTABLE}
+            ${PROJECT_SOURCE_DIR}/scripts/test_run_strategy_gap_pad.py
 )
 
 # When PINEFORGE_ENABLE_COVERAGE is ON we also instrument the test

--- a/tests/test_accounting_reconciliation.cpp
+++ b/tests/test_accounting_reconciliation.cpp
@@ -83,6 +83,12 @@ public:
     int win_count() const { return win_trades_count_; }
     int loss_count() const { return loss_trades_count_; }
     int even_count() const { return eventrades_count_; }
+    // TradingView's range-end accounting: the report closes a position
+    // still open after the final bar at that bar's close (report-only rows,
+    // record_range_end_close_trades). Exposed so the report can be footed
+    // to the blotter PLUS those rows.
+    const std::vector<Trade>& range_end_rows() const { return range_end_trades_; }
+    double last_close() const { return current_bar_.close; }
 };
 
 std::vector<Bar> make_feed(int n) {
@@ -128,10 +134,24 @@ static void test_reconciliation_identities() {
     }
     CHECK(near(recomputed_total, p.net_sum()));
 
-    // Report mirror foots to the cached sum.
+    // I4 — the range-end rows (TradingView's accounting for a position still
+    // open after the last bar) foot independently: each is the open lot
+    // marked at the LAST bar's close, and none of them entered the live
+    // accumulators (net_sum() is the blotter's sum alone).
+    double range_end_total = 0.0;
+    for (const Trade& t : p.range_end_rows()) {
+        CHECK(t.open_at_end);
+        CHECK(near(t.exit_price, p.last_close()));
+        double expected = (t.is_long ? (t.exit_price - t.entry_price)
+                                     : (t.entry_price - t.exit_price)) * t.qty;
+        CHECK(near(t.pnl, expected));
+        range_end_total += expected;
+    }
+
+    // Report mirror foots to the cached sum plus the range-end rows.
     ReportC r{}; p.fill_report(&r);
-    CHECK(near(r.net_profit, p.net_sum()));
-    CHECK(r.total_trades == p.trade_count());
+    CHECK(near(r.net_profit, p.net_sum() + range_end_total));
+    CHECK(r.total_trades == p.trade_count() + (int)p.range_end_rows().size());
     BacktestEngine::free_report(&r);
 }
 

--- a/tests/test_range_end_close.cpp
+++ b/tests/test_range_end_close.cpp
@@ -1,0 +1,509 @@
+/*
+ * test_range_end_close.cpp — TradingView's range-end accounting: a position
+ * still open after the final bar is reported as a CLOSED trade whose exit
+ * leg is the last bar at that bar's close.
+ *
+ * Evidence (the ws-report-v1 tape the campaign grades against): orb-lite on
+ * NYSE:F 1D reports "Entry short 2026-03-16 @ 11.82, Exit 2026-04-30 @ 12.08",
+ * exit Signal EMPTY, closedTrades:1 — 12.08 is the last close of the range.
+ * On the f-1d spark set 8/10 engine runs held the same position to the last
+ * bar (bars-in-market = TV Duration + 1) and 7/10 had a mark-to-market open_pl
+ * equal to TV's row to the cent, so the row is exactly the open position
+ * marked at the last close. The engine exported closed trades only (trades_
+ * grows in emit_close_trade alone; no end-of-feed flatten in either run
+ * loop) and was one trade short on every such probe. Operator decision
+ * 2026-09-02: the engine emulates the row (engine_orders.cpp,
+ * record_range_end_close_trades) — in the REPORT: the row is built with the
+ * ordinary close arithmetic and merged behind the script's closed trades by
+ * fill_trades_section, while the live position, trades_ and the realized
+ * sums stay as the bar loop left them (a stream continues that position).
+ *
+ * Pins:
+ *   A. Open LONG at end: the report carries one extra closed trade, flagged
+ *      open_at_end, exit on the last bar (index, label timestamp) at the
+ *      last close; pnl is the mark-to-market of that close. The live
+ *      position is still LONG and trade_count() is still 0.
+ *   B. Flat at end (closed by the script): the report is unchanged and no
+ *      row carries the flag.
+ *   C. Open SHORT at end: mirror of A with the short sign; matches the
+ *      orb-lite row shape (entry 11.82, last close 12.08 -> -0.26 on qty 1).
+ *   D. Commission is applied like any close (0.1% on both legs): the row's
+ *      commission equals entry_price*qty*0.001 + exit_price*qty*0.001 and
+ *      pnl is net of it — the same arithmetic test_metrics pins for
+ *      script-driven exits.
+ *   E. The mark is the mintick-rounded close with NO slippage: a sub-tick
+ *      last close 12.083 books 12.08 even with slippage 2 ticks set (a
+ *      script close on the same bar would have booked 12.06).
+ *   F. Equity curve: every point before the last is byte-identical to a
+ *      run that stops one bar earlier; the last point is re-marked to the
+ *      flat account so equity == capital + net_profit + open_profit(0)
+ *      holds, and the report's net_profit / total_trades include the row.
+ *   J. Drawdown / run-up: the compute_equity_stats curve walk reproduces the
+ *      engine's scalar extremes with commission and a position open at the
+ *      end whose last bar is the trough (and, mirrored, the peak) — the
+ *      scalars are re-folded from the re-marked curve. A first cut re-marked
+ *      the point and left the scalars at the gross fold, and the two
+ *      disagreed by the row's commissions exactly there.
+ *   G. Pyramiding: two open slices produce two flagged rows, one per entry,
+ *      like every other full close.
+ *   H. Aggregated path (1m input -> 5m script): the exit is dated on the
+ *      script bar's LABEL (the equity curve's time_ms) and indexed by the
+ *      script bar, not the last input minute.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <pineforge/bar.hpp>
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_NEAR(a, b, tol)                                                  \
+    do {                                                                       \
+        double _a = (a), _b = (b);                                             \
+        if (!(std::fabs(_a - _b) <= (tol))) {                                  \
+            std::printf("  FAIL  %s:%d  %s == %.10f, expected %.10f\n",        \
+                        __FILE__, __LINE__, #a, _a, _b);                       \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+static Bar mk_bar(int64_t ts, double o, double h, double l, double c) {
+    Bar b;
+    b.open = o; b.high = h; b.low = l; b.close = c;
+    b.volume = 1.0; b.timestamp = ts;
+    return b;
+}
+
+namespace {
+
+constexpr int64_t kDay = 86'400'000;
+
+// Scripted probe: fixed qty 1, commission and slippage per constructor,
+// 1x margin, margin-call emulation off. 'L' / 'S' place a market entry that
+// fills on the next bar's open; 'C' closes everything; '.' does nothing.
+class Probe : public BacktestEngine {
+public:
+    Probe(double commission_pct = 0.0, int slippage_ticks = 0,
+          int pyramiding = 1) {
+        initial_capital_ = 100000.0;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_type_ = CommissionType::PERCENT;
+        commission_value_ = commission_pct;
+        margin_long_ = 100.0;
+        margin_short_ = 100.0;
+        pyramiding_ = pyramiding;
+        process_orders_on_close_ = false;
+        slippage_ = slippage_ticks;
+        set_syminfo_mintick(0.01);
+        margin_call_enabled_ = false;
+    }
+    std::string script;
+    void on_bar(const Bar& /*bar*/) override {
+        if (bar_index_ < 0 || bar_index_ >= (int)script.size()) return;
+        switch (script[bar_index_]) {
+            case 'L': strategy_entry("L", true); break;
+            case 'S': strategy_entry("S", false); break;
+            case 'C': strategy_close_all(); break;
+            default: break;
+        }
+    }
+    using BacktestEngine::position_side_;
+    using BacktestEngine::position_qty_;
+    const std::vector<Trade>& all_trades() const { return trades_; }
+    const std::vector<Trade>& range_end_rows() const { return range_end_trades_; }
+    const std::vector<pf_equity_point_t>& curve() const { return equity_curve_; }
+    double max_dd() const { return max_drawdown_; }
+    double max_ru() const { return max_runup_; }
+};
+
+std::vector<Bar> daily_bars(int n, double last_close) {
+    // Flat-ish tape: entries fill at 11.82 (bar 1 open); the last close is
+    // the parameter so each pin can shape the mark.
+    std::vector<Bar> bars;
+    for (int i = 0; i < n; ++i) {
+        double px = (i == 0) ? 11.80 : 11.82;
+        bars.push_back(mk_bar((int64_t)(i + 1) * kDay, px, px + 0.30, px - 0.30, px));
+    }
+    bars.back().close = last_close;
+    bars.back().high = std::max(bars.back().high, last_close);
+    bars.back().low = std::min(bars.back().low, last_close);
+    return bars;
+}
+
+}  // namespace
+
+// A. Open long at end -> one extra closed trade at the last close.
+static void test_open_long_at_end() {
+    std::printf("-- A: open long at end closes at the last bar's close --\n");
+    Probe eng;
+    eng.script = "L...";
+    auto bars = daily_bars(4, 12.08);
+    eng.run(bars.data(), (int)bars.size());
+    // Live state: exactly what the bar loop left — the lot is still open.
+    CHECK(eng.trade_count() == 0);
+    CHECK(eng.position_side_ == PositionSide::LONG);
+    CHECK_NEAR(eng.position_qty_, 1.0, 1e-12);
+    CHECK(eng.range_end_rows().size() == 1);            // pre-fix: no such row
+    if (eng.range_end_rows().size() == 1) {
+        const Trade& t = eng.range_end_rows()[0];
+        CHECK(t.open_at_end);
+        CHECK(t.is_long);
+        CHECK_NEAR(t.entry_price, 11.82, 1e-9);
+        CHECK(t.entry_bar_index == 1);
+        CHECK_NEAR(t.exit_price, 12.08, 1e-9);
+        CHECK(t.exit_bar_index == 3);
+        CHECK(t.exit_time == 4 * kDay);
+        CHECK_NEAR(t.pnl, 12.08 - 11.82, 1e-9);
+        CHECK_NEAR(t.qty, 1.0, 1e-12);
+        CHECK(t.exit_id.empty());
+        CHECK(t.exit_comment.empty());
+    }
+    // Report: the row is a closed trade (TV closedTrades:1).
+    ReportC rep{};
+    eng.fill_report(&rep);
+    CHECK(rep.total_trades == 1);                       // pre-fix: 0
+    CHECK(rep.trades_len == 1);
+    if (rep.trades_len == 1) {
+        CHECK(rep.trades[0].open_at_end == 1);
+        CHECK(rep.trades[0].is_long == 1);
+        CHECK_NEAR(rep.trades[0].exit_price, 12.08, 1e-9);
+        CHECK(rep.trades[0].exit_bar_index == 3);
+        CHECK(rep.trades[0].exit_time == 4 * kDay);
+    }
+    CHECK_NEAR(rep.net_profit, 12.08 - 11.82, 1e-9);
+    CHECK(rep.metrics.all.num_trades == 1);
+    CHECK(rep.metrics.longs.num_trades == 1);
+    // The last point is the flat account: the row is closed, nothing is open.
+    CHECK_NEAR(rep.metrics.equity.open_pl, 0.0, 1e-12);
+    CHECK_NEAR(eng.curve().back().equity, 100000.0 + (12.08 - 11.82), 1e-9);
+    BacktestEngine::free_report(&rep);
+}
+
+// B. Flat at end: nothing changes, no row is flagged.
+static void test_flat_at_end_unchanged() {
+    std::printf("-- B: flat at end is unaffected --\n");
+    Probe eng;
+    eng.script = "L.C.";
+    auto bars = daily_bars(4, 12.08);
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.trade_count() == 1);
+    CHECK(eng.range_end_rows().empty());
+    CHECK(eng.position_side_ == PositionSide::FLAT);
+    if (eng.trade_count() == 1) {
+        const Trade& t = eng.all_trades()[0];
+        CHECK(!t.open_at_end);
+        CHECK_NEAR(t.exit_price, 11.82, 1e-9);       // bar 3 open, the script's close
+        CHECK(t.exit_bar_index == 3);
+    }
+    ReportC rep{};
+    eng.fill_report(&rep);
+    CHECK(rep.total_trades == 1);
+    if (rep.trades_len == 1) CHECK(rep.trades[0].open_at_end == 0);
+    const pf_equity_point_t& last = eng.curve().back();
+    CHECK_NEAR(last.open_profit, 0.0, 1e-12);
+    CHECK_NEAR(last.equity, 100000.0 + rep.net_profit, 1e-9);
+    BacktestEngine::free_report(&rep);
+}
+
+// C. Open short at end: the orb-lite row shape.
+static void test_open_short_at_end() {
+    std::printf("-- C: open short at end (orb-lite: 11.82 -> 12.08 = -0.26) --\n");
+    Probe eng;
+    eng.script = "S...";
+    auto bars = daily_bars(4, 12.08);
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.trade_count() == 0);
+    CHECK(eng.position_side_ == PositionSide::SHORT);
+    CHECK(eng.range_end_rows().size() == 1);
+    if (eng.range_end_rows().size() == 1) {
+        const Trade& t = eng.range_end_rows()[0];
+        CHECK(t.open_at_end);
+        CHECK(!t.is_long);
+        CHECK_NEAR(t.entry_price, 11.82, 1e-9);
+        CHECK_NEAR(t.exit_price, 12.08, 1e-9);
+        CHECK_NEAR(t.pnl, -0.26, 1e-9);
+        CHECK_NEAR(t.pnl_pct, -0.26 / 11.82 * 100.0, 1e-9);
+        CHECK(t.exit_bar_index == 3);
+    }
+}
+
+// D. Commission on both legs, like any close.
+static void test_commission_applied_like_a_close() {
+    std::printf("-- D: 0.1%% commission charged on entry and the range-end exit --\n");
+    Probe eng(/*commission_pct=*/0.1);
+    eng.script = "L...";
+    auto bars = daily_bars(4, 12.08);
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.range_end_rows().size() == 1);
+    if (eng.range_end_rows().size() == 1) {
+        const Trade& t = eng.range_end_rows()[0];
+        const double expect_comm = 11.82 * 1.0 * 0.001 + 12.08 * 1.0 * 0.001;
+        CHECK_NEAR(t.commission, expect_comm, 1e-12);
+        CHECK_NEAR(t.pnl, (12.08 - 11.82) - expect_comm, 1e-12);
+        CHECK(t.open_at_end);
+    }
+    // The last equity point is the flat account: net of both legs'
+    // commission, like TV's own curve after the range-end close.
+    ReportC rep{};
+    eng.fill_report(&rep);
+    const pf_equity_point_t& last = eng.curve().back();
+    CHECK_NEAR(last.open_profit, 0.0, 1e-12);
+    CHECK_NEAR(last.equity, 100000.0 + rep.net_profit, 1e-9);
+    CHECK_NEAR(last.equity, 100000.0 + (12.08 - 11.82) - (11.82 * 0.001 + 12.08 * 0.001), 1e-9);
+    CHECK_NEAR(rep.metrics.all.commission_paid, 11.82 * 0.001 + 12.08 * 0.001, 1e-12);
+    BacktestEngine::free_report(&rep);
+}
+
+// E. Sub-tick last close rounds to the nearest tick; slippage is not applied.
+static void test_mark_is_rounded_close_without_slippage() {
+    std::printf("-- E: 12.083 last close books 12.08, slippage ignored --\n");
+    Probe eng(/*commission_pct=*/0.0, /*slippage_ticks=*/2);
+    eng.script = "L...";
+    auto bars = daily_bars(4, 12.083);
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.range_end_rows().size() == 1);
+    if (eng.range_end_rows().size() == 1) {
+        const Trade& t = eng.range_end_rows()[0];
+        CHECK_NEAR(t.exit_price, 12.08, 1e-9);        // not 12.06 (2 ticks adverse)
+        // The entry, a market order, DID take slippage: 11.82 + 2 ticks.
+        CHECK_NEAR(t.entry_price, 11.84, 1e-9);
+        CHECK_NEAR(t.pnl, 12.08 - 11.84, 1e-9);
+    }
+}
+
+// F. Equity curve before the last bar is untouched; the last point is the
+//    flat account.
+static void test_equity_curve_earlier_points_unchanged() {
+    std::printf("-- F: earlier equity points unchanged, last point re-marked flat --\n");
+    auto bars = daily_bars(6, 12.30);
+    bars[3].close = 11.60; bars[3].low = 11.50;      // an interior drawdown bar
+    bars[4].close = 12.10; bars[4].high = 12.40;
+    Probe full(/*commission_pct=*/0.1);
+    full.script = "L.....";
+    full.run(bars.data(), (int)bars.size());
+    Probe shorter(/*commission_pct=*/0.1);
+    shorter.script = "L.....";
+    shorter.run(bars.data(), (int)bars.size() - 1);   // stops one bar earlier
+    CHECK(full.curve().size() == 6);
+    CHECK(shorter.curve().size() == 5);
+    // Points 0..3 (before the shorter run's own last bar) are identical.
+    for (size_t i = 0; i + 1 < shorter.curve().size() && i < full.curve().size(); ++i) {
+        CHECK(full.curve()[i].time_ms == shorter.curve()[i].time_ms);
+        CHECK_NEAR(full.curve()[i].equity, shorter.curve()[i].equity, 1e-12);
+        CHECK_NEAR(full.curve()[i].open_profit, shorter.curve()[i].open_profit, 1e-12);
+    }
+    // Point 4 of the full run is the bar the shorter run ended on: the full
+    // run's copy still carries the mark-to-market (the position was open at
+    // that bar's close), i.e. the pre-fix reading, since nothing was
+    // flattened there.
+    CHECK_NEAR(full.curve()[4].open_profit, 12.10 - 11.82, 1e-9);
+    CHECK_NEAR(full.curve()[4].equity, 100000.0 + (12.10 - 11.82), 1e-9);
+    // The shorter run flattened on ITS last bar (bar 4): its last point is
+    // flat at the net of commission.
+    const double comm4 = 11.82 * 0.001 + 12.10 * 0.001;
+    CHECK_NEAR(shorter.curve()[4].open_profit, 0.0, 1e-12);
+    CHECK_NEAR(shorter.curve()[4].equity, 100000.0 + (12.10 - 11.82) - comm4, 1e-9);
+    // Report identities on the full run.
+    ReportC rep{};
+    full.fill_report(&rep);
+    const pf_equity_point_t& last = full.curve().back();
+    CHECK_NEAR(last.open_profit, 0.0, 1e-12);
+    CHECK_NEAR(last.equity, 100000.0 + rep.net_profit + last.open_profit, 1e-9);
+    CHECK_NEAR(rep.net_profit, (12.30 - 11.82) - (11.82 * 0.001 + 12.30 * 0.001), 1e-9);
+    // The curve walk reproduces the re-folded scalars on both runs.
+    CHECK_NEAR(rep.metrics.equity.max_equity_drawdown, full.max_dd(), 1e-9);
+    CHECK_NEAR(rep.metrics.equity.max_equity_runup, full.max_ru(), 1e-9);
+    CHECK(rep.total_trades == 1);
+    CHECK(rep.metrics.all.num_trades == 1);
+    CHECK_NEAR(rep.metrics.all.commission_paid, 11.82 * 0.001 + 12.30 * 0.001, 1e-12);
+    // time in market counts the last bar as in-market (position open at its
+    // close, as before): 5 of 6 bars.
+    CHECK_NEAR(rep.metrics.equity.time_in_market_pct, 5.0 / 6.0 * 100.0, 1e-9);
+    BacktestEngine::free_report(&rep);
+}
+
+// G. Pyramiding: one row per open slice.
+static void test_pyramiding_two_rows() {
+    std::printf("-- G: two open slices -> two flagged rows --\n");
+    Probe eng(/*commission_pct=*/0.0, /*slippage_ticks=*/0, /*pyramiding=*/2);
+    eng.script = "L.L..";
+    auto bars = daily_bars(5, 12.08);
+    bars[3].open = 11.90;                             // second slice fills here
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.trade_count() == 0);
+    CHECK(eng.position_side_ == PositionSide::LONG);
+    CHECK(eng.range_end_rows().size() == 2);
+    if (eng.range_end_rows().size() == 2) {
+        const Trade& a = eng.range_end_rows()[0];
+        const Trade& b = eng.range_end_rows()[1];
+        CHECK(a.open_at_end && b.open_at_end);
+        CHECK_NEAR(a.entry_price, 11.82, 1e-9);
+        CHECK_NEAR(b.entry_price, 11.90, 1e-9);
+        CHECK_NEAR(a.exit_price, 12.08, 1e-9);
+        CHECK_NEAR(b.exit_price, 12.08, 1e-9);
+        CHECK(a.exit_bar_index == 4 && b.exit_bar_index == 4);
+        CHECK_NEAR(a.pnl + b.pnl, (12.08 - 11.82) + (12.08 - 11.90), 1e-9);
+    }
+    ReportC rep{};
+    eng.fill_report(&rep);
+    CHECK(rep.total_trades == 2);
+    CHECK_NEAR(rep.net_profit, (12.08 - 11.82) + (12.08 - 11.90), 1e-9);
+    BacktestEngine::free_report(&rep);
+}
+
+// G2. A script-closed trade followed by an open one: the report lists the
+//     closed trade first, the range-end row last, and the row count is the
+//     sum. The live trade list still holds only the script's close.
+static void test_closed_then_open_rows_ordered() {
+    std::printf("-- G2: closed trade then range-end row, in that order --\n");
+    Probe eng;
+    eng.script = "L.C.L...";
+    auto bars = daily_bars(8, 12.08);
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.trade_count() == 1);
+    CHECK(eng.range_end_rows().size() == 1);
+    ReportC rep{};
+    eng.fill_report(&rep);
+    CHECK(rep.total_trades == 2);
+    if (rep.trades_len == 2) {
+        CHECK(rep.trades[0].open_at_end == 0);
+        CHECK(rep.trades[0].exit_bar_index == 3);
+        CHECK(rep.trades[1].open_at_end == 1);
+        CHECK(rep.trades[1].entry_bar_index == 5);
+        CHECK(rep.trades[1].exit_bar_index == 7);
+        CHECK_NEAR(rep.net_profit, rep.trades[0].pnl + rep.trades[1].pnl, 1e-12);
+    }
+    BacktestEngine::free_report(&rep);
+}
+
+// H. Aggregated path: the exit is dated on the script bar's label.
+static void test_aggregated_path_exit_on_script_label() {
+    std::printf("-- H: 1m -> 5m script bars, exit dated on the last script label --\n");
+    Probe eng;
+    eng.script = "L..";                               // script bar 0 places, bar 1 fills
+    std::vector<Bar> bars;
+    const int64_t t0 = 1'700'000'000'000LL;           // 5m-aligned? make it so
+    const int64_t base = (t0 / 300'000) * 300'000;
+    for (int i = 0; i < 15; ++i) {                    // three 5m script bars
+        double px = (i < 5) ? 11.80 : 11.82;
+        if (i == 14) px = 12.08;
+        bars.push_back(mk_bar(base + (int64_t)i * 60'000, px, px + 0.05, px - 0.05, px));
+    }
+    eng.run(bars.data(), (int)bars.size(), "1", "5", /*bar_magnifier=*/false, 4,
+            MagnifierDistribution::ENDPOINTS);
+    CHECK(eng.last_error().empty());
+    CHECK(eng.curve().size() == 3);
+    CHECK(eng.range_end_rows().size() == 1);
+    if (eng.range_end_rows().size() == 1 && eng.curve().size() == 3) {
+        const Trade& t = eng.range_end_rows()[0];
+        CHECK(t.open_at_end);
+        CHECK(t.exit_bar_index == 2);
+        CHECK(t.exit_time == eng.curve()[2].time_ms);
+        CHECK(t.exit_time == base + 10 * 60'000);
+        CHECK_NEAR(t.exit_price, 12.08, 1e-9);
+    }
+}
+
+// I. A second run() on the same handle starts from nothing: the rows of the
+//    first run do not leak into a run that ends flat.
+static void test_rerun_clears_rows() {
+    std::printf("-- I: re-run clears the range-end rows --\n");
+    Probe eng;
+    eng.script = "L...";
+    auto bars = daily_bars(4, 12.08);
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.range_end_rows().size() == 1);
+    eng.script = "L.C.";
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.range_end_rows().empty());
+    CHECK(eng.trade_count() == 1);
+}
+
+// J. The curve walk reproduces the scalar extremes with commission and an
+//    open position at the end, the last bar being the extreme.
+static void test_walk_reproduces_scalar_extremes_at_the_end() {
+    std::printf("-- J: dd/runup walk == scalar extremes with commission, open at end --\n");
+    // Long from bar 1 at 11.82; the tape rallies to a peak on bar 3 and
+    // then falls to its lowest close on the LAST bar: the trough is the
+    // range-end bar, where the first cut's re-mark moved the point.
+    {
+        auto bars = daily_bars(6, 11.20);
+        bars[2].close = 12.40; bars[2].high = 12.50;
+        bars[3].close = 12.10; bars[3].high = 12.45;
+        bars[4].close = 11.60; bars[4].low = 11.50;
+        bars[5].low = 11.10;
+        Probe eng(/*commission_pct=*/0.1);
+        eng.script = "L.....";
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.range_end_rows().size() == 1);
+        ReportC rep{};
+        eng.fill_report(&rep);
+        CHECK_NEAR(rep.metrics.equity.max_equity_drawdown, eng.max_dd(), 1e-9);
+        CHECK_NEAR(rep.metrics.equity.max_equity_runup, eng.max_ru(), 1e-9);
+        // The drawdown runs from the peak mark (12.40, gross) to the
+        // re-marked last point (11.20 net of both legs' commission): the
+        // first cut's scalars still read the gross 12.40 - 11.20 here.
+        CHECK_NEAR(eng.max_dd(), (12.40 - 11.20) + (11.82 * 0.001 + 11.20 * 0.001), 1e-9);
+        BacktestEngine::free_report(&rep);
+    }
+    // Mirrored: peak on bar 2, trough on bar 3, and the run-up from that
+    // trough ends on the LAST bar (below the peak, so the trough is not
+    // reset): the scalar reads the re-marked last point, net of the row's
+    // commissions, where the first cut still read the gross mark.
+    {
+        auto bars = daily_bars(6, 12.30);
+        bars[2].close = 12.40; bars[2].high = 12.50;
+        bars[3].close = 11.30; bars[3].low = 11.20;
+        bars[4].close = 12.10;
+        bars[5].high = 12.45;
+        Probe eng(/*commission_pct=*/0.1);
+        eng.script = "L.....";
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.range_end_rows().size() == 1);
+        ReportC rep{};
+        eng.fill_report(&rep);
+        CHECK_NEAR(rep.metrics.equity.max_equity_drawdown, eng.max_dd(), 1e-9);
+        CHECK_NEAR(rep.metrics.equity.max_equity_runup, eng.max_ru(), 1e-9);
+        // Run-up from the trough mark (11.30, gross) to the re-marked last
+        // point (12.90 net of commission).
+        CHECK_NEAR(eng.max_ru(), (12.30 - 11.30) - (11.82 * 0.001 + 12.30 * 0.001), 1e-9);
+        BacktestEngine::free_report(&rep);
+    }
+}
+
+int main() {
+    test_open_long_at_end();
+    test_flat_at_end_unchanged();
+    test_open_short_at_end();
+    test_commission_applied_like_a_close();
+    test_mark_is_rounded_close_without_slippage();
+    test_equity_curve_earlier_points_unchanged();
+    test_pyramiding_two_rows();
+    test_closed_then_open_rows_ordered();
+    test_aggregated_path_exit_on_script_label();
+    test_rerun_clears_rows();
+    test_walk_reproduces_scalar_extremes_at_the_end();
+    std::printf("%d passed, %d failed\n", tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_run_inputs_overrides.cpp
+++ b/tests/test_run_inputs_overrides.cpp
@@ -231,12 +231,25 @@ void test_overrides_applied_to_config_and_equity() {
     // No leg ever closes → final long position holds 2*4 = 8 contracts.
     CHECK(near(s.signed_size(), 8.0));
 
-    // No closed trades → net_profit==0 → equity stays at the overridden
-    // initial_capital. (open_profit is not part of current_equity().)
+    // No closed trades → the live net profit is 0 → equity stays at the
+    // overridden initial_capital. (open_profit is not part of
+    // current_equity().) The REPORT, however, carries TradingView's
+    // range-end accounting (record_range_end_close_trades): the two open
+    // legs are reported as closed trades at the last bar's close, one row
+    // per leg, flagged open_at_end, so total_trades is 2 and net_profit is
+    // their mark-to-market net of the 0.5% commission — both legs closed at
+    // the same price, so the report's net profit is exactly the sum of
+    // those two rows.
     ReportC rep{};
     s.fill_report(&rep);
-    CHECK(rep.total_trades == 0);
-    CHECK(near(rep.net_profit, 0.0));
+    CHECK(rep.total_trades == 2);
+    double rows_pnl = 0.0;
+    for (int i = 0; i < rep.trades_len; ++i) {
+        CHECK(rep.trades[i].open_at_end == 1);
+        CHECK(near(rep.trades[i].qty, 4.0));
+        rows_pnl += rep.trades[i].pnl;
+    }
+    CHECK(near(rep.net_profit, rows_pnl));
     CHECK(near(s.equity(), 250000.0));
     BacktestEngine::free_report(&rep);
 }

--- a/tests/test_trade_start_gap_pad.cpp
+++ b/tests/test_trade_start_gap_pad.cpp
@@ -1,0 +1,294 @@
+/*
+ * test_trade_start_gap_pad.cpp — the trade-start gate admits the script bar
+ * immediately PRECEDING the first in-window bar whatever calendar gap sits
+ * in front of the gate (weekend, holiday, session break), found by index on
+ * the feed rather than by subtracting one script TF in milliseconds.
+ *
+ * Evidence: orb-lite on NYSE:F 1D fires its short on the 2026-03-13 (Friday)
+ * bar and TradingView fills it on 2026-03-16 (Monday), its first entry. The
+ * validator opened the window one bar interval before Monday (Sunday), the
+ * gate's millisecond buffer reached one script TF further (Saturday), and
+ * Friday's strategy.entry sat before it — dropped, so the engine's tape
+ * started elsewhere. compute_trade_start_preceding_script_bar
+ * (engine_run.cpp) now resolves the bar before the first bar >= the gate
+ * once per run, and trading_is_active (engine_strategy_commands.cpp) admits
+ * it beside the unchanged millisecond rule.
+ *
+ * Pins (a market RAW_ORDER placed on ``place_bar`` fills the next bar's open
+ * when the gate admits the placement; the final position tells). The rule
+ * is ONE pad: the script bar immediately preceding the first in-window bar
+ * is admitted, nothing earlier. When the preceding bar resolves, the old
+ * millisecond buffer is not stacked on top of it (a first cut of this change
+ * did stack it and, with the validator's gate one bar early as well, admitted
+ * TWO bars before TradingView's first entry — Thursday for a Monday entry).
+ *   A. Daily feed Thu/Fri/Mon/Tue with the gate at Monday minus one calendar
+ *      day (Sunday — the pre-fix validator pad, and what --emit-window-ohlcv
+ *      style windows still produce): Friday's placement is admitted and
+ *      fills Monday's open; Thursday's (two bars before Monday) is refused.
+ *   B. The gate the validator now sets, Monday's label itself (TV's first
+ *      entry): Friday admitted, Thursday refused, Monday in-window.
+ *   C. A gate on Friday's label: Thursday (the bar before it) is admitted,
+ *      Wednesday is refused — the pad is one bar under any gate, where the
+ *      millisecond buffer stacked on the index rule admitted Wednesday too.
+ *   C2. Mid-week daily gate (Wednesday): Tuesday admitted, Monday refused.
+ *   D. Aggregated 1m -> 15m feed across an overnight session gap with the
+ *      gate on day 2's first 15m label (TV's entry): day 1's last 15m script
+ *      bar is admitted and its order fills day 2's first script bar; day 1's
+ *      second-to-last is refused. The pre-fix 1m validator pad (one input
+ *      minute before the label) gives the same verdicts.
+ *   E. Continuous 1m feed (test_strategy_commands_extra's gate pin, T = bar
+ *      3): bar 2 admitted, bar 1 refused — intraday behaviour unchanged.
+ *   E2. Continuous same-TF 15m feed with the gate on the entry bar: the bar
+ *      before it admitted, two bars before refused.
+ *   F. No gate: everything admitted, as before. A gate past the feed keeps
+ *      the millisecond rule (nothing admitted here); a gate before the feed
+ *      admits everything.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <pineforge/bar.hpp>
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+static bool near(double a, double b, double tol = 1e-9) { return std::fabs(a - b) <= tol; }
+static constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+static Bar mk_bar(int64_t ts, double o, double h, double l, double c) {
+    Bar b;
+    b.open = o; b.high = h; b.low = l; b.close = c;
+    b.volume = 1000.0; b.timestamp = ts;
+    return b;
+}
+
+namespace {
+
+// NYSE 1D bars, labelled at the 13:30 UTC session open.
+constexpr int64_t kThu = 1773322200000LL;   // 2026-03-12
+constexpr int64_t kFri = 1773408600000LL;   // 2026-03-13
+constexpr int64_t kMon = 1773667800000LL;   // 2026-03-16
+constexpr int64_t kTue = 1773754200000LL;   // 2026-03-17
+constexpr int64_t kDayMs = 86'400'000LL;
+
+std::vector<Bar> daily_feed() {
+    // Wed(idx0) Thu(1) Fri(2) Mon(3) Tue(4) Wed(5): a weekend between 2 and 3.
+    return {
+        mk_bar(kThu - kDayMs, 100, 101, 99, 100),
+        mk_bar(kThu,          100, 101, 99, 100),
+        mk_bar(kFri,          100, 101, 99, 100),
+        mk_bar(kMon,          100, 101, 99, 100),
+        mk_bar(kTue,          100, 101, 99, 100),
+        mk_bar(kTue + kDayMs, 100, 101, 99, 100),
+    };
+}
+
+class GateProbe : public BacktestEngine {
+public:
+    int place_bar = -1;
+    double final_pos = 1234.0;
+    int fill_bar = -1;
+    explicit GateProbe(int pb) : place_bar(pb) {
+        initial_capital_ = 1'000'000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        slippage_ = 0;
+        commission_value_ = 0;
+    }
+    void on_bar(const Bar& /*bar*/) override {
+        if (bar_index_ == place_bar) {
+            strategy_order("E", true, 2.0, /*limit=*/kNaN, /*stop=*/kNaN);
+        }
+        if (fill_bar < 0 && signed_position_size() != 0.0) fill_bar = bar_index_;
+        final_pos = signed_position_size();
+    }
+    int preceding() const { return trade_start_preceding_script_bar_; }
+};
+
+// Run the daily feed with a placement on ``place_bar`` and the gate at
+// ``gate_ms``; report whether the order filled and on which script bar.
+struct Verdict { bool filled; int fill_bar; int preceding; };
+Verdict daily_verdict(int place_bar, int64_t gate_ms) {
+    GateProbe p(place_bar);
+    p.set_trade_start_time(gate_ms);
+    auto bars = daily_feed();
+    p.run(bars.data(), (int)bars.size());
+    return {p.final_pos == 2.0, p.fill_bar, p.preceding()};
+}
+
+}  // namespace
+
+// A. Gate = Sunday (Monday - 1 calendar day).
+static void test_weekend_gap_gate_on_sunday() {
+    std::printf("-- A: gate Sunday: Friday admitted, Thursday refused --\n");
+    Verdict fri = daily_verdict(/*place_bar=*/2, kMon - kDayMs);
+    CHECK(fri.preceding == 2);                   // Friday precedes Monday
+    CHECK(fri.filled);                           // pre-fix: refused
+    CHECK(fri.fill_bar == 3);                    // fills Monday's open
+    Verdict thu = daily_verdict(/*place_bar=*/1, kMon - kDayMs);
+    CHECK(!thu.filled);
+}
+
+// B. Gate exactly on Monday's label: the validator's gate (TV's first entry).
+static void test_weekend_gap_gate_on_monday() {
+    std::printf("-- B: gate Monday: Friday admitted, Thursday refused --\n");
+    Verdict fri = daily_verdict(2, kMon);
+    CHECK(fri.preceding == 2);
+    CHECK(fri.filled);                           // pre-fix: refused (Fri < Sun)
+    CHECK(fri.fill_bar == 3);
+    Verdict thu = daily_verdict(1, kMon);
+    CHECK(!thu.filled);                          // two bars before: refused
+    Verdict mon = daily_verdict(3, kMon);
+    CHECK(mon.filled && mon.fill_bar == 4);      // in-window, as before
+}
+
+// C. Gate on Friday's label: one pad, Thursday only.
+static void test_gate_on_friday_pads_one_bar() {
+    std::printf("-- C: gate Friday: Thursday admitted, Wednesday refused --\n");
+    Verdict fri = daily_verdict(2, kFri);
+    CHECK(fri.preceding == 1);                   // Thursday precedes Friday
+    CHECK(fri.filled && fri.fill_bar == 3);
+    Verdict thu = daily_verdict(1, kFri);
+    CHECK(thu.filled && thu.fill_bar == 2);
+    Verdict wed = daily_verdict(0, kFri);        // first cut: admitted (Fri - 1d)
+    CHECK(!wed.filled);
+}
+
+// C2. Mid-week daily gate: no calendar gap, still one pad.
+static void test_midweek_gate_pads_one_bar() {
+    std::printf("-- C2: gate Wednesday: Tuesday admitted, Monday refused --\n");
+    const int64_t wed = kTue + kDayMs;
+    Verdict tue = daily_verdict(4, wed);
+    CHECK(tue.preceding == 4);
+    CHECK(tue.filled && tue.fill_bar == 5);
+    Verdict mon = daily_verdict(3, wed);
+    CHECK(!mon.filled);
+}
+
+// D. Aggregated 1m -> 15m across an overnight gap.
+static void test_aggregated_session_gap() {
+    std::printf("-- D: 1m->15m across a session gap: day 1's last script bar admitted --\n");
+    // Day 1: 13:30..14:29 UTC (four 15m buckets), day 2: 13:30..14:29 UTC.
+    const int64_t d1 = kFri, d2 = kMon;
+    std::vector<Bar> bars;
+    for (int i = 0; i < 60; ++i) bars.push_back(mk_bar(d1 + i * 60'000LL, 100, 101, 99, 100));
+    for (int i = 0; i < 60; ++i) bars.push_back(mk_bar(d2 + i * 60'000LL, 100, 101, 99, 100));
+    // Script bars: day 1 -> 0,1,2,3; day 2 -> 4,5,6,7 (the last bucket may
+    // stay open at end of feed; the placements below never depend on it).
+    auto run_case = [&](int place_bar, int64_t gate) {
+        GateProbe p(place_bar);
+        p.set_trade_start_time(gate);
+        p.run(bars.data(), (int)bars.size(), "1", "15", /*bar_magnifier=*/false, 4,
+              MagnifierDistribution::ENDPOINTS);
+        CHECK(p.last_error().empty());
+        return Verdict{p.final_pos == 2.0, p.fill_bar, p.preceding()};
+    };
+    for (int64_t gate : {d2, d2 - 60'000LL}) {     // TV's entry label; the old 1m pad
+        Verdict last_d1 = run_case(3, gate);
+        CHECK(last_d1.preceding == 3);
+        CHECK(last_d1.filled);                   // pre-fix: refused (day-1 14:15 < day-2 13:14)
+        CHECK(last_d1.fill_bar == 4);            // day 2's first script bar
+        Verdict prev_d1 = run_case(2, gate);
+        CHECK(!prev_d1.filled);
+    }
+}
+
+// E. Continuous 1m feed: unchanged.
+static void test_continuous_minute_feed_unchanged() {
+    std::printf("-- E: continuous 1m feed, gate bar 3: bar 2 admitted, bar 1 refused --\n");
+    std::vector<Bar> bars;
+    for (int i = 0; i < 6; ++i) bars.push_back(mk_bar((int64_t)(i + 1) * 60'000, 100, 105, 95, 100));
+    {
+        GateProbe gated(1);
+        gated.set_trade_start_time(240'000);
+        gated.run(bars.data(), (int)bars.size());
+        CHECK(gated.preceding() == 2);
+        CHECK(gated.final_pos == 0.0);
+    }
+    {
+        GateProbe active(2);
+        active.set_trade_start_time(240'000);
+        active.run(bars.data(), (int)bars.size());
+        CHECK(active.final_pos == 2.0);
+        CHECK(active.fill_bar == 3);
+    }
+}
+
+// E2. Continuous same-TF 15m feed, gate on the entry bar: one pad.
+static void test_continuous_15m_feed_one_pad() {
+    std::printf("-- E2: continuous 15m feed, gate bar 5: bar 4 admitted, bar 3 refused --\n");
+    std::vector<Bar> bars;
+    const int64_t base = 1'773'619'200'000LL;    // 2026-03-16 00:00 UTC
+    for (int i = 0; i < 10; ++i) bars.push_back(mk_bar(base + i * 900'000LL, 100, 105, 95, 100));
+    Verdict four{}, three{};
+    {
+        GateProbe p(4);
+        p.set_trade_start_time(base + 5 * 900'000LL);
+        p.run(bars.data(), (int)bars.size());
+        four = {p.final_pos == 2.0, p.fill_bar, p.preceding()};
+    }
+    {
+        GateProbe p(3);
+        p.set_trade_start_time(base + 5 * 900'000LL);
+        p.run(bars.data(), (int)bars.size());
+        three = {p.final_pos == 2.0, p.fill_bar, p.preceding()};
+    }
+    CHECK(four.preceding == 4);
+    CHECK(four.filled && four.fill_bar == 5);
+    CHECK(!three.filled);                        // the old validator pad + buffer admitted it
+}
+
+// F. No gate; gates outside the feed.
+static void test_no_gate() {
+    std::printf("-- F: no gate: everything admitted; gates outside the feed --\n");
+    auto bars = daily_feed();
+    GateProbe p(0);
+    p.run(bars.data(), (int)bars.size());
+    CHECK(p.preceding() == -1);
+    CHECK(p.final_pos == 2.0);
+    CHECK(p.fill_bar == 1);
+    // A gate past the feed's end has no preceding bar: the millisecond rule
+    // alone applies (nothing admitted here).
+    GateProbe late(4);
+    late.set_trade_start_time(kTue + 10 * kDayMs);
+    late.run(bars.data(), (int)bars.size());
+    CHECK(late.preceding() == -1);
+    CHECK(late.final_pos == 0.0);
+    // A gate before the feed's first bar: nothing precedes it, everything
+    // is in-window.
+    GateProbe early(0);
+    early.set_trade_start_time(kThu - 10 * kDayMs);
+    early.run(bars.data(), (int)bars.size());
+    CHECK(early.preceding() == -1);
+    CHECK(early.final_pos == 2.0 && early.fill_bar == 1);
+}
+
+int main() {
+    test_weekend_gap_gate_on_sunday();
+    test_weekend_gap_gate_on_monday();
+    test_gate_on_friday_pads_one_bar();
+    test_midweek_gate_pads_one_bar();
+    test_aggregated_session_gap();
+    test_continuous_minute_feed_unchanged();
+    test_continuous_15m_feed_one_pad();
+    test_no_gate();
+    std::printf("%d passed, %d failed\n", tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tutorial/run.py
+++ b/tutorial/run.py
@@ -29,7 +29,8 @@ class TradeC(ctypes.Structure):
                 ("max_drawdown",ctypes.c_double),("qty",        ctypes.c_double),
                 ("commission",  ctypes.c_double),
                 ("entry_bar_index", ctypes.c_int32),
-                ("exit_bar_index",  ctypes.c_int32)]
+                ("exit_bar_index",  ctypes.c_int32),
+                ("open_at_end",     ctypes.c_int32)]   # ABI v3: range-end close row
 
 class TradeStatsC(ctypes.Structure):  # pf_trade_stats_t
     _fields_ = [("num_trades", ctypes.c_int32), ("num_wins", ctypes.c_int32),
@@ -112,7 +113,7 @@ class ReportC(ctypes.Structure):
 
 # pf_report_t is caller-allocated, so a stale mirror means the runtime
 # writes past our buffer. Assert the .so's ABI version before any run.
-EXPECTED_PF_ABI = 2
+EXPECTED_PF_ABI = 3
 
 def check_abi(lib: ctypes.CDLL) -> None:
     try:


### PR DESCRIPTION
## Summary
Two commuting fixes for the daily-timeframe lanes, measured as a 2×2 on spark and as a six-lane experiment on Cloud Run.

**M2 — range-end close (TradingView emulation).** TradingView's deep-backtest report lists the position still open at the range's last bar as a closed trade at that bar's close. The engine exported closed trades only, so on 1D lanes where that is the only trade in the window the engine reported 0 trades ("no-trades", tier minimal) although it held the same position with the same mark-to-market P/L (spark: 7/10 to the cent). The engine now emits a report-only row for each lot still open after the final bar of the range (`record_range_end_close_trades`, `pf_trade_t::open_at_end`, ABI v3), priced at the last close on-tick, commission per the strategy's rules, no slippage; broker state, Pine accessors and the equity curve before the last bar are untouched. The harness bounds the run to the tape's last row (`ohlcv_end_ms`) so the row lands on TradingView's range end, not the feed's end.

**M1 — TV-entry gate pad.** The TV-entry emit window padded by one bar-interval in milliseconds, so a Friday signal filled on Monday fell outside the gate across a weekend. The gate now admits the feed's previous script bar by index (`trading_is_active`, `_window_start_before_first_entry`).

## Measurement
- spark 2×2 on f-1d shard 0 (64 probes): base 10 engine-0; M2 → 0 engine-0, all excellent 100%, 6 previously-ok probes improved; M1 alone neutral for that set, +2 with M2; zero match% decreases in any cell.
- Cloud Run `exp-1d-range-end-20260902` (all six 1D lanes, 1148 probes, 21 cases, 5 min): excellent+strong 74.0% → 93.6% overall — BTCUSDT-1D 77.6→93.8%, ES1-1D 79.5→96.6%, NQ1-1D 75.0→92.2%, NIFTY-1D 78.6→97.2%, NYSE-F-1D 68.4→92.8%, XAUUSD-1D 70.6→91.1%; engine-0 probes 134 → 12; 225 entrants, 1 leaver (`3commas-ena-grid-bot` XAUUSD-1D: engine 28 vs TV 25 — one range-end row per pyramided open lot where TV carries fewer; follow-up).
- Full-population gate: in progress (`gate-cand-1d-range-end-20260902`).

## Test plan
- [x] ctest 153/153 with `-UNDEBUG` (new `test_range_end_close`, `test_trade_start_gap_pad`, Python `test_run_strategy_gap_pad` / `test_run_strategy_range_end`); patches commute (tree `bc9b3797`)
- [x] Cloud Run six-lane 1D experiment above
- [ ] `gate_candidate` PASS recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXAE7TVTKZYbmtenHDHVJo