### PR TITLE
round 5: trail arming, OANDA day-stamp grids, daily session flags, TV affordability, extremes ring

### DIFF
--- a/docs/pine_v6_coverage_detail.md
+++ b/docs/pine_v6_coverage_detail.md
@@ -790,13 +790,13 @@ All **✅ Runtime** — backed by `PineMatrix` (`matrix.hpp` / `matrix.cpp`) for
 | `ta.dmi()` | fn | ✅ Runtime | `ta::DMI` class | |
 | `ta.ema()` | fn | ✅ Runtime | `ta::EMA` class | |
 | `ta.falling()` | fn | ✅ Runtime | `ta::Falling` class | |
-| `ta.highest()` | fn | ✅ Runtime | `ta::Highest` class | bar-addressed ring (K = length + 1 slots by `bar_index`, per context — chart and each `request.security`): a call inside an `if` that does not run every bar keeps stale slots, skips never-written ones, na iff `bar_index < length - 1` (NYSE:F 1D pins 39/39, 30/30); every-bar callers unchanged |
+| `ta.highest()` | fn | ✅ Runtime | `ta::Highest` class | bar-addressed ring (K = length + 1 slots by `bar_index`, per context — chart and each `request.security`): a call inside an `if` that does not run every bar keeps stale slots, skips never-written ones, na iff `bar_index < length - 1` (NYSE:F 1D pins 39/39, 30/30), read through a cached extremum with an implied bar — a call within `length` bars of the cached bar compares against the cache only and does not rescan the aliased slots (8 tapes, 696/696); every-bar callers unchanged |
 | `ta.highestbars()` | fn | ✅ Runtime | `ta::HighestBars` class | same ring as `ta.highest`; offset = slot distance of the extremum |
 | `ta.hma()` | fn | ✅ Runtime | `ta::HMA` class | |
 | `ta.kc()` | fn | ✅ Runtime | `ta::KC` class | |
 | `ta.kcw()` | fn | ✅ Runtime | `ta::KCW` class | |
 | `ta.linreg()` | fn | ✅ Runtime | `ta::Linreg` class | |
-| `ta.lowest()` | fn | ✅ Runtime | `ta::Lowest` class | same bar-addressed ring as `ta.highest` (mirror) |
+| `ta.lowest()` | fn | ✅ Runtime | `ta::Lowest` class | same bar-addressed ring and cached extremum as `ta.highest` (mirror; the 696/696 alias tapes are `ta.lowest(low, 10)`) |
 | `ta.lowestbars()` | fn | ✅ Runtime | `ta::LowestBars` class | same ring as `ta.lowest`; offset = slot distance of the extremum |
 | `ta.macd()` | fn | ✅ Runtime | `ta::MACD` class | |
 | `ta.max()` | fn | ✅ Runtime | `ta::AllTimeMax` class | Single-arg form only |

--- a/docs/pine_v6_coverage_detail.md
+++ b/docs/pine_v6_coverage_detail.md
@@ -790,14 +790,14 @@ All **✅ Runtime** — backed by `PineMatrix` (`matrix.hpp` / `matrix.cpp`) for
 | `ta.dmi()` | fn | ✅ Runtime | `ta::DMI` class | |
 | `ta.ema()` | fn | ✅ Runtime | `ta::EMA` class | |
 | `ta.falling()` | fn | ✅ Runtime | `ta::Falling` class | |
-| `ta.highest()` | fn | ✅ Runtime | `ta::Highest` class | |
-| `ta.highestbars()` | fn | ✅ Runtime | `ta::HighestBars` class | |
+| `ta.highest()` | fn | ✅ Runtime | `ta::Highest` class | bar-addressed ring (K = length + 1 slots by `bar_index`, per context — chart and each `request.security`): a call inside an `if` that does not run every bar keeps stale slots, skips never-written ones, na iff `bar_index < length - 1` (NYSE:F 1D pins 39/39, 30/30); every-bar callers unchanged |
+| `ta.highestbars()` | fn | ✅ Runtime | `ta::HighestBars` class | same ring as `ta.highest`; offset = slot distance of the extremum |
 | `ta.hma()` | fn | ✅ Runtime | `ta::HMA` class | |
 | `ta.kc()` | fn | ✅ Runtime | `ta::KC` class | |
 | `ta.kcw()` | fn | ✅ Runtime | `ta::KCW` class | |
 | `ta.linreg()` | fn | ✅ Runtime | `ta::Linreg` class | |
-| `ta.lowest()` | fn | ✅ Runtime | `ta::Lowest` class | |
-| `ta.lowestbars()` | fn | ✅ Runtime | `ta::LowestBars` class | |
+| `ta.lowest()` | fn | ✅ Runtime | `ta::Lowest` class | same bar-addressed ring as `ta.highest` (mirror) |
+| `ta.lowestbars()` | fn | ✅ Runtime | `ta::LowestBars` class | same ring as `ta.lowest`; offset = slot distance of the extremum |
 | `ta.macd()` | fn | ✅ Runtime | `ta::MACD` class | |
 | `ta.max()` | fn | ✅ Runtime | `ta::AllTimeMax` class | Single-arg form only |
 | `ta.median()` | fn | ✅ Runtime | `ta::Median` class | |

--- a/docs/pine_v6_coverage_detail.md
+++ b/docs/pine_v6_coverage_detail.md
@@ -160,13 +160,13 @@
 
 | Identifier | Kind | Status | Backing | Notes |
 |---|---|---|---|---|
-| `session.isfirstbar` | var | ✅ Runtime | `session_isfirstbar_` on engine; per-bar lookahead in `engine_run.cpp` | Sprint A |
+| `session.isfirstbar` | var | ✅ Runtime | `session_isfirstbar_` on engine; per-bar lookahead in `engine_run.cpp`; on a 1D+ chart every bar (the bar is its whole session) | Sprint A |
 | `session.isfirstbar_regular` | var | ✅ Runtime | Aliased to `session.isfirstbar` — engine has single session string, cannot distinguish RTH vs ETH (documented limitation) | Sprint A |
-| `session.islastbar` | var | ✅ Runtime | `session_islastbar_` on engine; per-bar lookahead | Sprint A |
+| `session.islastbar` | var | ✅ Runtime | `session_islastbar_` on engine; per-bar lookahead; on a 1D+ chart every bar (the bar is its whole session) | Sprint A |
 | `session.islastbar_regular` | var | ✅ Runtime | Aliased to `session.islastbar` | Sprint A |
-| `session.ismarket` | var | ✅ Runtime | `pine_session_ismarket(session, tz, bar_ms)` in `session_time.hpp` | Sprint A |
-| `session.ispostmarket` | var | ✅ Runtime | `pine_session_ispostmarket(...)` — standard ETH window `RTH_close-2000` local | Sprint A |
-| `session.ispremarket` | var | ✅ Runtime | `pine_session_ispremarket(...)` — standard ETH window `0400-RTH_open` local | Sprint A |
+| `session.ismarket` | var | ✅ Runtime | `pine_session_ismarket(session, tz, bar_ms, chart_tf)` in `session_time.hpp` (via `BacktestEngine::pine_session_ismarket`); always true on a 1D+ chart, as TradingView documents | Sprint A |
+| `session.ispostmarket` | var | ✅ Runtime | `pine_session_ispostmarket(...)` — standard ETH window `RTH_close-2000` local; always false on a 1D+ chart | Sprint A |
+| `session.ispremarket` | var | ✅ Runtime | `pine_session_ispremarket(...)` — standard ETH window `0400-RTH_open` local; always false on a 1D+ chart | Sprint A |
 
 ### Variables — strategy
 

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -2152,10 +2152,51 @@ protected:
     // and session.islastbar (prev_in_session_ && !in_session).
     bool prev_in_session_ = false;
     // Current-bar session predicates — recomputed at the start of each bar
-    // by update_session_state() in engine_run.cpp.
+    // by set_session_bar_state() (engine_run.cpp) on every bar pump.
     bool session_ismarket_ = false;
     bool session_isfirstbar_ = false;
     bool session_islastbar_ = false;
+
+    // session.ismarket of the CHART bar stamped bar_ms on the symbol's
+    // session clock — the chart-timeframe-aware rule of session_time.hpp:
+    // every bar of a daily-or-higher chart is the regular-session bar,
+    // intraday bars keep the time-of-day test.
+    bool chart_bar_ismarket(int64_t bar_ms) const;
+    // Set the three per-bar predicates for the chart bar being dispatched.
+    // in_session is chart_bar_ismarket(that bar); intraday_islastbar is the
+    // pump's own lookahead verdict for an intraday chart (peek at the next
+    // bar, barstate.islast, or never in magnifier mode). On a D/W/M chart
+    // the bar IS the whole session — its own first and last bar — so
+    // session.isfirstbar and session.islastbar both equal in_session there
+    // and the prev/next bookkeeping does not apply.
+    void set_session_bar_state(bool in_session, bool intraday_islastbar);
+
+    // The session.is* market-state variables as the generated strategy
+    // evaluates them. Codegen lowers session.ismarket / ispremarket /
+    // ispostmarket to the unqualified call
+    //   pine_session_is*(syminfo_.session, syminfo_.timezone, current_bar_.timestamp)
+    // inside the generated class, and class-scope lookup resolves it to these
+    // members (a member hides the namespace-scope function of the same name
+    // and suppresses ADL), so the chart timeframe joins the predicate with
+    // the emitted code unchanged. TradingView: on "1D" and above
+    // session.ismarket is always true, ispremarket / ispostmarket always
+    // false — OANDA:XAUUSD @1D (1800-1700, bars stamped 17:00 ET) took 0
+    // trades against TradingView's 57 while the time-of-day test decided.
+    // Every BacktestEngine member resolves here too; the one caller that
+    // wants the raw time-of-day test (the streaming clock's closed-interval
+    // skip) qualifies pineforge:: explicitly.
+    bool pine_session_ismarket(const std::string& session,
+                               const std::string& tz, int64_t bar_ms) const {
+        return pineforge::pine_session_ismarket(session, tz, bar_ms, script_tf_);
+    }
+    bool pine_session_ispremarket(const std::string& session,
+                                  const std::string& tz, int64_t bar_ms) const {
+        return pineforge::pine_session_ispremarket(session, tz, bar_ms, script_tf_);
+    }
+    bool pine_session_ispostmarket(const std::string& session,
+                                   const std::string& tz, int64_t bar_ms) const {
+        return pineforge::pine_session_ispostmarket(session, tz, bar_ms, script_tf_);
+    }
 
     // --- Timeframe state ---
     std::string input_tf_;

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -530,6 +530,69 @@ struct PendingOrder {
     // ADVERSE gap beyond the slip can decline. NaN = no snapshot.
     double explicit_slipped_signal_close =
         std::numeric_limits<double>::quiet_NaN();
+    // design-market-entry-affordability: TradingView's broker admission for a
+    // MARKET entry, pinned 2026-09-03 with `lab tv` on CME_MINI:NQ1! 15
+    // (default fixed qty 1, margin 100: 10,212 flat-entry + reversal
+    // decisions, 0 mismatches — pin-afford-{flat,reverse,gapup,gapdown,
+    // gapup-ctl}) and on OANDA:XAUUSD 15 / NYSE:F 15 (explicit
+    // qty = strategy.equity / close, commission 0.05% — pin-admit-allin-{xau,f},
+    // 1279/1279 and 352/352 exact):
+    //
+    //   admit iff lot_floored(resulting_position_qty)
+    //               * max(tick(close(S)), tick(fill)) * pv * fx * margin/100
+    //             <= placement_equity + max(1e-9, |placement_equity| * 1e-12)
+    //
+    // evaluated TWICE: at placement on tick(close(S)) against MARK-TO-MARKET
+    // equity (initial + net_profit + open_profit at close(S) — the NQ short
+    // reversal at 2025-05-06 14:15Z filled with realized 396,625 < cost 397,995
+    // but MTM 398,455 >= cost), and again at fill on tick(fill) against the
+    // SAME placement snapshot (capital 380,000: signal close 18,820.50 =
+    // 376,410 admitted, fill 19,225 = 384,500 -> NOT filled; capital 345,000:
+    // signal close 17,483.25 = 349,665 -> rejected at placement although the
+    // 17,100 fill would have cost 342,000; control capital 1e6 fills). The
+    // "resulting position" is the new side's quantity on a reversal (the
+    // closing leg's notional is not counted) and held + add on a
+    // same-direction add (masayanfx NQ1 2025-07-30 20:15Z: 2 * 23,667.75 * 20
+    // = 946,710 > MTM 945,225 -> TV dropped the add), with "held" frozen AT
+    // PLACEMENT: a same-source-bar sibling that fills first does not enter
+    // the later order's fill check (thula INR non-POOC short pair, TV rows
+    // pinned in test_margin_call: both 2-lot shorts fill from flat and the
+    // over-notional 4-lot position is then margin-called 2.6088, not
+    // declined). Commission is NOT in
+    // the notional and there is no max(equity, signal_notional) admission
+    // floor: the rounded signal close is only a second decline trigger
+    // (NYSE:F half-cent close 10.225 -> fill 10.23: floor(E/10.225) * 10.23 > E
+    // declines; XAUUSD 2025-04-08 13:30Z: 662.968 -> 662.96 lots * 3013.75 <=
+    // 1,998,000.02 admits where the raw 662.968 * 3013.745 would not).
+    // A rejected reversal drops the ENTRY leg only — its closing leg still
+    // executes (rampatel BTC 2025-05-12 07:15Z: TV closed the short by "Buy"
+    // @105,600 and opened no long, equity 103,572 < 105,600; the engine used
+    // to open it and cascade 4x-shortfall margin calls, 23,605 trades vs 1,486).
+    //
+    // Scope: high-level MARKET strategy.entry with an explicit qty OR default
+    // FIXED / CASH sizing. Default percent_of_equity entries keep their own
+    // pinned KI-54 / gap-reject / gross-admission family (not provably the
+    // same rule: their reversal decline is atomic and holds the position).
+    // NaN = no snapshot (out of scope, margin_pct == 0, non-finite close).
+    double affordability_placement_equity =
+        std::numeric_limits<double>::quiet_NaN();
+    // tick(close(S)): the on-tick signal close the placement check costed,
+    // and the floor of the fill-time admission price (max with tick(fill)).
+    // Slippage ticks are NOT in either basis — the pinned rule is stated on
+    // the rounded bar prices (all pins at slippage 0; the KI-65 explicit pair
+    // and the percent_of_equity family keep their own slipped conventions).
+    double affordability_signal_price =
+        std::numeric_limits<double>::quiet_NaN();
+    // The same-direction quantity held when the order was placed (net of a
+    // strategy.close issued earlier in the same on_bar); 0 for a flat open or
+    // a reversal. The fill check costs held + own with THIS value.
+    double affordability_held_qty = 0.0;
+    // The entry leg was declined (at placement or at fill) while an OPPOSITE
+    // position was live: the order survives only as the reversal's closing
+    // leg — apply_market_order_fill closes the opposite position and opens
+    // nothing. Inert (consumed, no broker effect) when the account is flat or
+    // same-side at the fill.
+    bool affordability_close_only = false;
     std::string comment;       // order comment for trade reporting
     bool requested_partial = false;         // true iff caller passed qty_percent < 100
     // Narrow POOC global-full-exit candidate. ``qty`` deliberately keeps the
@@ -1833,6 +1896,16 @@ protected:
                     round_to_mintick(current_bar_.close));
             }
             o.sizing_fx = active_account_currency_fx();
+        }
+        // design-market-entry-affordability: the placement-equity snapshot of
+        // THIS bar's affordability-gated market entries must see the same
+        // post-liquidation state.
+        for (auto& o : pending_orders_) {
+            if (o.type != OrderType::MARKET) continue;
+            if (o.created_bar != bar_index_) continue;
+            if (!std::isfinite(o.affordability_placement_equity)) continue;
+            o.affordability_placement_equity =
+                current_equity() + open_profit(current_bar_.close);
         }
     }
 

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -2220,6 +2220,11 @@ protected:
         int64_t feed_count = 0;
         int64_t eval_complete_count = 0;
         int64_t eval_partial_count = 0;
+        // Requested-context bar index of the latest dispatch_security_eval()
+        // (the ring address its TA members saw, see ta::bar_context()); -1
+        // before the first dispatch. The calling-boundary replay re-dispatches
+        // the same bar under the same index.
+        int64_t ta_bar_index = -1;
         // ``request.security_lower_tf`` returns one element per
         // synthesised sub-bar of the current chart bar, so the codegen
         // needs to know which sub-bar inside the current chart bar is
@@ -2380,6 +2385,17 @@ protected:
     int security_lower_tf_sub_bar_index(int sec_id) const;
     void validate_security_timeframes(const std::string& input_tf);
     bool security_series_slot_is_new(int sec_id) const;
+    // The one path to evaluate_security(): installs the requested context's
+    // bar index for the evaluator's TA members (ta::bar_context()) for the
+    // duration of the dispatch. `bar_index` is the 0-based index of the
+    // requested-context bar being evaluated — the just-completed bucket for a
+    // complete evaluation (eval_complete_count - 1), the in-progress bucket
+    // for a partial/lookahead one (eval_complete_count) — so every
+    // compute()/recompute() dispatch of one requested bar rewrites the same
+    // ring slot, and a conditional window call inside the security expression
+    // is addressed exactly like TradingView addresses it.
+    void dispatch_security_eval(SecurityEvalState& state, const Bar& bar,
+                                bool publish, int64_t bar_index);
     // KI-55 range-start gate for one evaluator: true when the input bar at
     // `input_ts` belongs to an HTF bucket that opened before
     // security_range_start_ms_ (always false while the flag is off). The

--- a/include/pineforge/session_time.hpp
+++ b/include/pineforge/session_time.hpp
@@ -55,7 +55,13 @@ int64_t pine_time_close(int64_t bar_ms,
 // (TradingView rolls `time("D", "0000-2359", "America/New_York")` at New
 // York midnight on a UTC symbol — measured), and its window is read in the
 // explicit `tz`, else `sym_tz` (the syminfo default above), else UTC.
-// Intraday tfs are unchanged.
+// An intraday `tf` (with or without a session argument, which only
+// filters) is the symbol's day-stamp-anchored HTF grid bucket
+// (session_intraday_bucket_open_ms in timeframe.hpp — the grid
+// request.security aggregates on): time("60") on NYSE:F is 09:30 / 10:30 /
+// .. / 15:30 ET, time("240") on NSE:NIFTY 09:15 / 13:15 IST and on
+// OANDA:XAUUSD the 17:00-ET-anchored 4h grid (pin-time-hours tapes,
+// 2025-04-01..07-01); the five-argument forms stay on the epoch grid.
 // With sym_tz="UTC" and an empty / "24x7" sym_session these are
 // bit-identical to the five-argument forms above.
 //

--- a/include/pineforge/session_time.hpp
+++ b/include/pineforge/session_time.hpp
@@ -163,4 +163,30 @@ bool pine_session_ispostmarket(const std::string& session,
                                const std::string& tz,
                                int64_t bar_ms);
 
+// Chart-timeframe forms: the rule the session.is* variables of a CHART bar
+// follow. TradingView evaluates them on the chart bar, and a daily-or-higher
+// bar covers whole session days rather than a time of day, so on "1D" and
+// above it documents session.ismarket as always true and session.ispremarket
+// / session.ispostmarket as always false (Pine docs, Sessions). OANDA:XAUUSD
+// @1D made the gap physical: an 1800-1700 America/New_York session and a tape
+// stamped at the 17:00 ET break put every daily open OUTSIDE the time-of-day
+// windows above, session.ismarket never held, and a script that ANDs every
+// signal with it took 0 trades against TradingView's 57. With an intraday or
+// empty chart_tf these forms defer to the three-argument time-of-day forms
+// above, byte for byte.
+bool pine_session_ismarket(const std::string& session,
+                           const std::string& tz,
+                           int64_t bar_ms,
+                           const std::string& chart_tf);
+
+bool pine_session_ispremarket(const std::string& session,
+                              const std::string& tz,
+                              int64_t bar_ms,
+                              const std::string& chart_tf);
+
+bool pine_session_ispostmarket(const std::string& session,
+                               const std::string& tz,
+                               int64_t bar_ms,
+                               const std::string& chart_tf);
+
 } // namespace pineforge

--- a/include/pineforge/ta.hpp
+++ b/include/pineforge/ta.hpp
@@ -56,6 +56,27 @@ bool& ema_na_warmup_flag();
 // installed (the default — unit tests, standalone use) every ``compute()`` is
 // its own bar and the objects are byte-identical to the previous positional
 // deque.
+//
+// The ring is read through a cached extremum with an implied bar. Each call
+// site keeps ``{value, bar}``: the first call caches ``(src, b)``; a call on
+// bar ``b`` with ``b - bar < length`` only compares ``src`` against the cache
+// (strict — ties never displace the cached member); the new-extremum test
+// comes FIRST, so a bar whose ``src`` beats the cache takes it without
+// reading the slots even when the cache has aged out; otherwise, once the
+// cached extremum has aged out (``b - bar >= length`` — by bars, not calls)
+// the slots are rescanned, oldest first, and the cache becomes
+// ``(best, b - k_best)``; otherwise the cache is kept. The output is the
+// cached value (the *Bars offset is ``b - bar``). Pinned 2026-09-04 with 8
+// ``lab tv`` tapes on NYSE:F 1D (696/696 entries), the BINANCE:ETHUSDT.P
+// geometry pin (82/82) and the jayentriken BBWP ETH replay (593/593):
+// ``m = bar_index % 49; if m < 4 or 37 <= m < 47 or m == 48: v =
+// ta.lowest(low, 10)`` answers 9.88 (cached from bar 42) on bars 48..51
+// although bar 3's stale 9.20 sits one slot behind bar 48 — the plain ring
+// would say 9.20 — and rescans to 9.20 on bar 52 once the cache has aged;
+// on ETH the run-start bar 4990 (low 2648.62 < the expired cache 2650.47)
+// answers its own low and never reads the aliased 08:15 slot the plain ring
+// returned. For an every-bar caller the cache is exactly the positional
+// window, so nothing changes there.
 struct BarContext {
     bool installed = false;
     long long bar_index = 0;   // ring address: the context's current bar index
@@ -97,6 +118,17 @@ private:
     std::vector<unsigned char> written_;
     long long own_bar_ = -1;   // cadence when no context is installed
     bool has_written_ = false;
+    // TradingView's cached extremum with an implied bar (bar_context() docs):
+    // the value the site last answered and the bar it is attributed to.
+    bool cached_ = false;
+    double cval_ = 0.0;
+    long long cbar_ = 0;
+    // The cache as it stood BEFORE the current bar's first tick, so a
+    // recompute() (same bar, advance=false) restores it and re-applies.
+    long long cache_seen_bar_ = -1;
+    bool saved_cached_ = false;
+    double saved_cval_ = 0.0;
+    long long saved_cbar_ = 0;
 };
 
 class RMA {

--- a/include/pineforge/ta.hpp
+++ b/include/pineforge/ta.hpp
@@ -29,6 +29,76 @@ namespace ta {
 // byte-identical to the prior src-seed behavior.
 bool& ema_na_warmup_flag();
 
+// Per-context bar index for bar-addressed window state (thread-local).
+//
+// TradingView keeps the source history of a window call site (``ta.highest``,
+// ``ta.lowest``, ``ta.highestbars``, ``ta.lowestbars``) in a ring of
+// ``K = length + 1`` slots addressed by ``bar_index % K``. A call on bar ``b``
+// writes ``slot[b % K] = src`` and returns the extremum over the WRITTEN slots
+// ``(b - k) % K``, ``k in [0, length)``. For a call that executes every bar
+// that is the plain positional window. For a call that executes
+// CONDITIONALLY (inside an ``if`` block that does not run every bar) the slots
+// not rewritten keep their stale values from earlier executions, never-written
+// slots are skipped, and the result is na iff ``bar_index < length - 1`` — NOT
+// until ``length`` executions have accumulated. Pinned 2026-09-03 with
+// ``lab tv`` on NYSE:F 1D (``if bar_index % 7 == 3: v = ta.highest(high, 5)``
+// 39/39 entry sizes exact, cadence 9 30/30; production: colasbreugnon-sma
+// F@1D 31/31 only with K = 6). ``ta.sma`` inside ``if`` is NOT ring-addressed
+// (per-execution buffer, pinned separately) and is untouched.
+//
+// The engine installs the executing context's bar index around every dispatch
+// of generated code: the chart's Pine ``bar_index`` around ``on_bar`` and the
+// requested context's evaluated-bar index around each ``evaluate_security``
+// (HTF / lower-tf / auxiliary feeds). ``origin`` is the first bar index the
+// context has data for — the warmup reference — so a feed that starts after
+// TradingView's hidden first chart bar (``bar_index_offset``) still warms up
+// over its own first ``length`` bars, exactly as before. With no context
+// installed (the default — unit tests, standalone use) every ``compute()`` is
+// its own bar and the objects are byte-identical to the previous positional
+// deque.
+struct BarContext {
+    bool installed = false;
+    long long bar_index = 0;   // ring address: the context's current bar index
+    long long origin = 0;      // warmup reference: the context's first bar index
+};
+BarContext& bar_context();
+
+// RAII installer: sets the thread-local BarContext for the enclosed dispatch
+// and restores the previous one on exit (also during stack unwinding), so
+// chart and request.security evaluation never see each other's index.
+class BarContextScope {
+    BarContext previous_;
+
+public:
+    BarContextScope(long long bar_index, long long origin);
+    ~BarContextScope();
+    BarContextScope(const BarContextScope&) = delete;
+    BarContextScope& operator=(const BarContextScope&) = delete;
+};
+
+// Bar-addressed extremum ring shared by Highest / Lowest / HighestBars /
+// LowestBars — the TradingView rule documented at bar_context() above.
+class ExtremeRing {
+public:
+    struct Result {
+        double value;   // na: window not formed yet, or no written non-na member
+        int bars_back;  // k of the extremum slot (0 = the current bar)
+    };
+    explicit ExtremeRing(int length);
+    // advance = true  -> compute():   records src for the context's current bar
+    // advance = false -> recompute(): rewrites the current bar's slot
+    // An na src is recorded as a gap (skipped by the extremum, never a member).
+    // Ties resolve to the OLDEST member (strict comparison, oldest slot first).
+    Result update(double src, bool advance, bool want_max);
+
+private:
+    int length_;
+    std::vector<double> values_;
+    std::vector<unsigned char> written_;
+    long long own_bar_ = -1;   // cadence when no context is installed
+    bool has_written_ = false;
+};
+
 class RMA {
     double output_val;
     double sum;
@@ -158,8 +228,7 @@ public:
 // --- Highest ---
 
 class Highest {
-    std::deque<double> buffer;
-    int length;
+    ExtremeRing ring_;
 
 public:
     explicit Highest(int length);
@@ -170,8 +239,7 @@ public:
 // --- Lowest ---
 
 class Lowest {
-    std::deque<double> buffer;
-    int length;
+    ExtremeRing ring_;
 
 public:
     explicit Lowest(int length);
@@ -597,8 +665,7 @@ public:
 // --- HighestBars ---
 
 class HighestBars {
-    int length_;
-    std::deque<double> buffer_;
+    ExtremeRing ring_;
 
 public:
     explicit HighestBars(int length);
@@ -609,8 +676,7 @@ public:
 // --- LowestBars ---
 
 class LowestBars {
-    int length_;
-    std::deque<double> buffer_;
+    ExtremeRing ring_;
 
 public:
     explicit LowestBars(int length);

--- a/include/pineforge/timeframe.hpp
+++ b/include/pineforge/timeframe.hpp
@@ -110,8 +110,12 @@ bool tf_change(int64_t prev_ms, int64_t curr_ms, const std::string& tf,
 // Every chart-level consumer of "the symbol's daily bar" — ta.vwap's default
 // anchor, timeframe.change("1D"), time("D")/time_close("D") — has to key on
 // this clock, the same one request.security aggregation already uses
-// (crosses_boundary / session_period_key above). With tz="UTC" and an
-// empty / "24x7" session all of these reduce to plain epoch integer math,
+// (crosses_boundary / session_period_key above). The bar OPENS at the
+// session-day's DAY STAMP — the session open on every session but OANDA's
+// 1800-1700, whose D bar is stamped 17:00 ET an hour before it trades
+// (time("D") reads 17:00 ET on OANDA:XAUUSD, pin-time-hours; the session
+// open stays where the tape trades from). With tz="UTC" and an empty /
+// "24x7" session all of these reduce to plain epoch integer math,
 // bit-identical to the UTC forms the corpus pins.
 //
 // Period attribution follows TV's trading-date rule: a session that wraps
@@ -128,11 +132,26 @@ bool tf_change(int64_t prev_ms, int64_t curr_ms, const std::string& tf,
 int64_t session_day_index(int64_t ms, const std::string& tz,
                           const std::string& session);
 
-/// Open (Unix ms) of the symbol's D/W/M bar that contains `ms`.
-/// CalendarPeriod::NONE returns `ms` unchanged.
+/// Open (Unix ms) of the symbol's D/W/M bar that contains `ms`: the day
+/// stamp of the period's first session-day (17:00 ET on OANDA 1800-1700,
+/// the session open elsewhere). CalendarPeriod::NONE returns `ms` unchanged.
 int64_t session_period_open_ms(int64_t ms, const std::string& tz,
                                const std::string& session,
                                CalendarPeriod period);
+
+/// Open (Unix ms) of the `bucket_sec`-wide intraday bucket that contains
+/// `ms` on the symbol's day-stamp-anchored grid: exchange-tz time since
+/// local midnight + day stamp, floored to the bucket width. This is THE
+/// intraday HTF grid — request.security's ratio buckets
+/// (TimeframeAggregator::bucket_open_ms), tf_change and
+/// time("<intraday tf>") / time_close all read it (pin-time-hours:
+/// time("60") on NYSE:F is 09:30 / 10:30 / .. / 15:30 ET, time("240") on
+/// NSE:NIFTY 09:15 / 13:15 IST, on OANDA:XAUUSD 17:00 ET + 4h*k). With
+/// tz="UTC" and session ""/"24x7" it is the epoch grid, bit-identical to
+/// the tz-less forms. bucket_sec <= 0 returns `ms`.
+int64_t session_intraday_bucket_open_ms(int64_t ms, int64_t bucket_sec,
+                                        const std::string& tz,
+                                        const std::string& session);
 
 /// The session instant a native CALENDAR chart stamp covers. A stamp inside
 /// its session (open to exclusive close) returns unchanged. A stamp in the
@@ -203,8 +222,9 @@ public:
     /// belongs to, on the aggregator's anchor clock (syminfo tz + session):
     /// CALENDAR -> session_period_open_ms of the bar's D/W/M period (the
     /// forex week opens Sunday 17:00 ET, its month on the session whose
-    /// close date is the 1st); RATIO -> the session-open-anchored intraday
-    /// grid bucket (the same key feed() splits on); PASSTHROUGH, or a
+    /// close date is the 1st); RATIO -> session_intraday_bucket_open_ms,
+    /// the day-stamp-anchored grid bucket (the same key feed() splits on
+    /// and time("<intraday tf>") reads); PASSTHROUGH, or a
     /// count-only ratio with no wall-clock width, -> `ms` itself. Pure
     /// function of the configuration: it neither reads nor advances the
     /// aggregation state, so callers may query it before feeding the bar.
@@ -215,11 +235,13 @@ public:
     /// on every bucket it starts (finding 473). RATIO -> bucket_open_ms
     /// (the session-anchored grid open, whether or not the grid-opening
     /// sub-bar traded: a forex 1m tape that starts at 17:04 ET still yields
-    /// the 17:00 chart bar); CALENDAR -> the open of the session-day holding
-    /// `ms` (the D/W/M bar is dated by its first TRADED session-day, so a
-    /// holiday-Monday week stays Tuesday's bar, but never by a thin-open
-    /// sub-bar inside that day); PASSTHROUGH -> `ms`. Gap-free feeds are
-    /// bit-identical: there the first sub-bar IS the bucket open.
+    /// the 17:00 chart bar); CALENDAR -> the day stamp of the session-day
+    /// holding `ms` (the D/W/M bar is dated by its first TRADED session-day,
+    /// so a holiday-Monday week stays Tuesday's bar, but never by a
+    /// thin-open sub-bar inside that day; on OANDA 1800-1700 the stamp is
+    /// 17:00 ET, an hour before the day trades); PASSTHROUGH -> `ms`.
+    /// Gap-free feeds whose open is the stamp are bit-identical: there the
+    /// first sub-bar IS the bucket open.
     int64_t bar_label_ms(int64_t ms) const;
 
 private:

--- a/include/pineforge/timeframe.hpp
+++ b/include/pineforge/timeframe.hpp
@@ -90,8 +90,12 @@ bool crosses_boundary(int64_t prev_ms, int64_t curr_ms, CalendarPeriod period);
 /// behavior for 24x7 symbols (the corpus regime). Session symbols
 /// (equities RTH, forex) anchor HTF buckets on the exchange clock instead:
 /// daily boundaries at symbol-local midnight, intraday buckets offset by the
-/// session-open minutes. With tz="UTC" and session ""/"24x7" these are
-/// bit-identical to the UTC forms, so existing callers are unaffected.
+/// symbol's day stamp -- the session open, except OANDA's 1800-1700 metals
+/// session whose day (and TradingView's "45"/"240" grid) rolls at the 17:00
+/// ET forex roll one hour before it opens (session_day_stamp_offset_minutes
+/// in timeframe.cpp cites the pin). With tz="UTC" and session ""/"24x7"
+/// these are bit-identical to the UTC forms, so existing callers are
+/// unaffected.
 bool crosses_boundary(int64_t prev_ms, int64_t curr_ms, CalendarPeriod period,
                       const std::string& tz, const std::string& session);
 bool tf_change(int64_t prev_ms, int64_t curr_ms, const std::string& tf,
@@ -131,10 +135,11 @@ int64_t session_period_open_ms(int64_t ms, const std::string& tz,
                                CalendarPeriod period);
 
 /// The session instant a native CALENDAR chart stamp covers. A stamp inside
-/// its session-day returns unchanged. A stamp in the inter-session gap (at
-/// or after its session-day's close) covers the session about to open --
-/// OANDA stamps daily FX/metal bars at the 17:00 ET break under an
-/// 1800-1700 session -- and rolls forward to the next session-day's open.
+/// its session (open to exclusive close) returns unchanged. A stamp in the
+/// inter-session gap -- before its session-day's open (the 1800-1700 day
+/// stamp hour) or at / after its close -- covers the session about to open
+/// -- OANDA stamps daily FX/metal bars at the 17:00 ET break under an
+/// 1800-1700 session -- and rolls forward to that session's open.
 /// ""/24x7 sessions have no gap and always return `ms` unchanged.
 int64_t session_covered_instant_ms(int64_t ms, const std::string& tz,
                                    const std::string& session);

--- a/include/pineforge/timeframe.hpp
+++ b/include/pineforge/timeframe.hpp
@@ -82,6 +82,14 @@ enum class CalendarPeriod { NONE, DAY, WEEK, MONTH };
 /// Determine the calendar period for a target TF string.
 CalendarPeriod calendar_period_for(const std::string& tf);
 
+/// True for a daily-or-higher chart timeframe ("D", "1D", "2D", "W", "M"):
+/// a bar that covers whole session days rather than a time of day (the
+/// aggregation path's CALENDAR classification). Intraday timeframes and an
+/// empty (undetected) one are false.
+inline bool tf_is_daily_or_higher(const std::string& tf) {
+    return calendar_period_for(tf) != CalendarPeriod::NONE;
+}
+
 /// Check if two timestamps (Unix milliseconds) fall in different calendar periods.
 bool crosses_boundary(int64_t prev_ms, int64_t curr_ms, CalendarPeriod period);
 

--- a/src/engine_aux_security.cpp
+++ b/src/engine_aux_security.cpp
@@ -279,7 +279,8 @@ void BacktestEngine::feed_aux_security_for_chart_bar(int chart_index) {
             state.current_bar = bar;
             state.current_sub_bar_count = 1;
             state.eval_complete_count++;
-            evaluate_security(state.sec_id, bar, true);
+            dispatch_security_eval(state, bar, true,
+                                   state.eval_complete_count - 1);
             state.lower_tf_sub_bar_index++;
         }
         state.lower_tf_input_buffer.clear();

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -3628,18 +3628,23 @@ void BacktestEngine::apply_filled_order_to_state(
     // with pct <= 100 — the one regime where the floor invariant above
     // exists AND TV ground truth pins the behavior. CASH default sizing
     // has NO equity term (cash/(price*pv)), so required is unbounded by
-    // sizing_equity and the gate would decline perfectly ordinary flat
-    // opens whenever cash_value > equity (a real transpiled cash-20k-on-
-    // 10k-capital probe lost all 73 of its trades to it). The same
-    // applies to pct > 100 (leveraged sizing). Neither regime has TV
-    // ground truth; frozen CASH / pct>100 orders keep their freeze but
-    // are admitted unconditionally here.
+    // sizing_equity and THIS gate's flat-open arm would decline ordinary
+    // flat opens whenever cash_value > equity; pct > 100 (leveraged sizing)
+    // breaks the invariant too. Frozen CASH / pct>100 orders keep their
+    // freeze and skip this gate. CASH (and FIXED) default MARKET entries are
+    // instead admitted by the unified design-market-entry-affordability gate
+    // below (resulting position costed at max(signal, fill) against the
+    // placement MTM equity) — a cash 20k on 10k capital account at margin 100
+    // is over-notional there and declines, exactly like a fixed-qty order of
+    // the same notional (pin-afford-gapdown).
     //
     // Frozen MARKET entries and frozen RAW market orders are checked; an
     // opposite-direction RAW fill only CLOSES the position
     // (apply_raw_order_fill's exit branch) and is never dropped.
-    // Explicit-qty entries keep the signal-time gate in strategy_entry;
-    // priced (limit/stop) entries carry no snapshot. Runs BEFORE the
+    // Explicit-qty and FIXED/CASH-default entries take the unified
+    // design-market-entry-affordability gate (placement half in
+    // strategy_entry, fill half below); priced (limit/stop) entries carry no
+    // snapshot. Runs BEFORE the
     // intraday-cap accounting below: a dropped order was never filled, so
     // it must not consume a max_intraday_filled_orders slot.
     // KI-72: a default-sized percent_of_equity MARKET/RAW order whose FROZEN
@@ -4008,37 +4013,88 @@ void BacktestEngine::apply_filled_order_to_state(
         }
     }
 
-    // design-explicit-qty-fill-admission: TV declines an EXPLICIT-qty (caller
-    // passed a finite qty) true-flat MARKET entry at fill when its notional at
-    // the SLIPPED FILL price overshoots the placement equity snapshot. This is
-    // the explicit-qty sibling of the frozen gap-reject family above (those all
-    // require isnan(qty) via the frozen snapshot / candidate flag); the shipped
-    // frozen fix deliberately left the explicit path alone.
+    // design-market-entry-affordability: the FILL-time half of TradingView's
+    // market-entry admission (rule, pins and evidence on
+    // PendingOrder::affordability_placement_equity, engine.hpp; the placement
+    // half is in strategy_entry). The quantity is exactly what the market
+    // kernel is about to dispatch (the frozen CASH default, the FIXED default,
+    // or the lot-floored explicit qty), a same-direction add is costed as
+    // held + add with "held" FROZEN AT PLACEMENT (a same-tick sibling that
+    // filled first is not re-costed here — thula INR short pair, TV rows in
+    // test_margin_call), a reversal as its own new side only, and the price is
+    // max(tick(close(S)), tick(fill)) — slippage ticks in neither basis: a
+    // fill at or below the placement price can never re-decline what
+    // placement admitted, only an adverse gap can (pin-afford-gapup: capital
+    // 380,000, signal close
+    // 18,820.50 = 376,410 admitted, fill 19,225 = 384,500 -> NOT filled;
+    // pin-afford-gapup-ctl at 1e6 fills). The threshold is the PLACEMENT
+    // equity snapshot with the float guard only — NO signal-notional floor
+    // (pin-admit-allin-f: floor(E/10.225) shares costed at the 10.23 fill
+    // overshoot E and TV declines) and NO raw-qty notional (pin-admit-allin-
+    // xau 2025-04-08 13:30Z: 662.968 -> 662.96 lots * 3013.75 <= 1,998,000.02,
+    // admitted). A declined reversal keeps its closing leg
+    // (affordability_close_only, dispatched by apply_market_order_fill); a
+    // declined flat open / add is dropped (no trade row, and it runs BEFORE
+    // the intraday-cap accounting so it consumes no slot). Commission is
+    // EXCLUDED — a fee-only overage admits here and the KI-61-family entry-bar
+    // trim may fire downstream. order.qty is NOT mutated (isnan(order.qty)
+    // stays the live default-sizing discriminator).
     //
-    //   |qty| * slipped_fill * pv * fx * (margin_pct/100)
-    //     >  max(placement_equity,
-    //            |qty| * slipped_signal_close * pv * fx * margin/100)
-    //        + max(1e-9, |placement_equity| * 1e-12)      (float guard only)
-    //
-    // The slipped-signal-close notional floors the threshold: a fill AT/BELOW
-    // the slipped signal close (POOC — fill == close(S)+slip on both sides — a
-    // no-gap open, or a favorable gap) can never decline, so the fill-time gate
-    // never re-declines what the signal-time gate already admitted; only an
-    // ADVERSE gap beyond the slip declines. With slippage 0 the floor collapses
-    // to the pure "fill notional > equity" rule the census pins (probe-68 comm=0
-    // decline-iff-notional>equity, zero slack, 99.94%; mdfe3757 306/306).
-    //
-    // Scope: created TRUE-FLAT (candidate flag) AND still FLAT at THIS fill,
-    // MARKET only, margin_pct>0. Commission is EXCLUDED — a fee-only overage
-    // ADMITS here, then the KI-61-family entry-bar trim may fire downstream.
-    // Reversals/adds are out of scope (flat-at-fill required — the flag is only
-    // set from a true-flat placement, and position_side_==FLAT is re-proven
-    // here). Runs BEFORE the intraday-cap accounting below: a declined order
-    // never filled, so it must not consume a max_intraday_filled_orders slot.
-    // order.qty is NOT mutated (isnan(order.qty) stays a live default-sizing
-    // discriminator for OCA / reversal-binding / partial-exit classification).
-    if (order.explicit_flat_admission_candidate
+    // The KI-65 explicit MARKET/MARKET pair is carved out: its first broker
+    // fill moves the frozen GROSS transaction and keeps the pinned pair
+    // admission below (test_dual_entry_placement_sizing).
+    const bool paired_flat_market_fill_admission =
+        order.explicit_flat_admission_candidate
         && order.type == OrderType::MARKET
+        && pending_flat_market_pair_is_live(order);
+    if (order.type == OrderType::MARKET
+        && !paired_flat_market_fill_admission
+        && !order.affordability_close_only
+        && std::isfinite(order.affordability_placement_equity)
+        && std::isfinite(order.affordability_signal_price)) {
+        const double margin_pct = order.is_long ? margin_long_ : margin_short_;
+        if (margin_pct > 0.0) {
+            const PositionSide requested =
+                order.is_long ? PositionSide::LONG : PositionSide::SHORT;
+            const bool same_dir = position_side_ == requested;
+            const bool reversal =
+                position_side_ != PositionSide::FLAT && !same_dir;
+            const double tick_fill = round_to_mintick(fill_price);
+            const double own_qty = !std::isnan(order.frozen_default_qty)
+                ? order.frozen_default_qty
+                : calc_qty_for_type(
+                      apply_fill_slippage(fill_price, order.is_long),
+                      std::isnan(order.qty) ? order.qty : std::abs(order.qty),
+                      order.qty_type);
+            const double held_qty =
+                std::isfinite(order.affordability_held_qty)
+                    ? order.affordability_held_qty : 0.0;
+            const double admit_price =
+                std::max(order.affordability_signal_price, tick_fill);
+            const double required_margin =
+                (held_qty + own_qty) * admit_price * syminfo_.pointvalue
+                * active_account_currency_fx() * (margin_pct / 100.0);
+            const double float_guard = std::max(
+                1e-9, std::abs(order.affordability_placement_equity) * 1e-12);
+            if (std::isfinite(required_margin)
+                && required_margin
+                       > order.affordability_placement_equity + float_guard) {
+                if (!reversal) {
+                    decline_and_cancel();
+                    return;
+                }
+                order.affordability_close_only = true;
+            }
+        }
+    }
+
+    // design-explicit-qty-fill-admission, KI-65 pair carve-out: a finalized
+    // explicit MARKET/MARKET pair's first broker fill may be the later source
+    // call and moves the frozen GROSS transaction. Cost that exact transaction
+    // at the slipped fill against max(placement equity, its slipped-signal-
+    // close notional) — the pair's pinned admission (POOC / no-gap fills are a
+    // structural no-op; only an adverse gap beyond the slip declines).
+    if (paired_flat_market_fill_admission
         && position_side_ == PositionSide::FLAT
         && !std::isnan(order.qty)
         && !std::isnan(order.explicit_placement_equity)
@@ -4050,19 +4106,10 @@ void BacktestEngine::apply_filled_order_to_state(
             const double notional_k = syminfo_.pointvalue
                                       * active_account_currency_fx()
                                       * (margin_pct / 100.0);
-            // A finalized pair's first broker fill may be the later source
-            // call and moves the frozen GROSS transaction. Cost that exact
-            // transaction here; using order.qty would admit an adverse gap on
-            // half the notional the fill is about to open.
-            const bool paired_flat_market =
-                pending_flat_market_pair_is_live(order);
-            const double admission_qty = paired_flat_market
-                ? order.paired_flat_market_transaction_qty
-                : std::abs(order.qty);
+            const double admission_qty =
+                order.paired_flat_market_transaction_qty;
             const double fill_notional =
                 admission_qty * slipped_fill * notional_k;
-            // POOC / no-gap admission floor: a fill at the slipped signal close
-            // was already admitted at signal time.
             const double signal_notional =
                 admission_qty * order.explicit_slipped_signal_close
                 * notional_k;
@@ -4828,6 +4875,29 @@ void BacktestEngine::apply_market_order_fill(PendingOrder& order, double fill_pr
                                              const Bar& bar,
                                              double& trail_best_path_state,
                                              bool later_same_tick_entry) {
+    // design-market-entry-affordability: the entry leg was declined (at
+    // placement or at fill) while an OPPOSITE position was live — execute the
+    // reversal's closing leg only (rampatel BTC 2025-05-12 07:15Z: TV closed
+    // the short by "Buy" @105,600 and opened no long). The exit rows carry
+    // this order's id/comment through the generic post-fill tagging. Flat or
+    // same-side at the fill: nothing to close, the order is consumed with no
+    // broker effect.
+    if (order.affordability_close_only) {
+        const PositionSide requested =
+            order.is_long ? PositionSide::LONG : PositionSide::SHORT;
+        if (position_side_ != PositionSide::FLAT
+            && position_side_ != requested
+            && std::isfinite(fill_price)) {
+            flip_market_position_to(
+                order.id, order.is_long,
+                apply_fill_slippage(fill_price, order.is_long),
+                order.qty, order.qty_type,
+                /*explicit_qty_prequantized=*/false,
+                /*close_only=*/true, order.incarnation);
+        }
+        trail_best_path_state = trail_best_price_;
+        return;
+    }
     // The final Short in the exact SHORT-seed collision is the broker
     // transaction that closes both physical LONG lots (the entry lot L and
     // the materialized min(S, L) lot) and re-opens the direction with exactly

--- a/src/engine_path_resolve.cpp
+++ b/src/engine_path_resolve.cpp
@@ -563,27 +563,42 @@ ExitTrailState compute_exit_trail_state(bool is_long, double trail_points,
         // Absolute activation price level (no entry-relative tick rounding).
         s.activation_level = trail_price;
     }
-    // TV treats an explicit zero offset like an omitted offset: the exit fires
-    // at the activation crossing itself. Keep zero represented as NaN here so
-    // it follows the existing activation-only path; positive offsets retain
-    // the ordinary best-price-minus/plus-offset trailing behaviour.
-    if (!std::isnan(trail_offset) && trail_offset != 0.0) {
-        // A fractional trail_offset (ticks) is TRUNCATED to whole ticks by
-        // TradingView, not rounded up: the trailing level sits
-        // floor(offset) ticks behind the running extreme. Measured on every
-        // non-gap trailing exit whose level could be recovered from the TV
-        // tape (level = TV fill + slippage ticks): nils123456-orb-strat on
-        // BINANCE:ETHUSDT.P (trail_offset = price / mintick, slippage 0)
-        // 11/11 and legalrice2697-nse-elite-strategy-v6-full-system on
-        // OANDA:EURUSD (atr * 4 / mintick, slippage 2) 58/62 sat exactly
-        // ONE tick nearer the extreme than the ceil() level, for offsets
-        // with a fractional part both below and above .5 (never zero for
-        // the .5+ half, which rules out round-to-nearest). Whole-tick
-        // offsets are unchanged.
-        s.trail_offset_price = std::floor(trail_offset) * syminfo_mintick;
+    // A fractional trail_offset (ticks) is TRUNCATED to whole ticks by
+    // TradingView, not rounded up: the trailing level sits floor(offset)
+    // ticks behind the running extreme. Measured on every non-gap trailing
+    // exit whose level could be recovered from the TV tape (level = TV fill
+    // + slippage ticks): nils123456-orb-strat on BINANCE:ETHUSDT.P
+    // (trail_offset = price / mintick, slippage 0) 11/11 and
+    // legalrice2697-nse-elite-strategy-v6-full-system on OANDA:EURUSD
+    // (atr * 4 / mintick, slippage 2) 58/62 sat exactly ONE tick nearer the
+    // extreme than the ceil() level, for offsets with a fractional part both
+    // below and above .5 (never zero for the .5+ half, which rules out
+    // round-to-nearest). Whole-tick offsets are unchanged.
+    //
+    // The truncation comes FIRST, and an offset that truncates to ZERO ticks
+    // -- an explicit 0 or any sub-tick value in (0, 1) -- is TV's
+    // exit-at-activation trail (the one-shot rule below), NOT a zero-distance
+    // trail riding on the running extreme. Keep it represented as NaN so it
+    // follows the activation-only path; positive whole-tick offsets retain
+    // the ordinary best-price-minus/plus-offset trailing behaviour. Pinned
+    // with `lab tv` on OANDA:EURUSD 15m (2025-04-01 -> 05-01): the tapes for
+    // strategy.exit("x", "L", trail_points=3, trail_offset=0),
+    // trail_offset=0.5 and trail_offset=0.9 are byte-identical (190 rows,
+    // sha256 36aa80ac...). The engine used to keep floor(0.6) = 0 as a
+    // FINITE zero distance, so the stop sat on the running extreme and
+    // filled at the bar's best price: winthetrade ema-9-vwap ATR trail
+    // (trail_offset = atr*2 passed as ticks) on OANDA:EURUSD 15m, short
+    // 2025-03-31 03:45Z @1.08330, atr*2 ~ 0.0006 "ticks" -> activation
+    // ceil -> 1 tick = 1.08329, offset floor -> 0; exit bar O 1.08330
+    // L 1.08314: TV 1.08329 (the activation), engine 1.08314 (the low).
+    const double trail_offset_ticks = std::floor(trail_offset);  // NaN stays NaN
+    const bool zero_tick_offset = (trail_offset_ticks == 0.0);   // explicit [0, 1)
+    if (!std::isnan(trail_offset_ticks) && !zero_tick_offset) {
+        s.trail_offset_price = trail_offset_ticks * syminfo_mintick;
     }
     s.exits_at_activation = std::isnan(s.trail_offset_price);
-    // An EXPLICIT trail_offset=0 is TV's one-shot exit-at-activation trail:
+    // An EXPLICIT trail_offset=0 (or a sub-tick offset that truncates to 0
+    // ticks, see above) is TV's one-shot exit-at-activation trail:
     // it FILLS at the activation crossing itself, so it can never survive
     // into a later bar in the armed state — an armed zero-offset trail is an
     // executed one. Deriving "armed" for it from the running post-entry
@@ -612,8 +627,7 @@ ExitTrailState compute_exit_trail_state(bool is_long, double trail_points,
     // only a carried armed state can produce. Offset>0 trails likewise keep
     // the reconstruction: activation is durable for every trail that keeps
     // running after it activates.
-    const bool one_shot_zero_offset_trail =
-        !std::isnan(trail_offset) && trail_offset == 0.0;
+    const bool one_shot_zero_offset_trail = zero_tick_offset;
     if (!one_shot_zero_offset_trail && !std::isnan(s.best_price)) {
         s.trail_active = is_long ? (s.best_price >= s.activation_level)
                                  : (s.best_price <= s.activation_level);
@@ -707,6 +721,54 @@ void update_exit_trail_state(bool is_long, bool rising, bool falling,
             trail->best_price = to_price;
         }
         if (!trail->trail_active && trail->best_price <= trail->activation_level) {
+            trail->trail_active = true;
+        }
+    }
+}
+
+// Fold the bar's OPEN into the trail state before the intrabar path walk.
+// TradingView's broker emulator sees the open as the FIRST traded price of
+// the bar: a trail whose activation level the open already sits past arms AT
+// the open with best = open, so the trailing level on the first leg is
+// open -/+ offset. The engine used to observe prices only at the END of each
+// path segment (update_exit_trail_state), so on an adverse-leg-first bar
+// (|O-L| < |H-O| for a long) the trail stayed dormant through the retrace,
+// armed only at the favourable extreme and filled at extreme -/+ offset --
+// the worst-case price TV never prints.
+//
+// Evidence (winthetrade-ema-9-vwap-strategy-with-atr-trailing-stop family,
+// trail_points = trail_offset = atr*2 passed as ticks; the entries are POOC
+// close fills, so the carried best is the entry price itself):
+//   OANDA:XAUUSD 15m long 2025-04-04 10:45Z @3110.31; 11:00Z bar O 3110.40
+//     H 3136.775 L 3109.24 C 3134.46, 15 ticks / 15 ticks (mintick 0.001):
+//     TV "Long Exit" 3110.385 = open - 0.015 (PnL 24.47); engine 3136.76 =
+//     high - 0.015 (PnL 8631). 194 of the 195 differing XAUUSD exits fit
+//     TV = open -/+ k ticks vs engine = extreme -/+ the same k, always on an
+//     adverse-leg-first path with the open past the activation level.
+//   NASDAQ:AAPL 15m short 2025-04-02 18:45Z @222.93; 04-03 13:30Z bar
+//     O 205.54 L 202.52: TV 205.55 (open + 1 tick), engine 202.53 (low + 1).
+//   NYSE:F 1D long 2025-04-21 @9.47; 04-22 bar O 9.55 H 9.72: TV 9.54,
+//     engine 9.71.
+//
+// Only the OPEN itself arms here -- never the carried best: a one-shot
+// zero-offset trail must not retro-arm from a carried extreme (#148, see
+// compute_exit_trail_state), and an open already past its activation has
+// been filled by try_exit_open_gap_fill before this runs, so for the
+// exit-at-activation shapes this is a pure best-price observation.
+void observe_exit_trail_open(bool is_long, double open, ExitTrailState* trail) {
+    if (!trail->has_trail) return;
+    if (is_long) {
+        if (std::isnan(trail->best_price) || open > trail->best_price) {
+            trail->best_price = open;
+        }
+        if (!trail->trail_active && open >= trail->activation_level) {
+            trail->trail_active = true;
+        }
+    } else {
+        if (std::isnan(trail->best_price) || open < trail->best_price) {
+            trail->best_price = open;
+        }
+        if (!trail->trail_active && open <= trail->activation_level) {
             trail->trail_active = true;
         }
     }
@@ -884,6 +946,14 @@ ExitPathFill resolve_exit_path_fill(const Bar& bar,
             fill.path_position = 0.0;
             return fill;
         }
+        // No gap fill: the open is still the first price this bar the
+        // resting order saw. Fold it into the trail's running best (and arm
+        // the trail if the open is already past its activation) before the
+        // segment walk, exactly as TV's emulator does -- see
+        // observe_exit_trail_open for the tapes. Same liveness condition as
+        // the gap shortcut: a mid-path cursor or a non-magnifier entry bar
+        // means the order did not exist at the open.
+        observe_exit_trail_open(is_long, bar.open, &trail);
     }
 
     double path[4];

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -1535,6 +1535,28 @@ void BacktestEngine::clear_historical_security_lookahead_projections() {
 }
 
 
+bool BacktestEngine::chart_bar_ismarket(int64_t bar_ms) const {
+    return pineforge::pine_session_ismarket(syminfo_.session, syminfo_.timezone,
+                                            bar_ms, script_tf_);
+}
+
+void BacktestEngine::set_session_bar_state(bool in_session,
+                                           bool intraday_islastbar) {
+    session_ismarket_ = in_session;
+    if (tf_is_daily_or_higher(script_tf_)) {
+        // A daily-or-higher chart bar covers its whole session day(s): it is
+        // the session's first bar and its last bar at once (TradingView's
+        // "first / last bar of the day's session", read on a bar that IS the
+        // day), so both predicates hold on every bar of such a chart.
+        session_isfirstbar_ = in_session;
+        session_islastbar_ = in_session;
+        return;
+    }
+    session_isfirstbar_ = in_session && !prev_in_session_;
+    session_islastbar_ = intraday_islastbar;
+}
+
+
 // Bar pump for the no-aggregation, no-magnifier case: every input bar is a
 // script bar, fed straight to on_bar with the standard
 // pending-orders / per-trade-extremes / on_bar / equity-update sequence
@@ -1571,20 +1593,16 @@ void BacktestEngine::run_simple_bar_loop(const Bar* input_bars, int n_input) {
         }
 
         // Update session predicates for session.ismarket / isfirstbar / islastbar.
-        session_ismarket_  = pine_session_ismarket(syminfo_.session, syminfo_.timezone,
-                                                    current_bar_.timestamp);
-        session_isfirstbar_ = session_ismarket_ && !prev_in_session_;
-        // islastbar: fire when this bar is in-session but the NEXT bar won't be
-        // (lookahead: peek at next bar's timestamp if available, else fire on last bar).
-        if (session_ismarket_) {
+        // Intraday islastbar: fire when this bar is in-session but the NEXT bar
+        // won't be (lookahead: peek at the next bar's timestamp if available,
+        // else fire on the last bar).
+        {
+            const bool in_session = chart_bar_ismarket(current_bar_.timestamp);
             bool next_in_session = false;
-            if (i + 1 < n_input) {
-                next_in_session = pine_session_ismarket(syminfo_.session, syminfo_.timezone,
-                                                         input_bars[i + 1].timestamp);
+            if (in_session && i + 1 < n_input) {
+                next_in_session = chart_bar_ismarket(input_bars[i + 1].timestamp);
             }
-            session_islastbar_ = !next_in_session;
-        } else {
-            session_islastbar_ = false;
+            set_session_bar_state(in_session, in_session && !next_in_session);
         }
 
         dispatch_bar();
@@ -1673,10 +1691,10 @@ void BacktestEngine::run_aggregation_bar_loop(const Bar* input_bars, int n_input
             if (bar_magnifier && !group_sub_bars.empty()) {
                 // Magnifier mode: update session state using script-bar timestamp
                 // (first sub-bar's timestamp represents the aggregated bar).
-                session_ismarket_  = pine_session_ismarket(syminfo_.session, syminfo_.timezone,
-                                                            group_sub_bars.front().timestamp);
-                session_isfirstbar_ = session_ismarket_ && !prev_in_session_;
-                session_islastbar_  = false;  // not deterministic in magnifier mode without lookahead
+                // Intraday islastbar is not deterministic here without lookahead.
+                set_session_bar_state(
+                    chart_bar_ismarket(group_sub_bars.front().timestamp),
+                    /*intraday_islastbar=*/false);
                 run_magnified_bar(
                     group_sub_bars, script_bar_ts, completed_on_boundary);
                 prev_in_session_ = session_ismarket_;
@@ -1697,10 +1715,10 @@ void BacktestEngine::run_aggregation_bar_loop(const Bar* input_bars, int n_input
                 // (09:30-anchored, not UTC-aligned) label correctly too.
                 current_bar_ = ab.bar;
                 // Update session predicates.
-                session_ismarket_  = pine_session_ismarket(syminfo_.session, syminfo_.timezone,
-                                                            current_bar_.timestamp);
-                session_isfirstbar_ = session_ismarket_ && !prev_in_session_;
-                session_islastbar_  = session_ismarket_ && barstate_islast_;
+                {
+                    const bool in_session = chart_bar_ismarket(current_bar_.timestamp);
+                    set_session_bar_state(in_session, in_session && barstate_islast_);
+                }
                 dispatch_bar();
                 prev_in_session_ = session_ismarket_;
             }

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -87,6 +87,13 @@ void BacktestEngine::invoke_chart_on_bar(const Bar& bar) {
         }
     } scope(chart_ema_na_warmup_);
 
+    // Bar-addressed window state (ta::bar_context()): the chart context's TA
+    // members address their rings by the Pine bar_index the script sees, and
+    // warm up from the feed's first bar (pine index bar_index_offset_).
+    // Every tick of one script bar (compute() then recompute() under the bar
+    // magnifier) shares the index, so they rewrite the same slot.
+    ta::BarContextScope bar_scope(pine_bar_index(), bar_index_offset_);
+
     named_entry_cancelled_incarnation_in_current_eval_.clear();
     on_bar(bar);
 }
@@ -764,6 +771,7 @@ void BacktestEngine::run(const Bar* bars, int n) {
         state.eval_partial_count = 0;
         state.current_bar = Bar{};
         state.current_sub_bar_count = 0;
+        state.ta_bar_index = -1;
     }
 
     for (int i = 0; i < n; i++) {

--- a/src/engine_security.cpp
+++ b/src/engine_security.cpp
@@ -266,6 +266,17 @@ void BacktestEngine::validate_security_timeframes(const std::string& input_tf) {
 }
 
 
+void BacktestEngine::dispatch_security_eval(SecurityEvalState& state,
+                                            const Bar& bar, bool publish,
+                                            int64_t bar_index) {
+    state.ta_bar_index = bar_index;
+    // The requested context starts at its own bar 0 (origin 0): its TA members
+    // warm up over the first `length` evaluated bars, exactly as before.
+    ta::BarContextScope bar_scope(static_cast<long long>(bar_index), 0);
+    evaluate_security(state.sec_id, bar, publish);
+}
+
+
 bool BacktestEngine::security_series_slot_is_new(int sec_id) const {
     if (security_history_publication_replay_) {
         return false;
@@ -298,8 +309,11 @@ void BacktestEngine::publish_security_eval_state_at_calling_boundary(
     // the final requested value that was already evaluated for the completed
     // caller, before the chart body runs and before that retained input is fed.
     // security_series_slot_is_new() returns false in this scope, so generated
-    // TA sites recompute the current slot instead of advancing their cadence.
-    evaluate_security(state.sec_id, state.current_bar, true);
+    // TA sites recompute the current slot instead of advancing their cadence —
+    // under the same requested-context bar index as the evaluation replayed.
+    dispatch_security_eval(state, state.current_bar, true,
+                           state.ta_bar_index >= 0 ? state.ta_bar_index
+                                                   : state.eval_complete_count);
 }
 
 
@@ -457,7 +471,8 @@ void BacktestEngine::feed_security_eval_state(
                 state.current_bar = b;
                 state.current_sub_bar_count = 1;
                 state.eval_complete_count++;
-                evaluate_security(state.sec_id, b, true);
+                dispatch_security_eval(state, b, true,
+                                       state.eval_complete_count - 1);
                 state.lower_tf_sub_bar_index++;
             }
             state.lower_tf_input_buffer.clear();
@@ -500,7 +515,8 @@ void BacktestEngine::feed_security_eval_state(
             state.current_bar = synthetic_bar;
             state.current_sub_bar_count = 1;
             state.eval_complete_count++;
-            evaluate_security(state.sec_id, synthetic_bar, true);
+            dispatch_security_eval(state, synthetic_bar, true,
+                                   state.eval_complete_count - 1);
             state.lower_tf_sub_bar_index++;
         }
         return;
@@ -541,8 +557,10 @@ void BacktestEngine::feed_security_eval_state(
         } else {
             state.eval_partial_count++;
         }
-        evaluate_security(state.sec_id, projected_bar,
-                          projection.is_complete);
+        dispatch_security_eval(state, projected_bar, projection.is_complete,
+                               projection.is_complete
+                                   ? state.eval_complete_count - 1
+                                   : state.eval_complete_count);
         return;
     }
 
@@ -577,7 +595,8 @@ void BacktestEngine::feed_security_eval_state(
             // replaced.
             publish = calling_bar_complete;
         }
-        evaluate_security(state.sec_id, ab.bar, publish);
+        dispatch_security_eval(state, ab.bar, publish,
+                               state.eval_complete_count - 1);
     } else if (state.lookahead_on) {
         if (state.heikinashi) apply_ha(ab.bar, /*commit=*/false);
         state.current_bar = ab.bar;
@@ -587,7 +606,9 @@ void BacktestEngine::feed_security_eval_state(
         // merged history without adding a second evaluator/TA dispatch.
         const bool publish = state.publish_gate_tf_seconds > 0
             && calling_bar_complete;
-        evaluate_security(state.sec_id, ab.bar, publish);
+        // Partial (in-progress) bucket: the index the completion will carry.
+        dispatch_security_eval(state, ab.bar, publish,
+                               state.eval_complete_count);
     } else {
         state.current_bar = ab.bar;
         if (state.gaps_on) {

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -183,53 +183,74 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
         }
     }
 
-    // TradingView broker rule: market-entry orders are admitted only
-    // when ``qty * <signal-bar close> * margin_pct/100 <= equity``.
-    // The check happens HERE (at signal time, with current_bar_.close
-    // — the close of the bar where ``strategy.entry`` was just called),
-    // NOT later in apply_market_order_fill where fill_price is the
-    // NEXT bar's open. For ``qty = strategy.equity / close`` sizing
-    // patterns (parity-anomalies/equity-mirror, community/IES) this
-    // distinction is load-bearing: the close-vs-open slippage routinely
-    // inflates overshoot from ~zero (at signal) to ~$20 (at fill), and
-    // pre-fix engine rejected those at fill time while TV accepted
-    // them at signal time — accumulating into community/IES's PnL
-    // drift. Verified empirically by parity-probe-04..06 (all 57/57
-    // matched) and the equity-mirror anomaly (full-equity sizing right at the
-    // 1× boundary, where TV's behaviour is itself non-deterministic — see
-    // corpus/validation/anomaly-equity-mirror-strategy-equity-01).
-    // Only applied to MARKET entries (limit/stop entries have their
-    // own price baked into the order itself).
+    // design-market-entry-affordability: TradingView's broker admission for a
+    // MARKET entry — rule, pins and evidence on
+    // PendingOrder::affordability_placement_equity (engine.hpp). This is the
+    // PLACEMENT half: the resulting position, lot-floored, is costed at the
+    // slipped on-tick signal close against MARK-TO-MARKET equity. A rejected
+    // flat open or same-direction add is dropped outright; a rejected reversal
+    // keeps ONLY its closing leg (affordability_close_only). The fill-time
+    // half in apply_filled_order_to_state costs the same quantity at
+    // max(signal price, slipped fill) against the placement snapshot.
     //
-    // Scope: this signal-time gate covers EXPLICIT-qty market entries only
-    // (the empirical base above — parity-probe-04..06 — is all explicit
-    // ``qty = <expr>`` sizing, all with headroom at the boundary). DEFAULT-
-    // sized (qty=na) market entries never reach it (qty is NaN here); their
-    // quantity is frozen at this bar's close further below (see
-    // frozen_default_market_qty), AFTER this gate, precisely so the freeze
-    // cannot accidentally activate a gate whose equity basis (realized-only
-    // current_equity()) was never validated for default sizing. Those frozen
-    // default-sized entries instead get their own, much narrower fill-time
-    // re-check: the percent==100 zero-commission true-flat above-lot gap-reject
-    // in apply_filled_order_to_state (design-cntvxiao-gap-reject). It does NOT
-    // contradict the explicit-qty "signal-time only" rule above — different
-    // sizing regime, different TV ground truth.
-    if (!std::isnan(qty) && std::isnan(limit_price) && std::isnan(stop_price)) {
-        double margin_pct = is_long ? margin_long_ : margin_short_;
-        if (margin_pct > 0.0 && !std::isnan(current_bar_.close)) {
-            // Position value in account currency includes the futures
-            // point-value multiplier (1.0 for crypto/equity — unchanged).
-            // The notional is in the symbol's quote currency; convert it to the
-            // account currency (FX 1.0 unless the script declared a differing
-            // currency=) so it is comparable to equity, which is denominated in
-            // the account currency. Default 1.0 leaves the corpus untouched.
-            double required_margin = std::abs(qty) * current_bar_.close
-                                     * syminfo_.pointvalue
-                                     * active_account_currency_fx()
-                                     * (margin_pct / 100.0);
-            double available_equity = current_equity();
-            double epsilon = std::max(1e-9, std::abs(available_equity) * 1e-12);
-            if (required_margin > available_equity + epsilon) {
+    // Scope: explicit-qty entries and DEFAULT FIXED / CASH sizing. Default
+    // percent_of_equity entries never reach it: their quantity is frozen at
+    // this bar's close further below (frozen_default_market_qty) and their
+    // admission is the separately pinned KI-54 / gap-reject / gross-admission
+    // family in apply_filled_order_to_state. Priced (limit/stop) entries carry
+    // their own price and their own admission (KI-62). margin_pct == 0
+    // disables the check, as it does in TradingView.
+    const bool affordability_scope =
+        std::isnan(limit_price) && std::isnan(stop_price)
+        && (!std::isnan(qty)
+            || default_qty_type_ == QtyType::FIXED
+            || default_qty_type_ == QtyType::CASH);
+    bool affordability_close_only = false;
+    double affordability_placement_equity =
+        std::numeric_limits<double>::quiet_NaN();
+    double affordability_signal_price =
+        std::numeric_limits<double>::quiet_NaN();
+    double affordability_held_qty = 0.0;
+    if (affordability_scope) {
+        const double margin_pct = is_long ? margin_long_ : margin_short_;
+        if (margin_pct > 0.0 && std::isfinite(current_bar_.close)
+            && current_bar_.close > 0.0) {
+            const PositionSide requested =
+                is_long ? PositionSide::LONG : PositionSide::SHORT;
+            const bool same_dir = position_side_ == requested;
+            const bool reversal =
+                position_side_ != PositionSide::FLAT && !same_dir;
+            // The on-tick signal close is the price the rule is stated on
+            // (slippage ticks are in neither basis). The quantity is exactly
+            // the one the fill kernel dispatches: the lot-floored explicit
+            // contracts, the FIXED default, or the CASH default frozen at its
+            // slipped sizing basis (frozen_default_market_qty).
+            const double signal_price = round_to_mintick(current_bar_.close);
+            const double own_qty = std::isnan(qty)
+                ? frozen_default_market_qty(/*is_buy=*/is_long)
+                : calc_qty_for_type(signal_price, std::abs(qty), qty_type);
+            // A same-direction add is costed as the RESULTING position. Calls
+            // are evaluated in source order, so a strategy.close issued
+            // earlier in this on_bar has already released its quantity
+            // (pending_close_qty_in_bar_ — the tv_carry_qty convention
+            // below).
+            const double held_qty = same_dir
+                ? std::max(0.0, position_qty_ - pending_close_qty_in_bar_)
+                : 0.0;
+            // Position value in account currency: the futures point-value
+            // multiplier (1.0 for crypto/equity) and the account-currency FX
+            // (1.0 unless the script declared a differing currency=), so the
+            // notional is comparable to equity.
+            const double placement_equity =
+                current_equity() + open_profit(current_bar_.close);
+            const double required_margin =
+                (held_qty + own_qty) * signal_price * syminfo_.pointvalue
+                * active_account_currency_fx() * (margin_pct / 100.0);
+            const double epsilon =
+                std::max(1e-9, std::abs(placement_equity) * 1e-12);
+            if (std::isfinite(required_margin)
+                && std::isfinite(placement_equity)
+                && required_margin > placement_equity + epsilon) {
                 last_rejected_strategy_entry_call_bar_ = bar_index_;
                 // A rejected third call leaves no PendingOrder or incarnation,
                 // but it still means the source body was not the clean exact
@@ -238,7 +259,15 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
                     pending_flat_market_pair_disqualified_bars_.insert(
                         bar_index_);
                 }
-                return;
+                if (!reversal) return;
+                // The reversal's closing leg still executes: the order is
+                // kept as a close-only transaction.
+                affordability_close_only = true;
+            }
+            if (std::isfinite(placement_equity)) {
+                affordability_placement_equity = placement_equity;
+                affordability_signal_price = signal_price;
+                affordability_held_qty = held_qty;
             }
         }
     }
@@ -392,6 +421,13 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
         order.type = OrderType::MARKET;
         order.limit_price = std::numeric_limits<double>::quiet_NaN();
         order.stop_price = std::numeric_limits<double>::quiet_NaN();
+        // design-market-entry-affordability: the placement snapshot the
+        // fill-time half re-checks against, and the close-only verdict of a
+        // reversal whose entry leg was already rejected above.
+        order.affordability_placement_equity = affordability_placement_equity;
+        order.affordability_signal_price = affordability_signal_price;
+        order.affordability_held_qty = affordability_held_qty;
+        order.affordability_close_only = affordability_close_only;
         if (paired_flat_market_candidate) {
             order.paired_flat_market_candidate = true;
             order.paired_flat_market_own_qty = paired_flat_market_own_qty;
@@ -482,18 +518,15 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
                 && std::isfinite(order.sizing_mark)
                 && order.sizing_mark > 0.0;
         }
-        // design-explicit-qty-fill-admission: capture the fill-time admission
-        // snapshot for an EXPLICIT-qty (the caller passed a finite qty) MARKET
-        // entry created TRUE-FLAT. The signal-time gate above (~:139-158)
-        // already rejected orders whose notional at THIS bar's close overshoots
-        // equity; this snapshot lets the fill-time re-check drop the entry when
-        // the next-bar fill gaps adversely enough that |qty|*slipped_fill
-        // exceeds the placement equity — TV's pinned behavior for the all-in
-        // floor idiom (probe-68 / mdfe3757). Disjoint from the frozen default-
-        // sizing snapshot above (that path requires isnan(qty)); priced
-        // (limit/stop) entries never reach here (else-branch) and RAW
-        // strategy.order builds its order elsewhere, so neither carries the
-        // candidate flag. Commission is EXCLUDED from the fill predicate.
+        // design-explicit-qty-fill-admission: capture the true-flat EXPLICIT-
+        // qty MARKET snapshot. Its fill-time admission is now the unified
+        // design-market-entry-affordability gate (affordability_* above); the
+        // candidate flag and snapshot are retained as the KI-65 explicit
+        // MARKET/MARKET pair's eligibility and gross-transaction basis
+        // (finalize_pending_flat_market_pair / its fill-time admission).
+        // Disjoint from the frozen default-sizing snapshot above (that path
+        // requires isnan(qty)); priced (limit/stop) entries never reach here
+        // (else-branch) and RAW strategy.order builds its order elsewhere.
         if (!std::isnan(qty) && !std::isnan(current_bar_.close)) {
             const double explicit_margin = is_long ? margin_long_ : margin_short_;
             // Equity basis matches the frozen path (KI-54): realized equity plus

--- a/src/engine_stream.cpp
+++ b/src/engine_stream.cpp
@@ -256,7 +256,12 @@ bool BacktestEngine::stream_end(bool finalize_partial_input_bar) {
 bool BacktestEngine::stream_finalize_until(int64_t timestamp_ms) {
     while (timestamp_ms >= stream_next_input_open_ms_ + stream_input_tf_ms_) {
         const bool had_tick = stream_has_input_bar_;
-        const bool in_session = pine_session_ismarket(
+        // The raw time-of-day session test (namespace-scope form), not the
+        // chart-bar rule BacktestEngine::pine_session_ismarket applies: this
+        // decides whether a tick-less INPUT interval is a closed market that
+        // must not become a synthetic bar, and stays byte-identical on
+        // daily-or-higher feeds too.
+        const bool in_session = pineforge::pine_session_ismarket(
             syminfo_.session, syminfo_.timezone,
             stream_next_input_open_ms_);
 
@@ -374,16 +379,17 @@ void BacktestEngine::stream_dispatch_script_bar(const Bar& bar, bool had_tick) {
     }
 
     current_bar_ = bar;
-    session_ismarket_ = pine_session_ismarket(
-        syminfo_.session, syminfo_.timezone, current_bar_.timestamp);
-    session_isfirstbar_ = session_ismarket_ && !prev_in_session_;
-    if (session_ismarket_ && script_tf_seconds_ > 0) {
-        const int64_t next_ts = current_bar_.timestamp
-            + static_cast<int64_t>(script_tf_seconds_) * 1000;
-        session_islastbar_ = !pine_session_ismarket(
-            syminfo_.session, syminfo_.timezone, next_ts);
-    } else {
-        session_islastbar_ = false;
+    {
+        const bool in_session = chart_bar_ismarket(current_bar_.timestamp);
+        // Intraday islastbar: the next script bar opens one bar width ahead
+        // on the stream clock; fire when that open is out of session.
+        bool intraday_islastbar = false;
+        if (in_session && script_tf_seconds_ > 0) {
+            const int64_t next_ts = current_bar_.timestamp
+                + static_cast<int64_t>(script_tf_seconds_) * 1000;
+            intraday_islastbar = !chart_bar_ismarket(next_ts);
+        }
+        set_session_bar_state(in_session, intraday_islastbar);
     }
 
     _push_source_series();

--- a/src/session_time.cpp
+++ b/src/session_time.cpp
@@ -159,18 +159,6 @@ static bool minute_in_window(int mod, int start, int end) {
     return mod >= start || mod < end;
 }
 
-static int64_t utc_bucket_open_ms(int64_t bar_ms, int period_sec) {
-    if (period_sec <= 0)
-        return bar_ms;
-    int64_t period_ms = static_cast<int64_t>(period_sec) * 1000;
-    if (bar_ms >= 0)
-        return (bar_ms / period_ms) * period_ms;
-    int64_t q = bar_ms / period_ms;
-    if (bar_ms % period_ms != 0 && bar_ms < 0)
-        --q;
-    return q * period_ms;
-}
-
 static int64_t calendar_week_open_local_ms_tz(int64_t bar_ms, const std::string& tz);
 
 static int64_t calendar_week_open_local_ms(int64_t bar_ms, const std::string& tz) {
@@ -248,9 +236,15 @@ static int64_t calendar_month_open_local_ms_tz(int64_t bar_ms, const std::string
     return static_cast<int64_t>(m0) * 1000;
 }
 
+// D/W/M open on the `tz` calendar; an intraday tf on the SYMBOL's
+// day-stamp-anchored HTF grid (session_intraday_bucket_open_ms — the grid
+// request.security aggregates on), which with sym_tz "UTC" and no
+// sym_session is the epoch grid the five-argument forms keep.
 static int64_t compute_tf_open_ms(int64_t bar_ms,
                                   const std::string& tf,
-                                  const std::string& tz) {
+                                  const std::string& tz,
+                                  const std::string& sym_tz,
+                                  const std::string& sym_session) {
     if (tf.empty())
         return bar_ms;
 
@@ -264,7 +258,7 @@ static int64_t compute_tf_open_ms(int64_t bar_ms,
 
     int sec = tf_to_seconds(tf);
     if (sec > 0 && sec < kSecPerDay)
-        return utc_bucket_open_ms(bar_ms, sec);
+        return session_intraday_bucket_open_ms(bar_ms, sec, sym_tz, sym_session);
     return bar_ms;
 }
 
@@ -586,8 +580,9 @@ static bool session_arg_is_timezone(const std::string& s) {
 //     deliberately left exactly as before: explicit tz argument, else UTC.
 //     The D/W/M calendar path of compute_tf_open_ms is owned elsewhere and
 //     must not silently start rolling at syminfo.timezone just because a
-//     session was supplied; intraday timeframes are UTC-bucketed and never
-//     depended on tz anyway.
+//     session was supplied; intraday timeframes sit on the symbol's own
+//     HTF grid (the seven-argument forms) or the epoch grid (these) and
+//     never depended on tz.
 //
 // When a 2-arg call passes a timezone-looking string in the session slot (and
 // no explicit tz), TV treats it as an invalid session and ignores it: drop the
@@ -630,7 +625,7 @@ int64_t pine_time(int64_t bar_ms,
     if (!sess.empty() && !passes_session_filter(sess, session_tz, bar_ms))
         return na<int64_t>();
 
-    return compute_tf_open_ms(bar_ms, tf, tf_tz);
+    return compute_tf_open_ms(bar_ms, tf, tf_tz, "UTC", "");
 }
 
 int64_t pine_time_close(int64_t bar_ms,
@@ -649,7 +644,7 @@ int64_t pine_time_close(int64_t bar_ms,
     if (!sess.empty() && !passes_session_filter(sess, session_tz, bar_ms))
         return na<int64_t>();
 
-    int64_t t_open = compute_tf_open_ms(bar_ms, tf, tf_tz);
+    int64_t t_open = compute_tf_open_ms(bar_ms, tf, tf_tz, "UTC", "");
     return compute_tf_close_ms(t_open, tf, tf_tz);
 }
 
@@ -664,7 +659,13 @@ int64_t pine_time_close(int64_t bar_ms,
 // roll, 18% with the symbol's UTC roll), so that path keeps the tz-only
 // calendar floor of the five-argument forms. A timezone-looking string in the
 // session slot is an invalid session (dropped by resolve_session_tz) and
-// falls back to the symbol clock. Intraday tfs keep the epoch-grid bucket.
+// falls back to the symbol clock. An intraday tf is the symbol's
+// day-stamp-anchored HTF grid bucket whatever the session argument (it
+// only filters): TradingView's time("60") on NYSE:F 15 is 09:30 / 10:30 /
+// .. / 15:30 ET, time("240") on NSE:NIFTY 09:15 / 13:15 IST and on
+// OANDA:XAUUSD 17:00 ET + 4h*k, 00:00 UTC + 4h*k only on 24x7 UTC
+// (pin-time-hours, 2025-04-01..07-01) — the very grid request.security
+// aggregates on (session_intraday_bucket_open_ms), one grid in one place.
 static bool symbol_clock_applies(const std::string& resolved_session,
                                  CalendarPeriod cp) {
     return cp != CalendarPeriod::NONE && resolved_session.empty();
@@ -694,7 +695,7 @@ int64_t pine_time(int64_t bar_ms,
     const CalendarPeriod cp = calendar_period_for(tf);
     if (symbol_clock_applies(sess, cp))
         return session_period_open_ms(bar_ms, sym_tz, sym_session, cp);
-    return compute_tf_open_ms(bar_ms, tf, tf_tz);
+    return compute_tf_open_ms(bar_ms, tf, tf_tz, sym_tz, sym_session);
 }
 
 int64_t pine_time_close(int64_t bar_ms,
@@ -720,7 +721,7 @@ int64_t pine_time_close(int64_t bar_ms,
         // tz-only forms above; intraday closes stay the exact boundary.
         return session_period_close_ms(bar_ms, sym_tz, sym_session, cp) - 1;
     }
-    int64_t t_open = compute_tf_open_ms(bar_ms, tf, tf_tz);
+    int64_t t_open = compute_tf_open_ms(bar_ms, tf, tf_tz, sym_tz, sym_session);
     return compute_tf_close_ms(t_open, tf, tf_tz);
 }
 

--- a/src/session_time.cpp
+++ b/src/session_time.cpp
@@ -541,6 +541,35 @@ bool pine_session_ispostmarket(const std::string& session,
     return (mod >= rth_close_min && mod < post_close_min);
 }
 
+// Chart-timeframe forms (see session_time.hpp): a D/W/M chart bar is the
+// symbol's regular-session bar whatever time of day its stamp reads.
+bool pine_session_ismarket(const std::string& session,
+                           const std::string& tz,
+                           int64_t bar_ms,
+                           const std::string& chart_tf) {
+    if (tf_is_daily_or_higher(chart_tf))
+        return true;
+    return pine_session_ismarket(session, tz, bar_ms);
+}
+
+bool pine_session_ispremarket(const std::string& session,
+                              const std::string& tz,
+                              int64_t bar_ms,
+                              const std::string& chart_tf) {
+    if (tf_is_daily_or_higher(chart_tf))
+        return false;
+    return pine_session_ispremarket(session, tz, bar_ms);
+}
+
+bool pine_session_ispostmarket(const std::string& session,
+                               const std::string& tz,
+                               int64_t bar_ms,
+                               const std::string& chart_tf) {
+    if (tf_is_daily_or_higher(chart_tf))
+        return false;
+    return pine_session_ispostmarket(session, tz, bar_ms);
+}
+
 // ---------------------------------------------------------------------------
 // pine_time / pine_time_close (existing public API)
 // ---------------------------------------------------------------------------

--- a/src/ta_extremes_volume.cpp
+++ b/src/ta_extremes_volume.cpp
@@ -34,6 +34,15 @@ namespace ta {
 // does not run every bar) keep stale values in the slots they did not rewrite,
 // skip never-written slots, and are na iff bar_index < length - 1 — pinned
 // 2026-09-03 on NYSE:F 1D (cadence-7 39/39, cadence-9 30/30 entry sizes).
+// The slots are read through a cached extremum with an implied bar: a src
+// that strictly beats the cache takes it without reading the slots (aged or
+// not); otherwise an aged-out cache (by bars, not calls) rescans the slots
+// oldest first and re-caches (best, bar - k_best); otherwise the cache is
+// kept, leaving aliased stale slots unread — pinned 2026-09-04 on NYSE:F 1D
+// (8 tapes 696/696: t382 `m = bar_index % 49; m < 4 or 37 <= m < 47 or
+// m == 48`, ta.lowest(low, 10) -> bars 48..51 keep 9.88 over bar 3's
+// aliased 9.20, bar 52 rescans to 9.20), BINANCE:ETHUSDT.P 15 (82/82) and
+// the jayentriken BBWP ETH replay (593/593; the plain ring 587).
 
 BarContext& bar_context() {
     // Thread-local so parallel in-process engines never cross-contaminate;
@@ -94,26 +103,64 @@ ExtremeRing::Result ExtremeRing::update(double src, bool advance, bool want_max)
     written_[cur] = 1;
     has_written_ = true;
 
+    // The cached extremum {cval_, cbar_} is maintained on every call, warmup
+    // included (r5g8: bar 13 answers bar 4's 9.00 cached while still na).
+    // A recompute() on the bar the cache was last touched restores the
+    // pre-bar cache first, so every tick of one bar re-applies from the same
+    // starting point (magnifier compute -> recompute).
+    if (bar != cache_seen_bar_) {
+        cache_seen_bar_ = bar;
+        saved_cached_ = cached_;
+        saved_cval_ = cval_;
+        saved_cbar_ = cbar_;
+    } else {
+        cached_ = saved_cached_;
+        cval_ = saved_cval_;
+        cbar_ = saved_cbar_;
+    }
+    const auto rescan = [&]() {
+        // Oldest slot first with a strict comparison: ties resolve to the
+        // oldest member, exactly as the deque scan did (only the *Bars
+        // offsets can tell). Never-written slots are skipped, not zero: the
+        // campaign grades against UI-scraped tapes whose chart carried
+        // pre-range writes (TradingView's deep-backtest export reads them
+        // as 0 -- a documented, deliberate deviation).
+        double best = na<double>();
+        int best_k = 0;
+        for (int k = length_ - 1; k >= 0; --k) {
+            const std::size_t i = ring_slot(bar - k, K);
+            if (!written_[i]) continue;          // never written: skipped, not na
+            const double v = values_[i];
+            if (is_na(v)) continue;              // written gap: skipped
+            if (is_na(best) || (want_max ? v > best : v < best)) {
+                best = v;
+                best_k = k;
+            }
+        }
+        cval_ = best;
+        cbar_ = bar - best_k;    // the implied bar of an aliased slot
+    };
+    if (!cached_) {
+        cached_ = true;
+        cval_ = src;
+        cbar_ = bar;
+    } else if (!is_na(src) && (is_na(cval_) || (want_max ? src > cval_ : src < cval_))) {
+        // A strictly new extremum takes the cache without reading the slots,
+        // aged-out cache or not (ETH bar 4990). Ties never displace it.
+        cval_ = src;
+        cbar_ = bar;
+    } else if (bar - cbar_ >= static_cast<long long>(length_)) {
+        // The cached extremum has aged out of the window (by bars, not
+        // calls): rescan the slots, aliasing included.
+        rescan();
+    }
+    // else: the cache is younger than `length` bars and src did not beat it.
+
     // na until the context has seen `length` bars (TV: bar_index < length - 1;
     // `origin` keeps a range-truncated feed warming up over its own bars).
     if (bar - origin < static_cast<long long>(length_) - 1) return out;
-
-    double best = na<double>();
-    int best_k = 0;
-    // Oldest slot first with a strict comparison: ties resolve to the oldest
-    // member, exactly as the deque scan did (only the *Bars offsets can tell).
-    for (int k = length_ - 1; k >= 0; --k) {
-        const std::size_t i = ring_slot(bar - k, K);
-        if (!written_[i]) continue;          // never written: skipped, not na
-        const double v = values_[i];
-        if (is_na(v)) continue;              // written gap: skipped
-        if (is_na(best) || (want_max ? v > best : v < best)) {
-            best = v;
-            best_k = k;
-        }
-    }
-    out.value = best;
-    out.bars_back = best_k;
+    out.value = cval_;
+    out.bars_back = static_cast<int>(bar - cbar_);
     return out;
 }
 

--- a/src/ta_extremes_volume.cpp
+++ b/src/ta_extremes_volume.cpp
@@ -22,55 +22,125 @@ namespace pineforge {
 namespace ta {
 
 
+// --- Bar-addressed extremum ring (Highest / Lowest / HighestBars / LowestBars) ---
+//
+// TradingView's rule (see <pineforge/ta.hpp> bar_context()): a window call site
+// owns K = length + 1 slots addressed by bar_index % K; a call on bar b writes
+// slot[b % K] = src and reads the extremum over the WRITTEN slots (b - k) % K,
+// k in [0, length). Every-bar callers get the positional window (findings
+// 331/332 oracle, KI-55 family): an na input advances the window as a gap, the
+// extremum is taken over the non-na members, na while the window has not
+// formed or has no non-na member. Conditional callers (inside an ``if`` that
+// does not run every bar) keep stale values in the slots they did not rewrite,
+// skip never-written slots, and are na iff bar_index < length - 1 — pinned
+// 2026-09-03 on NYSE:F 1D (cadence-7 39/39, cadence-9 30/30 entry sizes).
+
+BarContext& bar_context() {
+    // Thread-local so parallel in-process engines never cross-contaminate;
+    // default "not installed" keeps standalone objects on their own cadence.
+    static thread_local BarContext ctx;
+    return ctx;
+}
+
+BarContextScope::BarContextScope(long long bar_index, long long origin)
+    : previous_(bar_context()) {
+    BarContext& ctx = bar_context();
+    ctx.installed = true;
+    ctx.bar_index = bar_index;
+    ctx.origin = origin;
+}
+
+BarContextScope::~BarContextScope() {
+    bar_context() = previous_;
+}
+
+namespace {
+
+inline std::size_t ring_slot(long long bar, long long K) {
+    long long m = bar % K;
+    if (m < 0) m += K;
+    return static_cast<std::size_t>(m);
+}
+
+}  // namespace
+
+ExtremeRing::ExtremeRing(int length)
+    : length_(length),
+      values_(length > 0 ? static_cast<std::size_t>(length) + 1 : 0, na<double>()),
+      written_(length > 0 ? static_cast<std::size_t>(length) + 1 : 0, 0) {}
+
+ExtremeRing::Result ExtremeRing::update(double src, bool advance, bool want_max) {
+    Result out{na<double>(), 0};
+    if (length_ <= 0) return out;
+
+    long long bar;
+    long long origin;
+    const BarContext& ctx = bar_context();
+    if (ctx.installed) {
+        bar = ctx.bar_index;
+        origin = ctx.origin;
+    } else {
+        // No context: every compute() is its own bar and recompute() rewrites
+        // the current one (a pristine recompute() counts as the first bar) —
+        // the previous positional-deque cadence, byte for byte.
+        if (advance || !has_written_) ++own_bar_;
+        bar = own_bar_;
+        origin = 0;
+    }
+
+    const long long K = static_cast<long long>(length_) + 1;
+    const std::size_t cur = ring_slot(bar, K);
+    values_[cur] = src;
+    written_[cur] = 1;
+    has_written_ = true;
+
+    // na until the context has seen `length` bars (TV: bar_index < length - 1;
+    // `origin` keeps a range-truncated feed warming up over its own bars).
+    if (bar - origin < static_cast<long long>(length_) - 1) return out;
+
+    double best = na<double>();
+    int best_k = 0;
+    // Oldest slot first with a strict comparison: ties resolve to the oldest
+    // member, exactly as the deque scan did (only the *Bars offsets can tell).
+    for (int k = length_ - 1; k >= 0; --k) {
+        const std::size_t i = ring_slot(bar - k, K);
+        if (!written_[i]) continue;          // never written: skipped, not na
+        const double v = values_[i];
+        if (is_na(v)) continue;              // written gap: skipped
+        if (is_na(best) || (want_max ? v > best : v < best)) {
+            best = v;
+            best_k = k;
+        }
+    }
+    out.value = best;
+    out.bars_back = best_k;
+    return out;
+}
+
 // --- Highest ---
 
 Highest::Highest(int length)
-    : length(length) {}
+    : ring_(length) {}
 
 double Highest::compute(double src) {
-    // TV positional-window semantics (findings 331/332 oracle, KI-55 family):
-    // the lookback window covers the last `length` BARS — an na input advances
-    // the window as a gap instead of being dropped, the extremum is taken over
-    // the non-na members, and the result is na only while the bar window has
-    // not fully formed or contains no non-na member. On gap-free series this
-    // is byte-identical to the previous last-N-non-na buffer.
-    buffer.push_back(src);
-    while ((int)buffer.size() > length) {
-        buffer.pop_front();
-    }
+    return ring_.update(src, /*advance=*/true, /*want_max=*/true).value;
+}
 
-    if ((int)buffer.size() < length) {
-        return na<double>();
-    }
-
-    double hi = na<double>();
-    for (int i = 0; i < (int)buffer.size(); i++) {
-        if (!is_na(buffer[i]) && (is_na(hi) || buffer[i] > hi)) hi = buffer[i];
-    }
-    return hi;
+double Highest::recompute(double src) {
+    return ring_.update(src, /*advance=*/false, /*want_max=*/true).value;
 }
 
 // --- Lowest ---
 
 Lowest::Lowest(int length)
-    : length(length) {}
+    : ring_(length) {}
 
 double Lowest::compute(double src) {
-    // TV positional-window semantics — see Highest::compute above.
-    buffer.push_back(src);
-    while ((int)buffer.size() > length) {
-        buffer.pop_front();
-    }
+    return ring_.update(src, /*advance=*/true, /*want_max=*/false).value;
+}
 
-    if ((int)buffer.size() < length) {
-        return na<double>();
-    }
-
-    double lo = na<double>();
-    for (int i = 0; i < (int)buffer.size(); i++) {
-        if (!is_na(buffer[i]) && (is_na(lo) || buffer[i] < lo)) lo = buffer[i];
-    }
-    return lo;
+double Lowest::recompute(double src) {
+    return ring_.update(src, /*advance=*/false, /*want_max=*/false).value;
 }
 
 // --- PivotHigh ---
@@ -258,63 +328,38 @@ double Median::compute(double src) {
 }
 
 // --- HighestBars ---
+// Same ring as Highest; the result is the slot distance k of the extremum
+// (0 = the current bar, negative offsets as TV reports them). An na input is
+// recorded as a positional gap and answers na on that bar.
 
-HighestBars::HighestBars(int length) : length_(length) {}
+HighestBars::HighestBars(int length) : ring_(length) {}
 
 double HighestBars::compute(double src) {
-    if (is_na(src)) {
-        return na<double>();
-    }
+    const ExtremeRing::Result r = ring_.update(src, /*advance=*/true, /*want_max=*/true);
+    if (is_na(src) || is_na(r.value)) return na<double>();
+    return -static_cast<double>(r.bars_back);
+}
 
-    buffer_.push_back(src);
-    while ((int)buffer_.size() > length_) {
-        buffer_.pop_front();
-    }
-
-    if ((int)buffer_.size() < length_) {
-        return na<double>();
-    }
-
-    int max_idx = 0;
-    double max_val = buffer_[0];
-    for (int i = 1; i < (int)buffer_.size(); i++) {
-        if (buffer_[i] > max_val) {
-            max_val = buffer_[i];
-            max_idx = i;
-        }
-    }
-    // Return negative offset from current bar
-    return (double)(max_idx - ((int)buffer_.size() - 1));
+double HighestBars::recompute(double src) {
+    const ExtremeRing::Result r = ring_.update(src, /*advance=*/false, /*want_max=*/true);
+    if (is_na(src) || is_na(r.value)) return na<double>();
+    return -static_cast<double>(r.bars_back);
 }
 
 // --- LowestBars ---
 
-LowestBars::LowestBars(int length) : length_(length) {}
+LowestBars::LowestBars(int length) : ring_(length) {}
 
 double LowestBars::compute(double src) {
-    if (is_na(src)) {
-        return na<double>();
-    }
+    const ExtremeRing::Result r = ring_.update(src, /*advance=*/true, /*want_max=*/false);
+    if (is_na(src) || is_na(r.value)) return na<double>();
+    return -static_cast<double>(r.bars_back);
+}
 
-    buffer_.push_back(src);
-    while ((int)buffer_.size() > length_) {
-        buffer_.pop_front();
-    }
-
-    if ((int)buffer_.size() < length_) {
-        return na<double>();
-    }
-
-    int min_idx = 0;
-    double min_val = buffer_[0];
-    for (int i = 1; i < (int)buffer_.size(); i++) {
-        if (buffer_[i] < min_val) {
-            min_val = buffer_[i];
-            min_idx = i;
-        }
-    }
-    // Return negative offset from current bar
-    return (double)(min_idx - ((int)buffer_.size() - 1));
+double LowestBars::recompute(double src) {
+    const ExtremeRing::Result r = ring_.update(src, /*advance=*/false, /*want_max=*/false);
+    if (is_na(src) || is_na(r.value)) return na<double>();
+    return -static_cast<double>(r.bars_back);
 }
 
 // --- OBV ---
@@ -562,36 +607,6 @@ double Range::compute(double src) {
     return h - l;
 }
 
-// --- Highest ---
-double Highest::recompute(double src) {
-    if (buffer.empty()) return compute(src);
-    buffer.back() = src;
-
-    if ((int)buffer.size() < length) return na<double>();
-
-    // Mirrors Highest::compute — positional window, na members skipped.
-    double hi = na<double>();
-    for (int i = 0; i < (int)buffer.size(); i++) {
-        if (!is_na(buffer[i]) && (is_na(hi) || buffer[i] > hi)) hi = buffer[i];
-    }
-    return hi;
-}
-
-// --- Lowest ---
-double Lowest::recompute(double src) {
-    if (buffer.empty()) return compute(src);
-    buffer.back() = src;
-
-    if ((int)buffer.size() < length) return na<double>();
-
-    // Mirrors Lowest::compute — positional window, na members skipped.
-    double lo = na<double>();
-    for (int i = 0; i < (int)buffer.size(); i++) {
-        if (!is_na(buffer[i]) && (is_na(lo) || buffer[i] < lo)) lo = buffer[i];
-    }
-    return lo;
-}
-
 // --- PivotHigh ---
 // Recompute mirrors compute(): LEFT non-strict (`>` rejects), RIGHT strict
 // (`>=` rejects). Both must stay in lockstep — a delta here would surface as
@@ -671,38 +686,6 @@ double Median::recompute(double src) {
     int n = (int)sorted.size();
     if (n % 2 == 1) return sorted[n / 2];
     return (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0;
-}
-
-// --- HighestBars ---
-double HighestBars::recompute(double src) {
-    if (buffer_.empty()) return compute(src);
-    buffer_.back() = src;
-
-    if (is_na(src)) return na<double>();
-    if ((int)buffer_.size() < length_) return na<double>();
-
-    int max_idx = 0;
-    double max_val = buffer_[0];
-    for (int i = 1; i < (int)buffer_.size(); i++) {
-        if (buffer_[i] > max_val) { max_val = buffer_[i]; max_idx = i; }
-    }
-    return (double)(max_idx - ((int)buffer_.size() - 1));
-}
-
-// --- LowestBars ---
-double LowestBars::recompute(double src) {
-    if (buffer_.empty()) return compute(src);
-    buffer_.back() = src;
-
-    if (is_na(src)) return na<double>();
-    if ((int)buffer_.size() < length_) return na<double>();
-
-    int min_idx = 0;
-    double min_val = buffer_[0];
-    for (int i = 1; i < (int)buffer_.size(); i++) {
-        if (buffer_[i] < min_val) { min_val = buffer_[i]; min_idx = i; }
-    }
-    return (double)(min_idx - ((int)buffer_.size() - 1));
 }
 
 // --- OBV ---

--- a/src/timeframe.cpp
+++ b/src/timeframe.cpp
@@ -237,9 +237,14 @@ static int session_length_minutes(const std::string& session);
 /// anchor put them at 22:00Z / 02:00Z / ... and 22:00Z / 22:45Z / 23:30Z.
 /// Every 3commas-* XAUUSD DCA probe (request.security "240" RSI gate) shows
 /// the same 17:00-ET grid on TV against the engine's 18:00-ET one, the DCA
-/// legs agreeing to 1e-6 once the grid does. The session OPEN stays the
-/// session-day's nominal open (the D bar's label and its close arithmetic,
-/// session_day_open_nominal_ms); only the clock moves, and no 1800-1700 bar
+/// legs agreeing to 1e-6 once the grid does. The stamp is also where the
+/// symbol's D bar OPENS -- time("D") on OANDA:XAUUSD 15 reads 17:00 ET on
+/// 147/147 entries of pin-time-hours (2025-04-01..07-01), never the 18:00
+/// ET session open -- so session_period_open_ms and the D/W/M bucket label
+/// sit on it (session_day_stamp_real_ms). The session OPEN keeps the
+/// trading window: session_day_open_real_ms / session_covered_instant_ms
+/// (where a native 17:00-stamped bar's content lies) and the close
+/// arithmetic (open + length = the next 17:00 stamp). No 1800-1700 bar
 /// trades in the 17:00-18:00 hour the two clocks attribute differently.
 static int session_day_stamp_offset_minutes(const std::string& session) {
     const int open = session_open_offset_minutes(session);
@@ -260,6 +265,19 @@ static int64_t intraday_clock_ms(int64_t ts, const std::string& tz,
                                  const std::string& session) {
     return calendar_clock_ms(ts, tz)
                - static_cast<int64_t>(session_day_stamp_offset_minutes(session)) * 60000;
+}
+
+int64_t session_intraday_bucket_open_ms(int64_t ms, int64_t bucket_sec,
+                                        const std::string& tz,
+                                        const std::string& session) {
+    if (bucket_sec <= 0) return ms;
+    // Floor (not truncate) so the open never lands after `ms` on a negative
+    // clock; for every real feed the two agree.
+    const int64_t bucket_ms = bucket_sec * 1000;
+    const int64_t clock = intraday_clock_ms(ms, tz, session);
+    int64_t open_clock = (clock / bucket_ms) * bucket_ms;
+    if (clock < 0 && clock % bucket_ms != 0) open_clock -= bucket_ms;
+    return ms - (clock - open_clock);
 }
 
 /// Minutes from symbol-local midnight to the first session window's CLOSE
@@ -377,17 +395,32 @@ static int64_t session_day_open_nominal_ms(int64_t d, const std::string& session
          + static_cast<int64_t>(session_open_offset_minutes(session)) * 60000;
 }
 
-/// Real epoch of session-day `d`'s open: the nominal wall-clock instant
-/// mapped back through the zone offset in force on THAT date (resolved
-/// twice so an east-of-UTC zone whose local open lands on the previous UTC
-/// date reads its own offset, not the nominal date's).
-static int64_t session_day_open_real_ms(int64_t d, const std::string& tz,
-                                        const std::string& session) {
-    const int64_t nominal = session_day_open_nominal_ms(d, session);
+/// Real epoch of a nominal wall-clock instant (UTC-encoded local time):
+/// mapped back through the zone offset in force at THAT instant (resolved
+/// twice so an east-of-UTC zone whose local instant lands on the previous
+/// UTC date reads its own offset, not the nominal date's).
+static int64_t nominal_to_real_ms(int64_t nominal, const std::string& tz) {
     if (is_utc_tz(tz)) return nominal;
     int64_t real = nominal + tz_offset_ms(nominal, tz);
     real = nominal + tz_offset_ms(real, tz);
     return real;
+}
+
+/// Real epoch of session-day `d`'s OPEN: the first traded instant.
+static int64_t session_day_open_real_ms(int64_t d, const std::string& tz,
+                                        const std::string& session) {
+    return nominal_to_real_ms(session_day_open_nominal_ms(d, session), tz);
+}
+
+/// Real epoch of session-day `d`'s DAY STAMP: where the symbol's D bar
+/// opens (session_day_stamp_offset_minutes) -- the session open everywhere
+/// but 1800-1700, whose bar is stamped 17:00 ET an hour before it trades.
+static int64_t session_day_stamp_real_ms(int64_t d, const std::string& tz,
+                                         const std::string& session) {
+    return nominal_to_real_ms(
+        d * kMsPerDay
+            + static_cast<int64_t>(session_day_stamp_offset_minutes(session)) * 60000,
+        tz);
 }
 
 int64_t session_day_index(int64_t ms, const std::string& tz,
@@ -421,9 +454,11 @@ int64_t session_period_open_ms(int64_t ms, const std::string& tz,
                                const std::string& session,
                                CalendarPeriod period) {
     if (period == CalendarPeriod::NONE) return ms;
+    // The period's bar opens where its first session-day's D bar does: the
+    // day stamp (the session open on every session but 1800-1700).
     const int64_t d = session_day_index(ms, tz, session);
-    return session_day_open_real_ms(session_period_first_day(d, session, period),
-                                    tz, session);
+    return session_day_stamp_real_ms(session_period_first_day(d, session, period),
+                                     tz, session);
 }
 
 /// Epoch day of the first session-day of the W/M period FOLLOWING the one
@@ -476,8 +511,9 @@ int64_t session_period_close_ms(int64_t ms, const std::string& tz,
     if (period == CalendarPeriod::NONE) return ms;
     const int64_t d = session_day_index(ms, tz, session);
     if (period == CalendarPeriod::DAY) return session_day_close_real_ms(d, tz, session);
-    return session_day_open_real_ms(session_period_next_first_day(d, session, period),
-                                    tz, session);
+    // W/M close on the next period's first D bar open -- its day stamp.
+    return session_day_stamp_real_ms(session_period_next_first_day(d, session, period),
+                                     tz, session);
 }
 
 /// True when the run declares a real exchange session (equities RTH, forex
@@ -1046,18 +1082,12 @@ int64_t TimeframeAggregator::bucket_open_ms(int64_t ms) const {
         case Mode::CALENDAR:
             return session_period_open_ms(ms, anchor_tz_, anchor_session_,
                                           cal_period_);
-        case Mode::RATIO: {
-            if (target_seconds_ <= 0) return ms;   // count-only ratio: no grid
-            // Same grid feed_ratio_mode keys on: exchange-tz ms since
-            // local-midnight + session-open, floored to the bucket width.
-            // Floor (not truncate) so the open never lands after `ms` on a
-            // negative clock; for every real feed the two agree.
-            const int64_t bucket_ms = target_seconds_ * 1000;
-            const int64_t clock = intraday_clock_ms(ms, anchor_tz_, anchor_session_);
-            int64_t open_clock = (clock / bucket_ms) * bucket_ms;
-            if (clock < 0 && clock % bucket_ms != 0) open_clock -= bucket_ms;
-            return ms - (clock - open_clock);
-        }
+        case Mode::RATIO:
+            // Same grid feed_ratio_mode keys on (and time("<intraday tf>")
+            // reads): exchange-tz ms since local-midnight + day stamp,
+            // floored to the bucket width. Count-only ratio: no grid.
+            return session_intraday_bucket_open_ms(ms, target_seconds_,
+                                                   anchor_tz_, anchor_session_);
         case Mode::PASSTHROUGH:
             return ms;
     }
@@ -1074,8 +1104,10 @@ int64_t TimeframeAggregator::bar_label_ms(int64_t ms) const {
             // The D/W/M bar is dated by its first TRADED session-day (a
             // holiday-Monday equity week is Tuesday's bar, exactly as the
             // first-present sub-bar already implied), but within that
-            // session-day by the session OPEN: the forex daily / weekly bar
-            // whose tape starts at 17:04 ET is still the 17:00 ET bar.
+            // session-day by the DAY STAMP: the forex daily / weekly bar
+            // whose tape starts at 17:04 ET is still the 17:00 ET bar, and
+            // the 1800-1700 day that trades from 18:00 ET is its 17:00 ET
+            // stamped bar (session_day_stamp_offset_minutes).
             return session_period_open_ms(ms, anchor_tz_, anchor_session_,
                                           CalendarPeriod::DAY);
         case Mode::PASSTHROUGH:

--- a/src/timeframe.cpp
+++ b/src/timeframe.cpp
@@ -216,13 +216,50 @@ static int64_t calendar_clock_ms(int64_t ts, const std::string& tz) {
     return ts - tz_offset_ms(ts, tz);
 }
 
-/// Intraday grid clock: exchange-tz seconds since (local-midnight + session
-/// open), so integer division by the bucket width reproduces TV's
-/// session-open-anchored grouping (09:30/13:30 on equities).
+static int session_length_minutes(const std::string& session);
+
+/// Minutes from symbol-local midnight to the symbol's DAY STAMP: the instant
+/// its daily bar starts, which is where TradingView anchors the intraday HTF
+/// grid ("45", "240", ...) and where the session-day ordinal below rolls.
+/// For every declared session that is the session open -- 09:30 ET on NYSE
+/// RTH, 09:15 IST on NSE, 17:00 CT on CME 1700-1600, 17:00 ET on OANDA forex
+/// 1700-1700, midnight on 24x7 -- with ONE exception the engine has to know
+/// by its session string: OANDA's 1800-1700 metals / CFD session (XAUUSD,
+/// XAGUSD, ...). It trades from 18:00 ET, but OANDA aligns every
+/// instrument's day at the 17:00 ET forex roll -- the stamp its native daily
+/// bars carry (engine_aux_security.cpp routes them by the session they
+/// COVER for that reason) -- and TradingView inherits that alignment.
+/// Pinned with `lab tv` on OANDA:XAUUSD 15, 2025-04-01..04-15
+/// (pin-xau-grid-240 / -45: entries on ta.change(time("<tf>"))): "240"
+/// buckets open 21:00Z / 01:00Z / 05:00Z / 09:00Z / 13:00Z / 17:00Z -- 17:00
+/// EDT, the 17:00-21:00 bucket holding only the 18:00-20:45 bars -- and "45"
+/// buckets 21:00Z / 21:45Z / 22:30Z / 23:15Z; the 18:00 ET session-open
+/// anchor put them at 22:00Z / 02:00Z / ... and 22:00Z / 22:45Z / 23:30Z.
+/// Every 3commas-* XAUUSD DCA probe (request.security "240" RSI gate) shows
+/// the same 17:00-ET grid on TV against the engine's 18:00-ET one, the DCA
+/// legs agreeing to 1e-6 once the grid does. The session OPEN stays the
+/// session-day's nominal open (the D bar's label and its close arithmetic,
+/// session_day_open_nominal_ms); only the clock moves, and no 1800-1700 bar
+/// trades in the 17:00-18:00 hour the two clocks attribute differently.
+static int session_day_stamp_offset_minutes(const std::string& session) {
+    const int open = session_open_offset_minutes(session);
+    if (open == 18 * 60
+        && (open + session_length_minutes(session)) % 1440 == 17 * 60) {
+        return 17 * 60;
+    }
+    return open;
+}
+
+/// Intraday grid clock: exchange-tz seconds since (local-midnight + the
+/// symbol's day stamp), so integer division by the bucket width reproduces
+/// TV's day-anchored grouping (09:30/13:30 on equities, 17:00 ET on OANDA).
+/// The session-day ordinal (session_day_index) runs on the same clock: the
+/// day rolls at the stamp, and the nominal session open is added back per
+/// day by session_day_open_nominal_ms.
 static int64_t intraday_clock_ms(int64_t ts, const std::string& tz,
                                  const std::string& session) {
     return calendar_clock_ms(ts, tz)
-               - static_cast<int64_t>(session_open_offset_minutes(session)) * 60000;
+               - static_cast<int64_t>(session_day_stamp_offset_minutes(session)) * 60000;
 }
 
 /// Minutes from symbol-local midnight to the first session window's CLOSE
@@ -420,6 +457,11 @@ static int64_t session_day_close_real_ms(int64_t d, const std::string& tz,
 int64_t session_covered_instant_ms(int64_t ms, const std::string& tz,
                                    const std::string& session) {
     const int64_t d = session_day_index(ms, tz, session);
+    // Before the session-day's open -- the 17:00-18:00 ET hour between the
+    // 1800-1700 day stamp and its session open, where OANDA stamps the daily
+    // bar: the stamp covers the session about to open.
+    const int64_t open = session_day_open_real_ms(d, tz, session);
+    if (ms < open) return open;
     // Inside the session-day (before its exclusive close): covered as-is.
     // ""/24x7 sessions close exactly at the next open, so the gap is empty
     // and every timestamp takes this branch.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ set(TEST_SOURCES
     test_htf_session_close_completion
     test_chart_bar_bucket_label
     test_htf_bucket_real_end
+    test_oanda_day_stamp_grid
     test_adversarial_ohlcv
     test_report_trace
     test_path_resolve_extra

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,7 @@ set(TEST_SOURCES
     test_stop_decline_continue_path
     test_frozen_flat_gap_reject
     test_explicit_qty_fill_admission
+    test_market_entry_affordability
     test_zero_lot_entry_decline
     test_pooc_coof_reversal_gross_admission
     test_limit_fill_slippage

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -141,6 +141,7 @@ set(TEST_SOURCES
     test_exit_bracket_position_cycle_lifetime
     test_range_end_close
     test_close_id_retires_ledger
+    test_session_predicates_daily_chart
 )
 
 find_package(Threads REQUIRED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ set(TEST_SOURCES
     test_chart_bar_bucket_label
     test_htf_bucket_real_end
     test_oanda_day_stamp_grid
+    test_pine_time_day_stamp_grid
     test_adversarial_ohlcv
     test_report_trace
     test_path_resolve_extra

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -116,6 +116,7 @@ set(TEST_SOURCES
     test_ta_ma_warmup_extra
     test_ta_osc_edge
     test_ta_extremes_edge
+    test_ta_extremes_ring
     test_ta_voltrend_edge
     test_timezone_concurrency
     test_pointvalue

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -141,6 +141,7 @@ set(TEST_SOURCES
     test_exit_bracket_position_cycle_lifetime
     test_range_end_close
     test_close_id_retires_ledger
+    test_trail_open_arm_subtick_offset
 )
 
 find_package(Threads REQUIRED)

--- a/tests/test_close_id_retires_ledger.cpp
+++ b/tests/test_close_id_retires_ledger.cpp
@@ -341,7 +341,11 @@ static void test_deferred_close_suppression_recredits_retired_remainder() {
     //       suppressed and the ledger re-credited: 60 + 40 = 100 (without
     //       the retired term: 60). Position holds LONG 60.
     // bar3: entry M 50 (fixed qty, a different id) -> fills bar4 open:
-    //       position 110; ledger L untouched.
+    //       position 110; ledger L untouched. Bar3 closes at 79 so the add is
+    //       affordable as held + add (design-market-entry-affordability):
+    //       MTM 10,000 - 60*21 = 8,740 >= 110 * 79 = 8,690. (At the former
+    //       close of 111 the all-in position had no free equity and TV's
+    //       rule drops the add.)
     // bar4: close(L): target = min(ledger, 110) = 100 with the full
     //       re-credit (60 without it) -> fills bar5 open.
     p.steps = {
@@ -364,10 +368,10 @@ static void test_deferred_close_suppression_recredits_retired_remainder() {
         mk(0, 100, 100, 100, 100),   // bar0: place L
         mk(1, 100, 100, 100, 100),   // bar1: L fills @100; explicit partial placed
         mk(2, 100, 112,  99, 110),   // bar2: partial fills @100; S + close(L) placed
-        mk(3, 111, 112, 110, 111),   // bar3: S declines (+1 tick), close suppressed
-        mk(4, 111, 111, 111, 111),   // bar4: M fills; close(L) placed
-        mk(5, 111, 111, 111, 111),   // bar5: close(L) fills
-        mk(6, 111, 111, 111, 111),
+        mk(3, 111, 112,  79,  79),   // bar3: S declines (+1 tick), close suppressed
+        mk(4,  79,  79,  79,  79),   // bar4: M fills; close(L) placed
+        mk(5,  79,  79,  79,  79),   // bar5: close(L) fills
+        mk(6,  79,  79,  79,  79),
     };
     p.run(bars.data(), (int)bars.size());
     CHECK(p.ledger_l35_after_bar.size() == 1);

--- a/tests/test_direct_short_reversal_affordability.cpp
+++ b/tests/test_direct_short_reversal_affordability.cpp
@@ -606,7 +606,10 @@ public:
         } else if (bar_index_ == 1) {
             captured_after_reversal = direct_lifecycle_active();
             if (mutation_ == Mutation::AcceptedAdd) {
-                strategy_entry("A", false, kNaN, kNaN, 1.0);
+                // Placed on bar 2 instead (see below): the all-in short has no
+                // free equity at its own fill price, so an add costed as
+                // held + add (design-market-entry-affordability) is only
+                // affordable once the short is in profit (close 90).
             } else if (mutation_ == Mutation::ScriptPartialReduction) {
                 strategy_close(
                     "S", "", 1.0, kNaN, /*immediately=*/true);
@@ -622,6 +625,10 @@ public:
                 cleared_after_mutation = !direct_lifecycle_active();
             }
         } else if (bar_index_ == 2
+                   && mutation_ == Mutation::AcceptedAdd) {
+            // MTM 11,000 at close 90 vs (100 + 1) * 90 = 9,090: admitted.
+            strategy_entry("A", false, kNaN, kNaN, 1.0);
+        } else if (bar_index_ == 3
                    && mutation_ == Mutation::AcceptedAdd) {
             mutation_applied =
                 position_side_ == PositionSide::SHORT

--- a/tests/test_explicit_qty_fill_admission.cpp
+++ b/tests/test_explicit_qty_fill_admission.cpp
@@ -37,7 +37,9 @@
  * GREEN-E margin>100 characterization + margin==0 inertness.
  * GREEN-F priced (stop=) entry adverse gap + RAW strategy.order -> unaffected.
  * GREEN-G POOC=true with slippage>0                         -> no spurious decline.
- * GREEN-H same-bar close-then-explicit-reentry (after-close) -> NOT declined.
+ * H       same-bar close-then-explicit-reentry (after-close), adverse gap ->
+ *         DECLINED (re-pinned 2026-09-03 under design-market-entry-
+ *         affordability: the rule has no after-close carve-out).
  * GREEN-I strategy.exit bracket bound to a declined entry   -> inert, no crash.
  */
 
@@ -376,14 +378,19 @@ void test_greenG_pooc_slippage_no_op() {
     CHECK_NEAR(eng.position_size(), 100.0, 1e-9);
 }
 
-// GREEN-H. Same-bar close-then-explicit-reentry. Bar0 opens a small long (qty
-// 1); bar1 immediately closes it AND places an all-in explicit reentry "R2"
-// from the now-flat position (created_after_position_close_in_bar == true).
-// Bar2 gaps +1 mintick adverse. Because the reentry is NOT created true-flat
-// (the after-close flag is set), it is EXCLUDED from the fill gate and fills
-// despite the adverse gap. A true-flat all-in here would be declined (RED-1).
-void test_greenH_close_reentry_not_declined() {
-    std::printf("-- GREEN-H: same-bar close-then-reentry not declined --\n");
+// H. Same-bar close-then-explicit-reentry. Bar0 opens a small long (qty 1);
+// bar1 immediately closes it AND places an all-in explicit reentry "R2"
+// (created_after_position_close_in_bar == true). Bar2 gaps +1 mintick
+// adverse: 100 * 100.01 = 10,001 > the placement equity 10,000 -> DECLINED.
+//
+// RE-PIN (2026-09-03, design-market-entry-affordability): this used to be
+// GREEN ("not declined") because the original fill gate was scoped to
+// true-flat placements only — a scope carve-out, never a TV observation. The
+// unified rule pinned by pin-afford-{gapup,gapdown} / pin-admit-allin-{xau,f}
+// has no after-close exemption: at fill the account is flat and the notional
+// at tick(fill) overshoots the placement snapshot, exactly RED-1's shape.
+void test_H_close_reentry_declined() {
+    std::printf("-- H: same-bar close-then-reentry declined on adverse gap --\n");
     Probe eng(/*capital=*/10000.0, /*comm=*/0.0, /*slip=*/0, /*margin=*/100.0,
               /*pooc=*/false, /*enable_mc=*/false);
     eng.entry_qty_ = 1.0;          // bar0 'L' small long
@@ -392,12 +399,13 @@ void test_greenH_close_reentry_not_declined() {
     std::vector<Bar> bars = {
         mk_bar(1000, 100,    100,    100,    100),      // L placed (qty 1)
         mk_bar(2000, 100,    100,    100,    100),       // L fills @100; then close+reentry
-        mk_bar(3000, 100.01, 100.02, 100.00, 100.01),   // R2 fills adverse -> NOT declined
+        mk_bar(3000, 100.01, 100.02, 100.00, 100.01),   // R2 adverse -> DECLINED
         mk_bar(4000, 100.01, 100.01, 100.01, 100.01),
     };
     eng.run(bars.data(), (int)bars.size());
-    CHECK(eng.position_side_ == PositionSide::LONG);       // reentry filled
-    CHECK_NEAR(eng.position_size(), 100.0, 1e-9);
+    CHECK(eng.position_side_ == PositionSide::FLAT);       // reentry declined
+    CHECK_NEAR(eng.position_size(), 0.0, 1e-9);
+    CHECK(eng.trade_count() == 1);                         // the qty-1 round trip
 }
 
 // GREEN-I. Dangling-exit safety. A strategy.exit bracket ("EX", from_entry
@@ -436,7 +444,7 @@ int main() {
     test_greenE_margin_variants();
     test_greenF_priced_and_raw_unaffected();
     test_greenG_pooc_slippage_no_op();
-    test_greenH_close_reentry_not_declined();
+    test_H_close_reentry_declined();
     test_greenI_dangling_exit_inert();
     std::printf("\n=== Results: %d passed, %d failed ===\n",
                 tests_passed, tests_failed);

--- a/tests/test_margin_admission_gate.cpp
+++ b/tests/test_margin_admission_gate.cpp
@@ -29,9 +29,12 @@
  *      0/1068 gap-up flip fills against a 50/50 gapping feed.)
  *   E. A reversal whose fill price EQUALS the sizing price is an exact
  *      required == free_funds tie at all-in — the epsilon must ADMIT it.
- *   F. CASH default sizing is exempt: a flat open with cash_value >
- *      equity (no floor invariant exists for CASH) must be ADMITTED —
- *      regression pin for the gate's percent_of_equity/pct<=100 scope.
+ *   F. CASH default sizing skips THIS gate (no floor invariant exists for
+ *      CASH) but is admitted by the unified design-market-entry-affordability
+ *      gate instead: cash 20,000 on 10,000 capital at margin 100 is DECLINED,
+ *      cash 5,000 fills 50 lots. (Re-pinned 2026-09-03 — the former "exempt,
+ *      must fill" pin was a scope carve-out, not a TV observation; TV's broker
+ *      rule is sizing-type-blind: pin-afford-gapdown.)
  */
 
 #include <cmath>
@@ -240,23 +243,44 @@ void test_reversal_admitted_at_exact_tie() {
     }
 }
 
-// F. CASH default sizing is exempt from the re-check: cash 20000 on 10000
-//    capital sizes 200 lots @100 — no floor invariant bounds it by equity,
-//    and no TV ground truth pins a decline, so the flat open must FILL.
-//    (Pre-fix the gate declined every such entry: 445/445 on a real
-//    transpiled cash probe, 73 trades -> 0.)
-void test_cash_flat_open_admitted() {
-    std::printf("-- F: cash default sizing exempt, flat open admitted --\n");
-    Probe eng(QtyType::CASH, 20000.0, 1);
-    eng.script = "L..";
-    std::vector<Bar> bars = {
-        mk_bar(1000, 100, 100, 100, 100),   // frozen 20000/100 = 200
-        mk_bar(2000, 100, 100, 100, 100),   // must fill: LONG 200
-        mk_bar(3000, 100, 100, 100, 100),
-    };
-    eng.run(bars.data(), (int)bars.size());
-    CHECK(eng.position_side_ == PositionSide::LONG);
-    CHECK_NEAR(eng.position_qty_, 200.0, 1e-9);
+// F. CASH default sizing skips the KI-54 re-check (no floor invariant bounds
+//    it by equity) — it is admitted by the unified design-market-entry-
+//    affordability gate instead (strategy_entry placement half): cash 20000
+//    on 10000 capital sizes 200 lots @100 = 20,000 > 10,000 -> DECLINED;
+//    cash 5000 sizes 50 lots = 5,000 -> fills.
+//    RE-PIN (2026-09-03): this used to assert "exempt, must FILL" on the
+//    grounds that no TV ground truth pinned a decline. TV's broker rule is
+//    sizing-type-blind (pin-afford-gapdown: a fixed-qty notional over equity is
+//    rejected at placement), so an over-notional CASH open is rejected the same
+//    way. The historical note that a cash-20k-on-10k transpiled probe "lost 73
+//    trades" to the old gate is retained in engine_fills.cpp's KI-54 comment
+//    for the record; no TV tape of that probe was ever pinned.
+void test_cash_flat_open_gated() {
+    std::printf("-- F: cash default sizing gated by the unified rule --\n");
+    {
+        Probe eng(QtyType::CASH, 20000.0, 1);
+        eng.script = "L..";
+        std::vector<Bar> bars = {
+            mk_bar(1000, 100, 100, 100, 100),   // frozen 20000/100 = 200 lots
+            mk_bar(2000, 100, 100, 100, 100),   // 20,000 > 10,000 -> declined
+            mk_bar(3000, 100, 100, 100, 100),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::FLAT);
+        CHECK(eng.trade_count() == 0);
+    }
+    {
+        Probe eng(QtyType::CASH, 5000.0, 1);
+        eng.script = "L..";
+        std::vector<Bar> bars = {
+            mk_bar(1000, 100, 100, 100, 100),   // frozen 5000/100 = 50 lots
+            mk_bar(2000, 100, 100, 100, 100),   // 5,000 <= 10,000 -> fills
+            mk_bar(3000, 100, 100, 100, 100),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::LONG);
+        CHECK_NEAR(eng.position_qty_, 50.0, 1e-9);
+    }
 }
 
 }  // namespace
@@ -622,7 +646,7 @@ int main() {
     test_fractional_same_dir_add_admitted();
     test_reversal_declined_on_adverse_gap();
     test_reversal_admitted_at_exact_tie();
-    test_cash_flat_open_admitted();
+    test_cash_flat_open_gated();
     test_slipped_short_reversal_zero_gap_admitted();
     test_reversal_lot_step_slack();
     test_fractional_add_marked_to_market();

--- a/tests/test_margin_call.cpp
+++ b/tests/test_margin_call.cpp
@@ -1277,10 +1277,15 @@ public:
     void on_bar(const Bar& /*bar*/) override {
         if (bar_index_ != 0) return;
 
+        // Both calls are placed from FLAT within one on_bar and fill at the
+        // POOC close in sequence — the real process_orders_on_close flow.
+        // (The fixture used to force a fill between the two placements; under
+        // design-market-entry-affordability an ADD placed while already
+        // holding the BASE is costed as held + add and declined at placement
+        // — masayanfx — whereas the same-source-bar pair placed from flat is
+        // admitted with "held" frozen at placement, then trimmed here.)
         strategy_entry("BASE", is_long_, kNaN, kNaN, /*qty=*/2.0);
-        process_pending_orders(current_bar_);
         strategy_entry("ADD", is_long_, kNaN, kNaN, /*qty=*/2.0);
-        process_pending_orders(current_bar_);
     }
 
 private:
@@ -1355,10 +1360,14 @@ static void test_same_bar_explicit_pair_fx1_direction_symmetry() {
         /*is_long=*/false, account_fx, initial_capital);
 }
 
-// The add fills above the base short. Marking required margin at the VWAP
-// (105) reports an exact 4*105 == 420 tie and incorrectly does nothing;
-// TradingView marks the whole position at the latest raw fill (110), including
-// the carried short's open loss, and immediately restores margin there.
+// The add would fill above the base short. RE-PIN (2026-09-03, design-market-
+// entry-affordability): an add placed while already HOLDING the base is
+// costed as the resulting position at the signal close — held 2 + add 2 =
+// 4 * 110 = 440 > MTM 420 - (110-100)*2 = 400 — and DECLINED at placement
+// (masayanfx NQ1 2025-07-30 20:15Z: TV drops an over-notional pyramiding
+// add). The base short stands (2 * 110 = 220 <= 400) and no margin call
+// fires. (This fixture used to assert admit-then-4x-trim marked at the latest
+// raw fill; that shape was never TV-pinned.)
 class UnequalFillShortAddProbe : public MCEngine {
 public:
     UnequalFillShortAddProbe() {
@@ -1389,16 +1398,12 @@ static void test_short_add_opening_margin_marks_latest_raw_fill() {
     UnequalFillShortAddProbe eng;
     eng.run(bars.data(), (int)bars.size());
 
-    // At the latest fill, equity is 420 - (110-100)*2 = 400 and required
-    // margin is 4*110=440. The 4x restore closes 4*(4-400/110).
-    const double expected_qty = 4.0 * (4.0 - 400.0 / 110.0);
-    CHECK(eng.trade_count() == 1);
-    CHECK(margin_call_rows(eng) == 1);
-    CHECK(eng.exit_comment(0) == std::string("Margin call"));
-    CHECK(near(eng.entry_price(0), 100.0));
-    CHECK(near(eng.exit_price(0), 110.0));
-    CHECK(near(eng.trade_size(0), expected_qty));
-    CHECK(near(eng.position_size(), -(4.0 - expected_qty)));
+    // At the add's signal close, MTM equity is 420 - (110-100)*2 = 400 and
+    // the resulting position would need 4*110 = 440: the add is declined,
+    // the base short (2 * 110 = 220) stands, no margin call.
+    CHECK(eng.trade_count() == 0);
+    CHECK(margin_call_rows(eng) == 0);
+    CHECK(near(eng.position_size(), -2.0));
 }
 
 // Literal non-POOC geometry from the Thula margin fork. The effective fixed FX
@@ -2189,10 +2194,14 @@ private:
 
 static void test_commissioned_default_short_lifecycle_mutations() {
     std::printf("test_commissioned_default_short_lifecycle_mutations\n");
+    // Bar 1 closes at 90 so the explicit 1-lot add is affordable as held + add
+    // (design-market-entry-affordability): the all-in short is in profit,
+    // MTM ~1,099 >= (9.99 + 1) * 90. At the former close of 100 the all-in
+    // position had no free equity and the add was (correctly) dropped.
     std::vector<Bar> bars = {
         mk_bar(1000, 100.0, 100.0, 100.0, 100.0, 1.0),
-        mk_bar(2000, 100.0, 100.0, 100.0, 100.0, 1.0),
-        mk_bar(3000, 100.0, 100.0, 100.0, 100.0, 1.0),
+        mk_bar(2000, 100.0, 100.0,  90.0,  90.0, 1.0),
+        mk_bar(3000,  90.0,  90.0,  90.0,  90.0, 1.0),
     };
     CommissionedDefaultShortLifecycleMutationProbe add(
         CommissionedDefaultShortLifecycleMutationProbe::Mutation::AcceptedAdd);
@@ -2601,9 +2610,13 @@ static void test_flat_clears_and_raw_fresh_reuses_state() {
     CHECK(near(eng.position_size(), 4.0));
 }
 
-// Reversal is a fresh position cycle. The closing short's realized loss must
-// be in the new long's opening-equity basis, and the raw reversal match must be
-// captured for the broker-generated closing leg.
+// Reversal is a fresh position cycle. RE-PIN (2026-09-03, design-market-entry-
+// affordability): the 10-lot long is admitted at placement (10 * 100 = 1,000
+// == MTM 1,000) but the fill gaps to 120 (1,200 > 1,000), so TV drops the
+// ENTRY leg and executes only the reversal's closing leg (pin-afford-gapup;
+// rampatel BTC 2025-05-12 07:15Z). No long opens, so no opening-affordability
+// nibble fires and the opening state stays clear. (This fixture used to
+// assert admit-then-nibble 4 of 10 at 120; that shape was never TV-pinned.)
 class ReversalOpeningProbe : public MCEngine {
 public:
     ReversalOpeningProbe() {
@@ -2636,13 +2649,11 @@ static void test_reversal_captures_fresh_opening_state() {
     ReversalOpeningProbe eng;
     eng.run(bars.data(), (int)bars.size());
 
-    CHECK(eng.trade_count() == 2);  // short reversal close + long MC nibble
-    CHECK(margin_call_rows(eng) == 1);
-    CHECK(eng.exit_comment(1) == std::string("Margin call"));
-    CHECK(near(eng.entry_price(1), 120.0));
-    CHECK(near(eng.exit_price(1), 120.0));
-    CHECK(near(eng.trade_size(1), 4.0));
-    CHECK(near(eng.position_size(), 6.0));
+    CHECK(eng.trade_count() == 1);  // the short, closed by "L"'s closing leg
+    CHECK(margin_call_rows(eng) == 0);
+    CHECK(near(eng.exit_price(0), 120.0));
+    CHECK(near(eng.trade_size(0), 1.0));
+    CHECK(near(eng.position_size(), 0.0));
     CHECK(!eng.opening_pending());
     CHECK(!eng.opening_eligible());
     CHECK(std::isnan(eng.opening_raw_base()));

--- a/tests/test_market_entry_affordability.cpp
+++ b/tests/test_market_entry_affordability.cpp
@@ -1,0 +1,682 @@
+/*
+ * test_market_entry_affordability.cpp — design-market-entry-affordability:
+ * TradingView's broker admission for a MARKET entry, unified over explicit-qty
+ * and default FIXED / CASH sizing (default percent_of_equity keeps its own
+ * pinned KI-54 / gap-reject / gross-admission family).
+ *
+ * Rule (pinned 2026-09-03 with `lab tv`, TV is ground truth):
+ *
+ *   admit iff lot_floored(resulting_position_qty)
+ *               * max(tick(close(S)), tick(fill)) * pv * fx * margin/100
+ *             <= placement_equity + max(1e-9, |placement_equity| * 1e-12)
+ *
+ * evaluated TWICE — at placement on tick(close(S)) against MARK-TO-MARKET
+ * equity (initial + net_profit + open_profit at close(S)), and at fill on
+ * tick(fill) against the same placement snapshot. "Resulting position" is the
+ * new side's qty on a reversal (the closing leg is not counted) and held + add
+ * on a same-direction add. Commission is NOT in the notional; there is no
+ * max(equity, signal_notional) admission floor. A rejected reversal drops the
+ * ENTRY leg only — its closing leg still executes.
+ *
+ * Evidence (tapes under scratchpad/r5/pins, `lab tv` exports):
+ *   pin-afford-{flat,reverse} CME_MINI:NQ1! 15, fixed qty 1, margin 100:
+ *     10,212 flat-entry + reversal decisions, 0 mismatches; the short reversal
+ *     at 2025-05-06 14:15Z filled with realized 396,625 < cost 397,995 because
+ *     MTM 398,455 >= cost.
+ *   pin-afford-gapup:     capital 380,000, signal close 18,820.50 (376,410 ok)
+ *                         -> fill 19,225 (384,500 > 380k) -> NOT filled.
+ *   pin-afford-gapdown:   capital 345,000, signal close 17,483.25 (349,665 >
+ *                         345k) -> fill 17,100 (342,000 ok) -> NOT filled.
+ *   pin-afford-gapup-ctl: capital 1e6 fills at 19,225.
+ *   pin-admit-allin-xau   OANDA:XAUUSD 15, qty = strategy.equity / close,
+ *                         commission 0.05%, 1279/1279: 2025-04-08 13:30Z
+ *                         E 1,998,000.02, close 3013.72, open 3013.745, lot
+ *                         step 0.01 -> 662.968 -> 662.96 lots ADMITTED.
+ *   pin-admit-allin-f     NYSE:F 15, 352/352: half-cent close 10.225 -> fill
+ *                         10.23: floor(E/10.225) * 10.23 > E -> DECLINED.
+ *   production: rampatel BTC 2025-05-12 07:15Z — TV closed the short remainder
+ *     by "Buy" @105,600 and opened no long (equity 103,572 < 105,600);
+ *     masayanfx NQ1 2025-07-30 20:15Z — pyramiding add 2 * 23,667.75 * 20 =
+ *     946,710 > MTM 945,225 -> TV dropped the add.
+ *
+ * Every price below is on-tick for its instrument (NQ 0.25, XAUUSD/F 0.01)
+ * unless the case is ABOUT a sub-tick print, so fills land on the bar prices.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <pineforge/bar.hpp>
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_NEAR(a, b, tol)                                                  \
+    do {                                                                       \
+        double _a = (a), _b = (b);                                             \
+        if (!(std::fabs(_a - _b) <= (tol))) {                                  \
+            std::printf("  FAIL  %s:%d  %s == %.10f, expected %.10f\n",        \
+                        __FILE__, __LINE__, #a, _a, _b);                       \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+static constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+static Bar mk_bar(int64_t ts, double o, double h, double l, double c) {
+    Bar b;
+    b.open = o; b.high = h; b.low = l; b.close = c;
+    b.volume = 1.0; b.timestamp = ts;
+    return b;
+}
+
+static Bar flat_bar(int64_t ts, double p) { return mk_bar(ts, p, p, p, p); }
+
+namespace {
+
+struct Instrument {
+    double pointvalue;
+    double mintick;
+    double qty_step;
+};
+static const Instrument kNQ  = {20.0, 0.25, 1.0};
+static const Instrument kXAU = {1.0,  0.01, 0.01};
+static const Instrument kF   = {1.0,  0.01, 1.0};
+static const Instrument kBTC = {1.0,  1.0,  0.001};
+
+// Scripted probe. Script chars (indexed by bar_index_):
+//   'L' default-sized LONG  market entry "L"      'S' default SHORT "S"
+//   'A' default-sized LONG  add "L2" (pyramiding)
+//   'l' explicit LONG  "L" qty = entry_qty_       's' explicit SHORT "S"
+//   'a' explicit LONG  add "L2" qty = entry_qty_
+//   'B' explicit LONG  "Buy" qty = entry_qty_ (the rampatel reversal id)
+//   'E' explicit LONG  "L" qty = strategy.equity / close (the all-in idiom)
+//   'C' strategy.close("L")                        '.' nothing
+class Probe : public BacktestEngine {
+public:
+    Probe(double capital, const Instrument& ins, QtyType qty_type,
+          double qty_value, double comm_pct, double margin, int pyramiding,
+          bool enable_mc) {
+        initial_capital_ = capital;
+        syminfo_.pointvalue = ins.pointvalue;
+        syminfo_mintick_ = ins.mintick;
+        qty_step_ = ins.qty_step;
+        default_qty_type_ = qty_type;
+        default_qty_value_ = qty_value;
+        commission_type_ = CommissionType::PERCENT;
+        commission_value_ = comm_pct;
+        margin_long_ = margin;
+        margin_short_ = margin;
+        pyramiding_ = pyramiding;
+        slippage_ = 0;
+        process_orders_on_close_ = false;
+        margin_call_enabled_ = enable_mc;
+    }
+    std::string script;
+    double entry_qty_ = 1.0;
+
+    void on_bar(const Bar& /*bar*/) override {
+        if (bar_index_ < 0 || bar_index_ >= (int)script.size()) return;
+        switch (script[bar_index_]) {
+            case 'L': strategy_entry("L", true); break;
+            case 'S': strategy_entry("S", false); break;
+            case 'A': strategy_entry("L2", true); break;
+            case 'l': strategy_entry("L", true,  kNaN, kNaN, entry_qty_); break;
+            case 's': strategy_entry("S", false, kNaN, kNaN, entry_qty_); break;
+            case 'a': strategy_entry("L2", true, kNaN, kNaN, entry_qty_); break;
+            case 'B': strategy_entry("Buy", true, kNaN, kNaN, entry_qty_); break;
+            case 'E': {
+                // Pine: qty = strategy.equity / close, raw (sub-lot) value.
+                const double equity =
+                    current_equity() + open_profit(current_bar_.close);
+                strategy_entry("L", true, kNaN, kNaN,
+                               equity / current_bar_.close);
+                break;
+            }
+            case 'C': strategy_close("L"); break;
+            default: break;
+        }
+    }
+    using BacktestEngine::position_qty_;
+    using BacktestEngine::position_side_;
+    using BacktestEngine::pyramid_entries_;
+    using BacktestEngine::process_orders_on_close_;
+    double position_size() const { return signed_position_size(); }
+    double tick(double p) const { return round_to_mintick(p); }
+    int trades_with_entry_id(const std::string& id) const {
+        int n = 0;
+        for (const auto& t : trades_) if (t.entry_id == id) ++n;
+        return n;
+    }
+    int trades_with_exit_id(const std::string& id) const {
+        int n = 0;
+        for (const auto& t : trades_) if (t.exit_id == id) ++n;
+        return n;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// NQ gap probes (default fixed qty 1, margin 100, commission 0).
+
+// pin-afford-gapup: placement admits (376,410 <= 380,000); the fill gaps to
+// 19,225 (384,500 > 380,000) -> the entry is NOT filled. Pre-fix: FIXED default
+// sizing had no fill-time check at all and the engine opened it.
+void test_nq_gap_up_declined_at_fill() {
+    std::printf("-- NQ gap-up: admitted at placement, declined at fill --\n");
+    Probe eng(380000.0, kNQ, QtyType::FIXED, 1.0, 0.0, 100.0, 0, false);
+    eng.script = "L....";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 18820.50),                       // L placed: 376,410 ok
+        mk_bar(2000, 19225.0, 19240.0, 19200.0, 19230.0), // fill 384,500 > 380k
+        flat_bar(3000, 19230.0),
+        flat_bar(4000, 19230.0),
+        flat_bar(5000, 19230.0),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::FLAT);   // pre-fix: LONG
+    CHECK_NEAR(eng.position_size(), 0.0, 1e-9);
+    CHECK(eng.trade_count() == 0);
+}
+
+// pin-afford-gapdown: placement REJECTS (349,665 > 345,000) even though the
+// gapped-down fill at 17,100 (342,000) would have been affordable -> NOT
+// filled. TV uses the rounded signal close as a decline trigger, never as an
+// admission floor. Pre-fix: no placement check for default sizing -> LONG.
+void test_nq_gap_down_declined_at_placement() {
+    std::printf("-- NQ gap-down: declined at placement --\n");
+    Probe eng(345000.0, kNQ, QtyType::FIXED, 1.0, 0.0, 100.0, 0, false);
+    eng.script = "L....";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 17483.25),                       // 349,665 > 345,000
+        mk_bar(2000, 17100.0, 17120.0, 17080.0, 17110.0), // 342,000 would fit
+        flat_bar(3000, 17110.0),
+        flat_bar(4000, 17110.0),
+        flat_bar(5000, 17110.0),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::FLAT);   // pre-fix: LONG
+    CHECK(eng.trade_count() == 0);
+}
+
+// pin-afford-gapup-ctl: capital 1e6, same gap -> fills 1 @ 19,225.
+void test_nq_gap_up_control_fills() {
+    std::printf("-- NQ gap-up control (capital 1e6) fills --\n");
+    Probe eng(1000000.0, kNQ, QtyType::FIXED, 1.0, 0.0, 100.0, 0, false);
+    eng.script = "L....";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 18820.50),
+        mk_bar(2000, 19225.0, 19240.0, 19200.0, 19230.0),
+        flat_bar(3000, 19230.0),
+        flat_bar(4000, 19230.0),
+        flat_bar(5000, 19230.0),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::LONG);
+    CHECK_NEAR(eng.position_size(), 1.0, 1e-9);
+    CHECK(!eng.pyramid_entries_.empty());
+    if (!eng.pyramid_entries_.empty()) {
+        CHECK_NEAR(eng.pyramid_entries_.back().price, 19225.0, 1e-9);
+    }
+}
+
+// A favorable (down) gap on a default FIXED long: the fill notional is below
+// the admitted placement notional -> fills (the fill check can only add an
+// adverse-gap decline, never re-decline a placement admit).
+void test_nq_favorable_gap_fills() {
+    std::printf("-- NQ favorable gap fills --\n");
+    Probe eng(380000.0, kNQ, QtyType::FIXED, 1.0, 0.0, 100.0, 0, false);
+    eng.script = "L...";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 18820.50),                       // 376,410 <= 380,000
+        mk_bar(2000, 18800.0, 18810.0, 18790.0, 18805.0), // 376,000 fits
+        flat_bar(3000, 18805.0),
+        flat_bar(4000, 18805.0),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::LONG);
+    CHECK_NEAR(eng.position_size(), 1.0, 1e-9);
+}
+
+// Exact tie at placement AND fill (notional == equity): admitted (the guard is
+// a float guard only, and the comparison is strict).
+void test_nq_exact_tie_admits() {
+    std::printf("-- NQ exact tie admits --\n");
+    Probe eng(376410.0, kNQ, QtyType::FIXED, 1.0, 0.0, 100.0, 0, false);
+    eng.script = "L...";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 18820.50),                       // 376,410 == equity
+        flat_bar(2000, 18820.50),
+        flat_bar(3000, 18820.50),
+        flat_bar(4000, 18820.50),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::LONG);
+    CHECK_NEAR(eng.position_size(), 1.0, 1e-9);
+}
+
+// margin_pct scales the requirement: margin 50 halves it; margin 0 disables
+// the check (TV performs no margin simulation at 0).
+void test_nq_margin_scaling_and_zero_inert() {
+    std::printf("-- NQ margin 50 scales / margin 0 inert --\n");
+    {
+        Probe eng(190000.0, kNQ, QtyType::FIXED, 1.0, 0.0, 50.0, 0, false);
+        eng.script = "L...";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 18820.50),   // 376,410 * 0.5 = 188,205 <= 190,000
+            flat_bar(2000, 18820.50), flat_bar(3000, 18820.50),
+            flat_bar(4000, 18820.50),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::LONG);
+    }
+    {
+        Probe eng(180000.0, kNQ, QtyType::FIXED, 1.0, 0.0, 50.0, 0, false);
+        eng.script = "L...";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 18820.50),   // 188,205 > 180,000 -> declined
+            flat_bar(2000, 18820.50), flat_bar(3000, 18820.50),
+            flat_bar(4000, 18820.50),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::FLAT);
+    }
+    {
+        Probe eng(1000.0, kNQ, QtyType::FIXED, 1.0, 0.0, 0.0, 0, false);
+        eng.script = "L...";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 18820.50),   // margin 0: no check at all
+            mk_bar(2000, 19225.0, 19240.0, 19200.0, 19230.0),
+            flat_bar(3000, 19230.0), flat_bar(4000, 19230.0),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::LONG);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reversals.
+
+// pin-afford-reverse 2025-05-06 14:15Z shape: long 1 @ 19,808.25; the short
+// signal closes at 19,899.75 (cost 397,995). Realized equity 396,625 < cost,
+// but MTM = 396,625 + 91.50 * 20 = 398,455 >= cost -> TV filled the reversal.
+// Only the NEW side's qty is costed (the closing leg is not part of the
+// notional). Pre-fix (realized-only basis) would have declined it.
+void test_reversal_uses_mtm_equity_and_new_side_only() {
+    std::printf("-- reversal: MTM equity, new side only --\n");
+    Probe eng(396625.0, kNQ, QtyType::FIXED, 1.0, 0.0, 100.0, 0, false);
+    eng.script = "L.S..";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 19808.25),   // L placed (396,165 <= 396,625)
+        flat_bar(2000, 19808.25),   // L fills
+        flat_bar(3000, 19899.75),   // S placed: MTM 398,455 >= 397,995
+        flat_bar(4000, 19899.75),   // S fills: long closed, short opened
+        flat_bar(5000, 19899.75),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::SHORT);
+    CHECK_NEAR(eng.position_size(), -1.0, 1e-9);
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() == 1) {
+        CHECK(eng.get_trade(0).is_long);
+        CHECK(eng.get_trade(0).exit_id == "S");
+        CHECK_NEAR(eng.get_trade(0).exit_price, 19899.75, 1e-9);
+    }
+}
+
+// The reversal is admitted at placement (MTM 389,000 >= 384,000) but the fill
+// gaps to 19,500 (390,000 > 389,000): the ENTRY leg is dropped, the CLOSING
+// leg still executes at the fill under the entry's id.
+void test_reversal_declined_at_fill_closes_only() {
+    std::printf("-- reversal declined at fill: close leg only --\n");
+    Probe eng(385000.0, kNQ, QtyType::FIXED, 1.0, 0.0, 100.0, 0, false);
+    eng.script = "L.S...";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 19000.0),    // L placed (380,000 <= 385,000)
+        flat_bar(2000, 19000.0),    // L fills
+        flat_bar(3000, 19200.0),    // S placed: 384,000 <= MTM 389,000
+        mk_bar(4000, 19500.0, 19520.0, 19480.0, 19500.0), // 390,000 > 389,000
+        flat_bar(5000, 19500.0),
+        flat_bar(6000, 19500.0),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::FLAT);   // pre-fix: SHORT
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() == 1) {
+        CHECK(eng.get_trade(0).is_long);
+        CHECK(eng.get_trade(0).exit_id == "S");
+        CHECK_NEAR(eng.get_trade(0).exit_price, 19500.0, 1e-9);
+        CHECK_NEAR(eng.get_trade(0).qty, 1.0, 1e-9);
+    }
+    CHECK(eng.trades_with_entry_id("S") == 0);
+}
+
+// rampatel BTC 2025-05-12 07:15Z shape: a live short, equity below the price
+// of one contract, an opposite "Buy" entry. TV closed the short by "Buy"
+// @105,600 and opened no long. Pre-fix the engine opened the long, then
+// margin-called 4x the shortfall and cascaded (23,605 trades vs TV 1,486).
+// (a) margin calls disabled: the pure broker rule.
+// (b) margin calls enabled: no long is ever opened, no cascade.
+void test_rampatel_reversal_close_leg_executes_no_entry() {
+    std::printf("-- rampatel: reversal close leg executes, no entry --\n");
+    {
+        Probe eng(103572.0, kBTC, QtyType::FIXED, 1.0, 0.0, 100.0, 0, false);
+        eng.entry_qty_ = 1.0;
+        eng.script = "S.B...";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 100000.0),   // S placed (100,000 <= 103,572)
+            flat_bar(2000, 100000.0),   // S fills
+            flat_bar(3000, 105600.0),   // Buy placed: MTM 97,972 < 105,600
+            flat_bar(4000, 105600.0),   // Buy: closes the short, opens nothing
+            flat_bar(5000, 105600.0),
+            flat_bar(6000, 105600.0),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::FLAT);   // pre-fix: LONG
+        CHECK(eng.trade_count() == 1);
+        if (eng.trade_count() == 1) {
+            CHECK(!eng.get_trade(0).is_long);
+            CHECK(eng.get_trade(0).exit_id == "Buy");
+            CHECK_NEAR(eng.get_trade(0).exit_price, 105600.0, 1e-9);
+            CHECK_NEAR(eng.get_trade(0).pnl, -5600.0, 1e-6);
+        }
+        CHECK(eng.trades_with_entry_id("Buy") == 0);
+    }
+    {
+        Probe eng(103572.0, kBTC, QtyType::FIXED, 1.0, 0.0, 100.0, 0, true);
+        eng.entry_qty_ = 1.0;
+        eng.script = "S.B.......";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 100000.0),
+            flat_bar(2000, 100000.0),
+            flat_bar(3000, 105600.0),   // the short may be margin-sliced here
+            flat_bar(4000, 105600.0),   // Buy closes the remainder, no long
+            flat_bar(5000, 105600.0),
+            flat_bar(6000, 105600.0),
+            flat_bar(7000, 105600.0),
+            flat_bar(8000, 105600.0),
+            flat_bar(9000, 105600.0),
+            flat_bar(10000, 105600.0),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::FLAT);
+        CHECK(eng.trades_with_entry_id("Buy") == 0);    // pre-fix: cascade
+        CHECK(eng.trades_with_exit_id("Buy") == 1);
+        CHECK(eng.trade_count() <= 3);                  // no 4x cascade
+        for (int i = 0; i < eng.trade_count(); ++i) {
+            CHECK(!eng.get_trade(i).is_long);
+        }
+    }
+}
+
+// A same-bar strategy.close co-queued AFTER the declined reversal is a no-op
+// (the entry's closing leg already flattened the account): exactly one exit
+// row, attributed to the entry id.
+void test_declined_reversal_with_coqueued_close() {
+    std::printf("-- declined reversal + co-queued close: one exit row --\n");
+    class P2 : public Probe {
+    public:
+        using Probe::Probe;
+        void on_bar(const Bar& bar) override {
+            if (bar_index_ == 2) {
+                strategy_entry("S", false);
+                strategy_close("L");
+                return;
+            }
+            Probe::on_bar(bar);
+        }
+    };
+    P2 eng(385000.0, kNQ, QtyType::FIXED, 1.0, 0.0, 100.0, 0, false);
+    eng.script = "L.....";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 19000.0),
+        flat_bar(2000, 19000.0),
+        flat_bar(3000, 19200.0),
+        mk_bar(4000, 19500.0, 19520.0, 19480.0, 19500.0),
+        flat_bar(5000, 19500.0),
+        flat_bar(6000, 19500.0),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::FLAT);
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() == 1) {
+        CHECK(eng.get_trade(0).exit_id == "S");
+        CHECK_NEAR(eng.get_trade(0).qty, 1.0, 1e-9);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pyramiding adds: the RESULTING position (held + add) is costed.
+
+// masayanfx NQ1 2025-07-30 20:15Z: held 1, add 1 at 23,667.75 -> 2 * 23,667.75
+// * 20 = 946,710 > MTM 945,225 -> the add is dropped, the position stays 1.
+// Control at 950,000 admits it. Pre-fix: FIXED default adds were ungated.
+void test_pyramiding_add_costed_as_resulting_position() {
+    std::printf("-- pyramiding add costed held + add --\n");
+    {
+        // initial 943,870 + open profit 67.75 * 20 = MTM 945,225 at the add.
+        Probe eng(943870.0, kNQ, QtyType::FIXED, 1.0, 0.0, 100.0, 2, false);
+        eng.script = "L.A..";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 23600.0),    // L placed (472,000 fits)
+            flat_bar(2000, 23600.0),    // L fills
+            flat_bar(3000, 23667.75),   // L2 placed: 946,710 > 945,225
+            flat_bar(4000, 23667.75),
+            flat_bar(5000, 23667.75),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::LONG);
+        CHECK_NEAR(eng.position_size(), 1.0, 1e-9);     // pre-fix: 2
+        CHECK(eng.pyramid_entries_.size() == 1);
+        CHECK(eng.trades_with_entry_id("L2") == 0);
+    }
+    {
+        Probe eng(950000.0, kNQ, QtyType::FIXED, 1.0, 0.0, 100.0, 2, false);
+        eng.script = "L.A..";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 23600.0), flat_bar(2000, 23600.0),
+            flat_bar(3000, 23667.75), flat_bar(4000, 23667.75),
+            flat_bar(5000, 23667.75),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::LONG);
+        CHECK_NEAR(eng.position_size(), 2.0, 1e-9);
+        CHECK(eng.pyramid_entries_.size() == 2);
+    }
+}
+
+// Explicit-qty add, same arithmetic: held 60 + add 60 at 100 = 12,000 >
+// 10,000 -> dropped; held 60 + add 40 = 10,000 == equity -> admitted.
+void test_explicit_add_costed_as_resulting_position() {
+    std::printf("-- explicit add costed held + add --\n");
+    {
+        Probe eng(10000.0, kF, QtyType::FIXED, 1.0, 0.0, 100.0, 2, false);
+        eng.entry_qty_ = 60.0;
+        eng.script = "l.a..";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 100.0), flat_bar(2000, 100.0), flat_bar(3000, 100.0),
+            flat_bar(4000, 100.0), flat_bar(5000, 100.0),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK_NEAR(eng.position_size(), 60.0, 1e-9);    // pre-fix: 120
+    }
+    {
+        class P2 : public Probe {
+        public:
+            using Probe::Probe;
+            void on_bar(const Bar& bar) override {
+                if (bar_index_ == 2) {
+                    strategy_entry("L2", true, kNaN, kNaN, 40.0);
+                    return;
+                }
+                Probe::on_bar(bar);
+            }
+        };
+        P2 eng(10000.0, kF, QtyType::FIXED, 1.0, 0.0, 100.0, 2, false);
+        eng.entry_qty_ = 60.0;
+        eng.script = "l....";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 100.0), flat_bar(2000, 100.0), flat_bar(3000, 100.0),
+            flat_bar(4000, 100.0), flat_bar(5000, 100.0),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK_NEAR(eng.position_size(), 100.0, 1e-9);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Explicit qty = strategy.equity / close (the all-in idiom).
+
+// pin-admit-allin-xau 2025-04-08 13:30Z: E 1,998,000.02, close 3013.72, next
+// open 3013.745 (a sub-tick print that books at tick(3013.745)), lot step
+// 0.01, commission 0.05%. qty = 662.968 -> floored 662.96; 662.96 * 3013.75 =
+// 1,997,995.7 <= E -> ADMITTED. Pre-fix the engine costed the RAW 662.968 at
+// the fill (1,998,016 > E) and declined.
+void test_xauusd_floored_qty_admitted() {
+    std::printf("-- XAUUSD 662.96 admitted (lot-floored qty) --\n");
+    Probe eng(1998000.02, kXAU, QtyType::FIXED, 1.0, 0.05, 100.0, 0, false);
+    eng.script = "E....";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 3013.72),
+        mk_bar(2000, 3013.745, 3015.0, 3012.0, 3014.0),
+        flat_bar(3000, 3014.0),
+        flat_bar(4000, 3014.0),
+        flat_bar(5000, 3014.0),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::LONG);   // pre-fix: FLAT
+    CHECK_NEAR(eng.position_size(), 662.96, 1e-9);
+    CHECK(eng.pyramid_entries_.size() == 1);
+    if (!eng.pyramid_entries_.empty()) {
+        CHECK_NEAR(eng.pyramid_entries_.back().price,
+                   eng.tick(3013.745), 1e-9);
+    }
+}
+
+// pin-admit-allin-f: half-cent close 10.225 (E = 10,225 -> qty 1000), next
+// open 10.23: 1000 * 10.23 = 10,230 > E -> DECLINED. Pre-fix the fill gate's
+// max(E, qty * tick(close)) floor admitted it.
+void test_f_half_cent_declined() {
+    std::printf("-- F half-cent close: declined --\n");
+    Probe eng(10225.0, kF, QtyType::FIXED, 1.0, 0.05, 100.0, 0, false);
+    eng.script = "E....";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 10.225),
+        mk_bar(2000, 10.23, 10.25, 10.20, 10.24),
+        flat_bar(3000, 10.24),
+        flat_bar(4000, 10.24),
+        flat_bar(5000, 10.24),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::FLAT);   // pre-fix: LONG 1000
+    CHECK(eng.trade_count() == 0);
+}
+
+// The same idiom with an on-tick close and a no-gap fill admits the floored
+// quantity (positive control for the two cases above).
+void test_all_in_idiom_no_gap_admits() {
+    std::printf("-- all-in idiom, no gap: admits --\n");
+    Probe eng(10225.0, kF, QtyType::FIXED, 1.0, 0.05, 100.0, 0, false);
+    eng.script = "E...";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 10.23),      // qty = 999.51 -> 999 shares = 10,219.77
+        flat_bar(2000, 10.23),
+        flat_bar(3000, 10.23),
+        flat_bar(4000, 10.23),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::LONG);
+    CHECK_NEAR(eng.position_size(), 999.0, 1e-9);
+}
+
+// ---------------------------------------------------------------------------
+// CASH default sizing takes the same rule (no TV tape of its own; the broker
+// does not know how the quantity was derived): cash 20,000 on 10,000 capital
+// at margin 100 is 200 lots @100 = 20,000 > 10,000 -> declined; cash 5,000 ->
+// 50 lots admitted. (Re-pins test_margin_admission_gate's former CASH
+// exemption, which was a scope carve-out, not a TV observation.)
+void test_cash_default_sizing_gated() {
+    std::printf("-- CASH default sizing gated --\n");
+    {
+        Probe eng(10000.0, kF, QtyType::CASH, 20000.0, 0.0, 100.0, 0, false);
+        eng.script = "L...";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 100.0), flat_bar(2000, 100.0),
+            flat_bar(3000, 100.0), flat_bar(4000, 100.0),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::FLAT);
+    }
+    {
+        Probe eng(10000.0, kF, QtyType::CASH, 5000.0, 0.0, 100.0, 0, false);
+        eng.script = "L...";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 100.0), flat_bar(2000, 100.0),
+            flat_bar(3000, 100.0), flat_bar(4000, 100.0),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::LONG);
+        CHECK_NEAR(eng.position_size(), 50.0, 1e-9);
+    }
+}
+
+// Priced (stop) entries and process_orders_on_close are outside / a no-op for
+// this gate: a POOC fill books at tick(close(S)) == the placement price, so
+// the fill half can never decline what placement admitted.
+void test_pooc_no_double_decline() {
+    std::printf("-- POOC: fill half is a no-op --\n");
+    Probe eng(376410.0, kNQ, QtyType::FIXED, 1.0, 0.0, 100.0, 0, false);
+    eng.process_orders_on_close_ = true;
+    eng.script = "L..";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 18820.50),   // placed AND filled at the close, tie
+        mk_bar(2000, 19225.0, 19240.0, 19200.0, 19230.0),
+        flat_bar(3000, 19230.0),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::LONG);
+    CHECK_NEAR(eng.position_size(), 1.0, 1e-9);
+}
+
+}  // namespace
+
+int main() {
+    std::printf("--- market_entry_affordability ---\n");
+    test_nq_gap_up_declined_at_fill();
+    test_nq_gap_down_declined_at_placement();
+    test_nq_gap_up_control_fills();
+    test_nq_favorable_gap_fills();
+    test_nq_exact_tie_admits();
+    test_nq_margin_scaling_and_zero_inert();
+    test_reversal_uses_mtm_equity_and_new_side_only();
+    test_reversal_declined_at_fill_closes_only();
+    test_rampatel_reversal_close_leg_executes_no_entry();
+    test_declined_reversal_with_coqueued_close();
+    test_pyramiding_add_costed_as_resulting_position();
+    test_explicit_add_costed_as_resulting_position();
+    test_xauusd_floored_qty_admitted();
+    test_f_half_cent_declined();
+    test_all_in_idiom_no_gap_admits();
+    test_cash_default_sizing_gated();
+    test_pooc_no_double_decline();
+    std::printf("\n=== Results: %d passed, %d failed ===\n",
+                tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_oanda_day_stamp_grid.cpp
+++ b/tests/test_oanda_day_stamp_grid.cpp
@@ -1,0 +1,392 @@
+// The intraday request.security grid anchors at the symbol's DAY STAMP — the
+// instant its daily bar starts — not at the first traded minute of its
+// session. On OANDA that instant is the 17:00 ET forex roll for EVERY
+// instrument: EURUSD (1700-1700) opens on it, XAUUSD (1800-1700) trades from
+// one hour after it, yet TradingView aligns XAUUSD's "45" / "240" buckets at
+// 17:00 ET all the same.
+//
+// Pinned with `lab tv` on OANDA:XAUUSD 15, 2025-04-01..04-15 (pin-xau-grid-240
+// / -45 / -D: a strategy entering on ta.change(time("<tf>")) and closing the
+// next bar, so every entry stamp is a boundary + 15 min; tapes in UTC+8):
+//   "240": entries 09:15 / 13:15 / 17:15 / 21:15 (+8) = boundaries 01:00Z /
+//          05:00Z / 09:00Z / 13:00Z, plus 17:00Z and the day's first traded
+//          bar 22:00Z -> a 4h grid anchored at 21:00Z = 17:00 EDT (the
+//          17:00-21:00 ET bucket holds only the 18:00-20:45 trading);
+//   "45":  entries 09:00 / 09:45 / 10:30 / 11:15 (+8) = boundaries 00:45Z /
+//          01:30Z / 02:15Z / 03:00Z -> 21:00Z + k*45m (an 18:00 ET anchor
+//          would put them at 01:00Z / 01:45Z / 02:30Z);
+//   "D":   the day's first bar is 22:00Z (18:00 ET), the daily bucket starts
+//          at the 17:00 ET stamp and trading begins an hour later.
+// Family evidence: every 3commas-* XAUUSD DCA probe (request.security "240"
+// RSI gate) enters on the 17:00-ET grid on TV and on the 18:00-ET grid in the
+// engine, the DCA legs agreeing to 1e-6 once the grid does.
+//
+// Rules pinned here:
+//   A. "240" from 15m on NY 1800-1700 (EDT): buckets open 21:00Z / 01:00Z /
+//      05:00Z / 09:00Z / 13:00Z / 17:00Z; the first holds the 12 bars
+//      22:00Z-00:45Z and is labelled 21:00Z; tf_change agrees;
+//   B. "45": buckets 21:00Z / 21:45Z / 22:30Z / 23:15Z / 00:00Z ...; the first
+//      traded bar 22:00Z sits in the 21:45Z bucket;
+//   C. the same in EST (17:00 EST = 22:00Z; first traded bar 23:00Z);
+//   D. the 1800-1700 SESSION-DAY model is unchanged: the D bar still opens on
+//      the 18:00 ET session open and closes 17:00 ET, the week on Sunday
+//      18:00 ET, the day ordinal rolls between 16:45 and 18:00 and not at UTC
+//      midnight, and OANDA's 17:00-ET-stamped native daily bars still route
+//      to the session they cover; the D bucket completes on the session's
+//      last chart bar (16:45 ET), as it does on 1700-1700;
+//   E. sessions whose open IS the stamp keep their grid: OANDA 1700-1700 (the
+//      same grid as XAUUSD), CME 1700-1600 CT, NYSE 0930-1600, NSE 0915-1530,
+//      24x7 UTC.
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include <pineforge/bar.hpp>
+#include <pineforge/timeframe.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                        \
+        if (!(expr)) {                                                          \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                     \
+        } else {                                                                \
+            ++tests_passed;                                                     \
+        }                                                                       \
+    } while (0)
+
+#define CHECK_EQ_MS(actual, expected)                                          \
+    do {                                                                        \
+        const int64_t _a = (actual), _e = (expected);                          \
+        if (_a != _e) {                                                         \
+            std::printf("  FAIL  %s:%d  %s == %s  (got %lld, want %lld)\n",     \
+                        __FILE__, __LINE__, #actual, #expected,                 \
+                        (long long)_a, (long long)_e);                          \
+            ++tests_failed;                                                     \
+        } else {                                                                \
+            ++tests_passed;                                                     \
+        }                                                                       \
+    } while (0)
+
+namespace {
+
+// Unix ms of a UTC civil date-time (Howard Hinnant's days_from_civil).
+int64_t utc_ms(int y, int m, int d, int h = 0, int mi = 0) {
+    y -= (m <= 2);
+    long era = (y >= 0 ? y : y - 399) / 400;
+    unsigned yoe = (unsigned)(y - era * 400);
+    unsigned doy = (153u * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;
+    unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    long days = era * 146097L + (long)doe - 719468L;
+    return (static_cast<int64_t>(days) * 86400 + h * 3600 + mi * 60) * 1000;
+}
+
+const std::string NY  = "America/New_York";
+const std::string CHI = "America/Chicago";
+const std::string IST = "Asia/Kolkata";
+const std::string UTC = "UTC";
+const std::string XAU = "1800-1700";          // OANDA metals / CFDs
+const std::string FX  = "1700-1700";          // OANDA forex
+const std::string CME = "1700-1600";          // CME Globex (Chicago)
+const std::string RTH = "0930-1600";          // NYSE / NASDAQ
+const std::string NSE = "0915-1530";          // NSE India
+const int64_t k15m = 15 * 60 * 1000;
+const int64_t k1h  = 60 * 60 * 1000;
+
+Bar bar_at(int64_t ts) {
+    Bar b;
+    b.timestamp = ts;
+    b.open = 100.0; b.high = 101.0; b.low = 99.0; b.close = 100.0;
+    b.volume = 1.0;
+    return b;
+}
+
+struct Completion {
+    int64_t at;         // input bar that finalized the bucket
+    int64_t bucket_ts;  // label of the completed HTF bar
+    int subs;
+};
+
+std::vector<Completion> drive(TimeframeAggregator& agg, const std::vector<int64_t>& ts) {
+    std::vector<Completion> out;
+    for (int64_t t : ts) {
+        AggregatedBar r = agg.feed(bar_at(t));
+        if (r.is_complete) out.push_back({t, r.bar.timestamp, r.sub_bar_count});
+    }
+    return out;
+}
+
+// One 1800-1700 session of 15m bars: `open_z` (18:00 ET) .. open_z + 22:45
+// (16:45 ET), 92 bars; nothing trades in the 17:00-18:00 ET break.
+void xau_session(std::vector<int64_t>& v, int64_t open_z) {
+    for (int i = 0; i < 92; ++i) v.push_back(open_z + i * k15m);
+}
+
+// ─── A. "240" on OANDA:XAUUSD, EDT ────────────────────────────────────────────
+
+void test_xau_240_grid_edt() {
+    std::printf("A. XAUUSD '240' anchors at 17:00 EDT = 21:00Z\n");
+    // Mon 2025-03-31 18:00 EDT = 22:00Z opens the Tuesday session; its day
+    // stamp is 17:00 EDT = 21:00Z.
+    const int64_t stamp = utc_ms(2025, 3, 31, 21, 0);
+    const int64_t open  = utc_ms(2025, 3, 31, 22, 0);
+    TimeframeAggregator agg("240", "15", NY, XAU);
+    // Grid opens.
+    CHECK_EQ_MS(agg.bucket_open_ms(open), stamp);
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 0, 45)), stamp);
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 1, 0)), utc_ms(2025, 4, 1, 1, 0));
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 4, 45)), utc_ms(2025, 4, 1, 1, 0));
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 12, 15)), utc_ms(2025, 4, 1, 9, 0));
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 20, 45)), utc_ms(2025, 4, 1, 17, 0));
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 22, 0)), utc_ms(2025, 4, 1, 21, 0));
+    // The label of the day's first bucket is the grid open, not the first
+    // traded sub-bar (finding 473).
+    CHECK_EQ_MS(agg.bar_label_ms(open), stamp);
+    // tf_change fires on the pinned boundaries ...
+    CHECK(tf_change(utc_ms(2025, 4, 1, 0, 45), utc_ms(2025, 4, 1, 1, 0), "240", NY, XAU));
+    CHECK(tf_change(utc_ms(2025, 4, 1, 4, 45), utc_ms(2025, 4, 1, 5, 0), "240", NY, XAU));
+    CHECK(tf_change(utc_ms(2025, 4, 1, 8, 45), utc_ms(2025, 4, 1, 9, 0), "240", NY, XAU));
+    CHECK(tf_change(utc_ms(2025, 4, 1, 12, 45), utc_ms(2025, 4, 1, 13, 0), "240", NY, XAU));
+    CHECK(tf_change(utc_ms(2025, 4, 1, 16, 45), utc_ms(2025, 4, 1, 17, 0), "240", NY, XAU));
+    CHECK(tf_change(utc_ms(2025, 4, 1, 20, 45), utc_ms(2025, 4, 1, 22, 0), "240", NY, XAU));
+    // ... and not on the 18:00-ET grid (22:00Z / 02:00Z / ...).
+    CHECK(!tf_change(utc_ms(2025, 4, 1, 1, 45), utc_ms(2025, 4, 1, 2, 0), "240", NY, XAU));
+    CHECK(!tf_change(utc_ms(2025, 4, 1, 5, 45), utc_ms(2025, 4, 1, 6, 0), "240", NY, XAU));
+    CHECK(!tf_change(utc_ms(2025, 4, 1, 1, 0), utc_ms(2025, 4, 1, 1, 15), "240", NY, XAU));
+    // Driven over two sessions: six buckets per session, the 17:00-21:00 ET
+    // bucket holding the 12 traded sub-bars (finalized on the 00:45Z bar whose
+    // close reaches the bucket end, finding 467), the others 16.
+    std::vector<int64_t> ts;
+    xau_session(ts, open);
+    xau_session(ts, utc_ms(2025, 4, 1, 22, 0));
+    auto c = drive(agg, ts);
+    CHECK(c.size() == 12);
+    const int64_t want[12] = {
+        utc_ms(2025, 3, 31, 21, 0), utc_ms(2025, 4, 1, 1, 0), utc_ms(2025, 4, 1, 5, 0),
+        utc_ms(2025, 4, 1, 9, 0),   utc_ms(2025, 4, 1, 13, 0), utc_ms(2025, 4, 1, 17, 0),
+        utc_ms(2025, 4, 1, 21, 0),  utc_ms(2025, 4, 2, 1, 0),  utc_ms(2025, 4, 2, 5, 0),
+        utc_ms(2025, 4, 2, 9, 0),   utc_ms(2025, 4, 2, 13, 0), utc_ms(2025, 4, 2, 17, 0),
+    };
+    for (size_t i = 0; i < c.size() && i < 12; ++i) {
+        CHECK_EQ_MS(c[i].bucket_ts, want[i]);
+        CHECK(c[i].subs == (i % 6 == 0 ? 12 : 16));
+        CHECK_EQ_MS(c[i].at, want[i] + 4 * k1h - k15m);   // bucket end - 15m
+    }
+}
+
+// ─── B. "45" on OANDA:XAUUSD, EDT ─────────────────────────────────────────────
+
+void test_xau_45_grid_edt() {
+    std::printf("B. XAUUSD '45' grid 21:00Z / 21:45Z / 22:30Z / 23:15Z ...\n");
+    const int64_t open = utc_ms(2025, 3, 31, 22, 0);
+    TimeframeAggregator agg("45", "15", NY, XAU);
+    CHECK_EQ_MS(agg.bucket_open_ms(open), utc_ms(2025, 3, 31, 21, 45));
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 3, 31, 22, 15)), utc_ms(2025, 3, 31, 21, 45));
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 3, 31, 22, 30)), utc_ms(2025, 3, 31, 22, 30));
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 3, 31, 23, 15)), utc_ms(2025, 3, 31, 23, 15));
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 0, 0)), utc_ms(2025, 4, 1, 0, 0));
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 1, 0)), utc_ms(2025, 4, 1, 0, 45));
+    CHECK_EQ_MS(agg.bar_label_ms(open), utc_ms(2025, 3, 31, 21, 45));
+    CHECK(tf_change(utc_ms(2025, 3, 31, 22, 15), utc_ms(2025, 3, 31, 22, 30), "45", NY, XAU));
+    CHECK(tf_change(utc_ms(2025, 3, 31, 23, 0), utc_ms(2025, 3, 31, 23, 15), "45", NY, XAU));
+    CHECK(tf_change(utc_ms(2025, 3, 31, 23, 45), utc_ms(2025, 4, 1, 0, 0), "45", NY, XAU));
+    CHECK(tf_change(utc_ms(2025, 4, 1, 2, 0), utc_ms(2025, 4, 1, 2, 15), "45", NY, XAU));
+    CHECK(tf_change(utc_ms(2025, 4, 1, 2, 45), utc_ms(2025, 4, 1, 3, 0), "45", NY, XAU));
+    // The 18:00-ET grid (22:00Z / 22:45Z / 23:30Z) is not a boundary.
+    CHECK(!tf_change(utc_ms(2025, 3, 31, 22, 0), utc_ms(2025, 3, 31, 22, 15), "45", NY, XAU));
+    CHECK(!tf_change(utc_ms(2025, 3, 31, 22, 30), utc_ms(2025, 3, 31, 22, 45), "45", NY, XAU));
+    CHECK(!tf_change(utc_ms(2025, 3, 31, 23, 15), utc_ms(2025, 3, 31, 23, 30), "45", NY, XAU));
+    // Driven over one session: 31 buckets (21:45Z .. 20:15Z next day), the
+    // first holding two sub-bars (22:00Z, 22:15Z) and finalized on 22:15Z.
+    std::vector<int64_t> ts;
+    xau_session(ts, open);
+    auto c = drive(agg, ts);
+    CHECK(c.size() == 31);
+    if (!c.empty()) {
+        CHECK_EQ_MS(c.front().bucket_ts, utc_ms(2025, 3, 31, 21, 45));
+        CHECK(c.front().subs == 2);
+        CHECK_EQ_MS(c.front().at, utc_ms(2025, 3, 31, 22, 15));
+        CHECK_EQ_MS(c.back().bucket_ts, utc_ms(2025, 4, 1, 20, 15));
+        CHECK(c.back().subs == 3);
+    }
+    for (size_t i = 1; i < c.size(); ++i) {
+        CHECK_EQ_MS(c[i].bucket_ts, utc_ms(2025, 3, 31, 21, 45) + static_cast<int64_t>(i) * 45 * 60000);
+        CHECK(c[i].subs == 3);
+    }
+}
+
+// ─── C. EST ───────────────────────────────────────────────────────────────────
+
+void test_xau_240_grid_est() {
+    std::printf("C. XAUUSD '240' in EST anchors at 22:00Z\n");
+    // Mon 2025-01-13 18:00 EST = 23:00Z; stamp 17:00 EST = 22:00Z.
+    const int64_t stamp = utc_ms(2025, 1, 13, 22, 0);
+    const int64_t open  = utc_ms(2025, 1, 13, 23, 0);
+    TimeframeAggregator agg("240", "15", NY, XAU);
+    CHECK_EQ_MS(agg.bucket_open_ms(open), stamp);
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 1, 14, 1, 45)), stamp);
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 1, 14, 2, 0)), utc_ms(2025, 1, 14, 2, 0));
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 1, 14, 21, 45)), utc_ms(2025, 1, 14, 18, 0));
+    CHECK(tf_change(utc_ms(2025, 1, 14, 1, 45), utc_ms(2025, 1, 14, 2, 0), "240", NY, XAU));
+    CHECK(tf_change(utc_ms(2025, 1, 14, 21, 45), utc_ms(2025, 1, 14, 23, 0), "240", NY, XAU));
+    CHECK(!tf_change(utc_ms(2025, 1, 14, 2, 45), utc_ms(2025, 1, 14, 3, 0), "240", NY, XAU));
+    TimeframeAggregator q("45", "15", NY, XAU);
+    CHECK_EQ_MS(q.bucket_open_ms(open), utc_ms(2025, 1, 13, 22, 45));
+    CHECK_EQ_MS(q.bucket_open_ms(utc_ms(2025, 1, 13, 23, 30)), utc_ms(2025, 1, 13, 23, 30));
+}
+
+// ─── D. The 1800-1700 session-day model is untouched ─────────────────────────
+
+void test_xau_session_day_model_unchanged() {
+    std::printf("D. 1800-1700 session-day anchors unchanged; D completes on 16:45 ET\n");
+    const int64_t tue_0300 = utc_ms(2025, 4, 1, 7, 0);   // Tue 03:00 EDT
+    CHECK_EQ_MS(session_period_open_ms(tue_0300, NY, XAU, CalendarPeriod::DAY),
+                utc_ms(2025, 3, 31, 22, 0));                // Mon 18:00 EDT
+    CHECK_EQ_MS(session_period_close_ms(tue_0300, NY, XAU, CalendarPeriod::DAY),
+                utc_ms(2025, 4, 1, 21, 0));                 // Tue 17:00 EDT
+    CHECK_EQ_MS(session_period_open_ms(tue_0300, NY, XAU, CalendarPeriod::WEEK),
+                utc_ms(2025, 3, 30, 22, 0));                // Sun 18:00 EDT
+    CHECK_EQ_MS(session_period_close_ms(tue_0300, NY, XAU, CalendarPeriod::WEEK),
+                utc_ms(2025, 4, 6, 22, 0));
+    CHECK_EQ_MS(session_period_open_ms(tue_0300, NY, XAU, CalendarPeriod::MONTH),
+                utc_ms(2025, 3, 31, 22, 0));                // April's first session
+    // The day ordinal rolls between 16:45 and 18:00 ET, not at UTC midnight.
+    CHECK(session_day_index(utc_ms(2025, 4, 1, 20, 45), NY, XAU)
+          != session_day_index(utc_ms(2025, 4, 1, 22, 0), NY, XAU));
+    CHECK(session_day_index(utc_ms(2025, 3, 31, 23, 45), NY, XAU)
+          == session_day_index(utc_ms(2025, 4, 1, 0, 0), NY, XAU));
+    CHECK(session_day_index(utc_ms(2025, 3, 31, 22, 0), NY, XAU)
+          == session_day_index(utc_ms(2025, 4, 1, 20, 45), NY, XAU));
+    CHECK(tf_change(utc_ms(2025, 4, 1, 20, 45), utc_ms(2025, 4, 1, 22, 0), "D", NY, XAU));
+    CHECK(!tf_change(utc_ms(2025, 3, 31, 23, 45), utc_ms(2025, 4, 1, 0, 0), "D", NY, XAU));
+    CHECK(!tf_change(utc_ms(2025, 3, 31, 22, 0), utc_ms(2025, 4, 1, 20, 45), "D", NY, XAU));
+    // OANDA's native daily bars are stamped at the 17:00 ET break: the aux
+    // routing key (engine_aux_security.cpp) still resolves them to the
+    // session they cover, whether the stamp sits on the roll or inside the
+    // break.
+    for (int mi : {0, 30, 59}) {
+        const int64_t stamp = utc_ms(2025, 3, 31, 21, mi);
+        CHECK_EQ_MS(session_period_open_ms(session_covered_instant_ms(stamp, NY, XAU),
+                                           NY, XAU, CalendarPeriod::DAY),
+                    utc_ms(2025, 3, 31, 22, 0));
+        CHECK_EQ_MS(session_period_open_ms(session_covered_instant_ms(stamp, NY, XAU),
+                                           NY, XAU, CalendarPeriod::WEEK),
+                    utc_ms(2025, 3, 30, 22, 0));
+    }
+    // A stamp past the close still rolls to the next session's open.
+    CHECK_EQ_MS(session_covered_instant_ms(utc_ms(2025, 4, 1, 21, 0), NY, XAU),
+                utc_ms(2025, 4, 1, 22, 0));
+    CHECK_EQ_MS(session_covered_instant_ms(utc_ms(2025, 4, 1, 12, 0), NY, XAU),
+                utc_ms(2025, 4, 1, 12, 0));
+    // The D bucket is labelled by the session open and completes on the
+    // session's last chart bar (16:45 ET, whose close is the 17:00 stamp),
+    // exactly as the 1700-1700 forex day does — not a session late.
+    TimeframeAggregator d("D", "15", NY, XAU);
+    CHECK_EQ_MS(d.bar_label_ms(utc_ms(2025, 3, 31, 22, 0)), utc_ms(2025, 3, 31, 22, 0));
+    std::vector<int64_t> ts;
+    xau_session(ts, utc_ms(2025, 3, 31, 22, 0));
+    xau_session(ts, utc_ms(2025, 4, 1, 22, 0));
+    auto c = drive(d, ts);
+    CHECK(c.size() == 2);
+    if (c.size() == 2) {
+        CHECK_EQ_MS(c[0].bucket_ts, utc_ms(2025, 3, 31, 22, 0));
+        CHECK_EQ_MS(c[0].at, utc_ms(2025, 4, 1, 20, 45));
+        CHECK(c[0].subs == 92);
+        CHECK_EQ_MS(c[1].bucket_ts, utc_ms(2025, 4, 1, 22, 0));
+        CHECK_EQ_MS(c[1].at, utc_ms(2025, 4, 2, 20, 45));
+    }
+    TimeframeAggregator dfx("D", "15", NY, FX);
+    std::vector<int64_t> fx;
+    for (int i = 0; i < 96; ++i) fx.push_back(utc_ms(2025, 3, 31, 21, 0) + i * k15m);
+    auto cfx = drive(dfx, fx);
+    CHECK(cfx.size() == 1);
+    if (!cfx.empty()) CHECK_EQ_MS(cfx[0].at, utc_ms(2025, 4, 1, 20, 45));
+    // Day-of-week suffix does not disturb the stamp.
+    TimeframeAggregator w("240", "15", NY, "1800-1700:23456");
+    CHECK_EQ_MS(w.bucket_open_ms(utc_ms(2025, 3, 31, 22, 0)), utc_ms(2025, 3, 31, 21, 0));
+}
+
+// ─── E. Sessions whose open is the stamp keep their grid ─────────────────────
+
+void test_open_equals_stamp_grids_unchanged() {
+    std::printf("E. OANDA 1700-1700 / CME 1700-1600 / NYSE / NSE / 24x7 grids unchanged\n");
+    // OANDA forex: 17:00 EDT = 21:00Z anchors '240' and '45' — the very grid
+    // XAUUSD now shares.
+    {
+        TimeframeAggregator fx("240", "15", NY, FX), xau("240", "15", NY, XAU);
+        CHECK_EQ_MS(fx.bucket_open_ms(utc_ms(2025, 3, 31, 21, 0)), utc_ms(2025, 3, 31, 21, 0));
+        CHECK_EQ_MS(fx.bucket_open_ms(utc_ms(2025, 4, 1, 0, 45)), utc_ms(2025, 3, 31, 21, 0));
+        CHECK_EQ_MS(fx.bucket_open_ms(utc_ms(2025, 4, 1, 1, 0)), utc_ms(2025, 4, 1, 1, 0));
+        CHECK(tf_change(utc_ms(2025, 4, 1, 0, 45), utc_ms(2025, 4, 1, 1, 0), "240", NY, FX));
+        CHECK(!tf_change(utc_ms(2025, 4, 1, 1, 45), utc_ms(2025, 4, 1, 2, 0), "240", NY, FX));
+        TimeframeAggregator fx45("45", "15", NY, FX), xau45("45", "15", NY, XAU);
+        CHECK_EQ_MS(fx45.bucket_open_ms(utc_ms(2025, 3, 31, 22, 15)), utc_ms(2025, 3, 31, 21, 45));
+        int same = 0;
+        for (int64_t t = utc_ms(2025, 3, 30, 21, 0); t < utc_ms(2025, 4, 4, 21, 0); t += k15m) {
+            if (fx.bucket_open_ms(t) == xau.bucket_open_ms(t)
+                && fx45.bucket_open_ms(t) == xau45.bucket_open_ms(t)) ++same;
+            CHECK(tf_change(t, t + k15m, "240", NY, FX) == tf_change(t, t + k15m, "240", NY, XAU));
+        }
+        CHECK(same == 5 * 96);
+        // Winter: 17:00 EST = 22:00Z.
+        CHECK_EQ_MS(fx.bucket_open_ms(utc_ms(2025, 1, 14, 1, 45)), utc_ms(2025, 1, 13, 22, 0));
+    }
+    // CME Globex: 17:00 CDT = 22:00Z anchors '240' (22:00Z / 02:00Z / ...).
+    {
+        TimeframeAggregator agg("240", "15", CHI, CME);
+        CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 3, 31, 22, 0)), utc_ms(2025, 3, 31, 22, 0));
+        CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 1, 45)), utc_ms(2025, 3, 31, 22, 0));
+        CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 2, 0)), utc_ms(2025, 4, 1, 2, 0));
+        CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 20, 45)), utc_ms(2025, 4, 1, 18, 0));
+        CHECK(tf_change(utc_ms(2025, 4, 1, 1, 45), utc_ms(2025, 4, 1, 2, 0), "240", CHI, CME));
+        CHECK(!tf_change(utc_ms(2025, 4, 1, 0, 45), utc_ms(2025, 4, 1, 1, 0), "240", CHI, CME));
+        TimeframeAggregator h("60", "15", CHI, CME);
+        CHECK_EQ_MS(h.bucket_open_ms(utc_ms(2025, 3, 31, 22, 30)), utc_ms(2025, 3, 31, 22, 0));
+        CHECK_EQ_MS(session_period_open_ms(utc_ms(2025, 4, 1, 7, 0), CHI, CME, CalendarPeriod::DAY),
+                    utc_ms(2025, 3, 31, 22, 0));
+        CHECK_EQ_MS(session_period_close_ms(utc_ms(2025, 4, 1, 7, 0), CHI, CME, CalendarPeriod::DAY),
+                    utc_ms(2025, 4, 1, 21, 0));
+    }
+    // NYSE RTH: 09:30 EDT = 13:30Z anchors '60' / '240'.
+    {
+        TimeframeAggregator h("60", "15", NY, RTH), q("240", "15", NY, RTH);
+        CHECK_EQ_MS(h.bucket_open_ms(utc_ms(2025, 4, 1, 14, 0)), utc_ms(2025, 4, 1, 13, 30));
+        CHECK_EQ_MS(h.bucket_open_ms(utc_ms(2025, 4, 1, 13, 30)), utc_ms(2025, 4, 1, 13, 30));
+        CHECK_EQ_MS(q.bucket_open_ms(utc_ms(2025, 4, 1, 17, 45)), utc_ms(2025, 4, 1, 17, 30));
+        CHECK(tf_change(utc_ms(2025, 4, 1, 14, 15), utc_ms(2025, 4, 1, 14, 30), "60", NY, RTH));
+        CHECK(!tf_change(utc_ms(2025, 4, 1, 13, 45), utc_ms(2025, 4, 1, 14, 0), "60", NY, RTH));
+    }
+    // NSE: 09:15 IST = 03:45Z anchors '60'.
+    {
+        TimeframeAggregator h("60", "15", IST, NSE);
+        CHECK_EQ_MS(h.bucket_open_ms(utc_ms(2025, 4, 1, 4, 0)), utc_ms(2025, 4, 1, 3, 45));
+        CHECK_EQ_MS(h.bucket_open_ms(utc_ms(2025, 4, 1, 4, 45)), utc_ms(2025, 4, 1, 4, 45));
+        CHECK(tf_change(utc_ms(2025, 4, 1, 4, 30), utc_ms(2025, 4, 1, 4, 45), "60", IST, NSE));
+        CHECK(!tf_change(utc_ms(2025, 4, 1, 3, 45), utc_ms(2025, 4, 1, 4, 0), "60", IST, NSE));
+    }
+    // 24x7 UTC: the epoch grid.
+    {
+        TimeframeAggregator q("240", "15", UTC, "24x7"), q0("240", "15");
+        CHECK_EQ_MS(q.bucket_open_ms(utc_ms(2025, 4, 1, 1, 0)), utc_ms(2025, 4, 1, 0, 0));
+        CHECK_EQ_MS(q.bucket_open_ms(utc_ms(2025, 4, 1, 1, 0)), q0.bucket_open_ms(utc_ms(2025, 4, 1, 1, 0)));
+        CHECK(tf_change(utc_ms(2025, 4, 1, 3, 45), utc_ms(2025, 4, 1, 4, 0), "240", UTC, "24x7"));
+        CHECK(!tf_change(utc_ms(2025, 4, 1, 0, 45), utc_ms(2025, 4, 1, 1, 0), "240", UTC, "24x7"));
+    }
+}
+
+}  // namespace
+
+int main() {
+    std::printf("=== OANDA day-stamp intraday grid tests ===\n\n");
+    test_xau_240_grid_edt();
+    test_xau_45_grid_edt();
+    test_xau_240_grid_est();
+    test_xau_session_day_model_unchanged();
+    test_open_equals_stamp_grids_unchanged();
+    std::printf("\n=== Results: %d passed, %d failed ===\n", tests_passed, tests_failed);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/tests/test_oanda_day_stamp_grid.cpp
+++ b/tests/test_oanda_day_stamp_grid.cpp
@@ -28,12 +28,17 @@
 //   B. "45": buckets 21:00Z / 21:45Z / 22:30Z / 23:15Z / 00:00Z ...; the first
 //      traded bar 22:00Z sits in the 21:45Z bucket;
 //   C. the same in EST (17:00 EST = 22:00Z; first traded bar 23:00Z);
-//   D. the 1800-1700 SESSION-DAY model is unchanged: the D bar still opens on
-//      the 18:00 ET session open and closes 17:00 ET, the week on Sunday
-//      18:00 ET, the day ordinal rolls between 16:45 and 18:00 and not at UTC
-//      midnight, and OANDA's 17:00-ET-stamped native daily bars still route
-//      to the session they cover; the D bucket completes on the session's
-//      last chart bar (16:45 ET), as it does on 1700-1700;
+//   D. the 1800-1700 SESSION-DAY model: the D bar OPENS at the 17:00 ET stamp
+//      (pin-time-hours, OANDA:XAUUSD 15, 2025-04-01..07-01: time("D") is
+//      17:00 ET on 147/147 entries -- see test_pine_time_day_stamp_grid) and
+//      closes at the next 17:00 ET; the week opens on the Sunday stamp and
+//      the month on its first session-day's stamp (extrapolated from the D
+//      pin: a period opens where its first D bar does, as 1700-1700 already
+//      does -- no W/M tape); the day ordinal rolls between 16:45 and 18:00
+//      and not at UTC midnight, and OANDA's 17:00-ET-stamped native daily
+//      bars still route to the session they cover; the D bucket is labelled
+//      by the stamp and completes on the session's last chart bar (16:45
+//      ET), as it does on 1700-1700;
 //   E. sessions whose open IS the stamp keep their grid: OANDA 1700-1700 (the
 //      same grid as XAUUSD), CME 1700-1600 CT, NYSE 0930-1600, NSE 0915-1530,
 //      24x7 UTC.
@@ -242,18 +247,27 @@ void test_xau_240_grid_est() {
 // ─── D. The 1800-1700 session-day model is untouched ─────────────────────────
 
 void test_xau_session_day_model_unchanged() {
-    std::printf("D. 1800-1700 session-day anchors unchanged; D completes on 16:45 ET\n");
+    std::printf("D. 1800-1700 session-day anchors: D opens on the 17:00 ET stamp, completes on 16:45 ET\n");
     const int64_t tue_0300 = utc_ms(2025, 4, 1, 7, 0);   // Tue 03:00 EDT
+    // The D bar opens at the stamp (pin-time-hours: time("D") == 17:00 ET),
+    // an hour before the 18:00 ET session open, and closes at the next stamp.
     CHECK_EQ_MS(session_period_open_ms(tue_0300, NY, XAU, CalendarPeriod::DAY),
-                utc_ms(2025, 3, 31, 22, 0));                // Mon 18:00 EDT
+                utc_ms(2025, 3, 31, 21, 0));                // Mon 17:00 EDT
     CHECK_EQ_MS(session_period_close_ms(tue_0300, NY, XAU, CalendarPeriod::DAY),
                 utc_ms(2025, 4, 1, 21, 0));                 // Tue 17:00 EDT
+    // W / M open on their first session-day's stamp (extrapolated from the D
+    // pin, the 1700-1700 relation; no W/M tape) and close on the next one's.
     CHECK_EQ_MS(session_period_open_ms(tue_0300, NY, XAU, CalendarPeriod::WEEK),
-                utc_ms(2025, 3, 30, 22, 0));                // Sun 18:00 EDT
+                utc_ms(2025, 3, 30, 21, 0));                // Sun 17:00 EDT
     CHECK_EQ_MS(session_period_close_ms(tue_0300, NY, XAU, CalendarPeriod::WEEK),
-                utc_ms(2025, 4, 6, 22, 0));
+                utc_ms(2025, 4, 6, 21, 0));
     CHECK_EQ_MS(session_period_open_ms(tue_0300, NY, XAU, CalendarPeriod::MONTH),
-                utc_ms(2025, 3, 31, 22, 0));                // April's first session
+                utc_ms(2025, 3, 31, 21, 0));                // April's first session
+    CHECK_EQ_MS(session_period_close_ms(tue_0300, NY, XAU, CalendarPeriod::MONTH),
+                utc_ms(2025, 4, 30, 21, 0));                // May 1 is a Thursday
+    // The week's last traded close is still Friday 17:00 ET.
+    CHECK_EQ_MS(session_period_last_traded_close_ms(tue_0300, NY, XAU, CalendarPeriod::WEEK),
+                utc_ms(2025, 4, 4, 21, 0));
     // The day ordinal rolls between 16:45 and 18:00 ET, not at UTC midnight.
     CHECK(session_day_index(utc_ms(2025, 4, 1, 20, 45), NY, XAU)
           != session_day_index(utc_ms(2025, 4, 1, 22, 0), NY, XAU));
@@ -270,33 +284,39 @@ void test_xau_session_day_model_unchanged() {
     // break.
     for (int mi : {0, 30, 59}) {
         const int64_t stamp = utc_ms(2025, 3, 31, 21, mi);
+        CHECK_EQ_MS(session_covered_instant_ms(stamp, NY, XAU), utc_ms(2025, 3, 31, 22, 0));
         CHECK_EQ_MS(session_period_open_ms(session_covered_instant_ms(stamp, NY, XAU),
                                            NY, XAU, CalendarPeriod::DAY),
-                    utc_ms(2025, 3, 31, 22, 0));
+                    utc_ms(2025, 3, 31, 21, 0));
         CHECK_EQ_MS(session_period_open_ms(session_covered_instant_ms(stamp, NY, XAU),
                                            NY, XAU, CalendarPeriod::WEEK),
-                    utc_ms(2025, 3, 30, 22, 0));
+                    utc_ms(2025, 3, 30, 21, 0));
+        // The same key the 1m content bars of that session resolve to.
+        CHECK_EQ_MS(session_period_open_ms(utc_ms(2025, 4, 1, 12, 0), NY, XAU, CalendarPeriod::DAY),
+                    utc_ms(2025, 3, 31, 21, 0));
     }
     // A stamp past the close still rolls to the next session's open.
     CHECK_EQ_MS(session_covered_instant_ms(utc_ms(2025, 4, 1, 21, 0), NY, XAU),
                 utc_ms(2025, 4, 1, 22, 0));
     CHECK_EQ_MS(session_covered_instant_ms(utc_ms(2025, 4, 1, 12, 0), NY, XAU),
                 utc_ms(2025, 4, 1, 12, 0));
-    // The D bucket is labelled by the session open and completes on the
-    // session's last chart bar (16:45 ET, whose close is the 17:00 stamp),
-    // exactly as the 1700-1700 forex day does — not a session late.
+    // The D bucket is labelled by the 17:00 ET stamp (TradingView's D bar
+    // time, which time("D") reads) and completes on the session's last
+    // chart bar (16:45 ET, whose close is the next stamp), exactly as the
+    // 1700-1700 forex day does — not a session late.
     TimeframeAggregator d("D", "15", NY, XAU);
-    CHECK_EQ_MS(d.bar_label_ms(utc_ms(2025, 3, 31, 22, 0)), utc_ms(2025, 3, 31, 22, 0));
+    CHECK_EQ_MS(d.bar_label_ms(utc_ms(2025, 3, 31, 22, 0)), utc_ms(2025, 3, 31, 21, 0));
+    CHECK_EQ_MS(d.bucket_open_ms(utc_ms(2025, 3, 31, 22, 0)), utc_ms(2025, 3, 31, 21, 0));
     std::vector<int64_t> ts;
     xau_session(ts, utc_ms(2025, 3, 31, 22, 0));
     xau_session(ts, utc_ms(2025, 4, 1, 22, 0));
     auto c = drive(d, ts);
     CHECK(c.size() == 2);
     if (c.size() == 2) {
-        CHECK_EQ_MS(c[0].bucket_ts, utc_ms(2025, 3, 31, 22, 0));
+        CHECK_EQ_MS(c[0].bucket_ts, utc_ms(2025, 3, 31, 21, 0));
         CHECK_EQ_MS(c[0].at, utc_ms(2025, 4, 1, 20, 45));
         CHECK(c[0].subs == 92);
-        CHECK_EQ_MS(c[1].bucket_ts, utc_ms(2025, 4, 1, 22, 0));
+        CHECK_EQ_MS(c[1].bucket_ts, utc_ms(2025, 4, 1, 21, 0));
         CHECK_EQ_MS(c[1].at, utc_ms(2025, 4, 2, 20, 45));
     }
     TimeframeAggregator dfx("D", "15", NY, FX);

--- a/tests/test_path_resolve_extra.cpp
+++ b/tests/test_path_resolve_extra.cpp
@@ -515,15 +515,27 @@ static void test_fractional_trail_offset_truncates() {
         /*trail_points=*/100, /*trail_price=*/kNaN, /*trail_offset=*/50.0, /*entry=*/100,
         /*best_start=*/kNaN, false, false, kMintick);
     CHECK(near(fl_int.fill_price, 101.50));
-    // Sub-tick offsets (0 < offset < 1) truncate to zero ticks: the level
-    // rides the extreme itself once armed (distinct from an explicit 0,
-    // which is the exit-at-activation shape). peak 102 -> fill @ 102.00.
+    // Sub-tick offsets (0 < offset < 1) truncate to zero ticks AND then
+    // follow the explicit-zero exit-at-activation rule: fill AT the
+    // activation crossing (101 on the L->H leg), NOT at the peak 102.
+    // This cell used to pin the peak (a finite zero-distance trail riding
+    // the extreme, "distinct from an explicit 0") as an extrapolation of
+    // the floor rule; it was never tape-backed and TradingView refutes it:
+    // `lab tv` on OANDA:EURUSD 15m 2025-04-01 -> 05-01 gives byte-identical
+    // tapes for trail_offset = 0, 0.5 and 0.9 (190 rows, sha256
+    // 36aa80ac...). Full pins, including the gapped open and the #148
+    // no-retro-arm hold, live in test_trail_open_arm_subtick_offset.cpp.
     ExitPathFill fl_sub = resolve_exit_path_fill(
         trail_long, PositionSide::LONG, kNaN, kNaN,
         /*trail_points=*/100, /*trail_price=*/kNaN, /*trail_offset=*/0.6, /*entry=*/100,
         /*best_start=*/kNaN, false, false, kMintick);
     CHECK(fl_sub.should_fill == true);
-    CHECK(near(fl_sub.fill_price, 102.00));
+    CHECK(near(fl_sub.fill_price, 101.00));
+    ExitPathFill fl_zero = resolve_exit_path_fill(
+        trail_long, PositionSide::LONG, kNaN, kNaN,
+        /*trail_points=*/100, /*trail_price=*/kNaN, /*trail_offset=*/0.0, /*entry=*/100,
+        /*best_start=*/kNaN, false, false, kMintick);
+    CHECK(near(fl_sub.fill_price, fl_zero.fill_price));
 }
 
 static void test_entry_bar_blocks_no_trail_exit() {

--- a/tests/test_pine_time_day_stamp_grid.cpp
+++ b/tests/test_pine_time_day_stamp_grid.cpp
@@ -19,11 +19,13 @@
 //   NSE:NIFTY (Asia/Kolkata 0915-1530): "D" = 23:45 NY (= 09:15 IST) on
 //     39/39; "240" in {23:45, 03:45} NY (= 09:15 / 13:15 IST);
 //   BINANCE:BTCUSDT (UTC 24x7): "D" = 20:00 NY (= 00:00 UTC) on 19/19 --
-//     the epoch grid, where the day stamp is 00:00 UTC.
-// CME_MINI:ES1! (America/Chicago 1700-1600) exported 0 rows, so its time()
-// values are the rule's extrapolation; what is pinned there is that its
-// request.security grid (test_oanda_day_stamp_grid rule E) does not move
-// and time("240") reads that grid.
+//     the epoch grid, where the day stamp is 00:00 UTC;
+//   CME_MINI:ES1! and NQ1! (America/Chicago 1700-1600; pin-time-hours-cme,
+//     capital 1e14 so every entry is affordable): "D" = 18:00 NY (= 17:00
+//     CT) on 147/147 each; "240" in {18:00, 22:00, 02:00, 06:00, 10:00,
+//     14:00} NY (= 17:00 / 21:00 / 01:00 / 05:00 / 09:00 / 13:00 CT); "60"
+//     every hour on the hour except 17:00 NY (the 16:00-17:00 CT break) --
+//     the 17:00-CT session-open grid request.security already used.
 //
 // Rules pinned here:
 //   A. OANDA:XAUUSD: time("D") is the 17:00 ET stamp for every bar of the
@@ -34,8 +36,9 @@
 //   C. NSE:NIFTY: "240" anchored at 09:15 IST; time("D") 09:15 IST;
 //   D. 24x7 UTC: every form is the epoch grid, bit-identical to the
 //      five-argument (tz-less) forms;
-//   E. CME 1700-1600 CT: stamp == open; the "240" grid is the 17:00-CT one
-//      request.security already used; D / W anchors unchanged.
+//   E. CME 1700-1600 CT: stamp == open; time("D") is 17:00 CT, "240" / "60"
+//      the 17:00-CT grid request.security already used (unchanged);
+//      D / W anchors unchanged.
 #include <cstdio>
 #include <initializer_list>
 #include <string>
@@ -357,7 +360,7 @@ void test_24x7_utc_is_the_epoch_grid() {
 // ─── E. CME 1700-1600 America/Chicago: the grid does not move ────────────────
 
 void test_cme_grid_unchanged() {
-    std::printf("E. CME 1700-1600 CT: stamp == open; \"240\" is the 17:00-CT grid request.security keeps\n");
+    std::printf("E. CME 1700-1600 CT: time(\"D\") == 17:00 CT; \"240\" / \"60\" on the 17:00-CT grid request.security keeps\n");
     const int64_t mon_open = utc_ms(2025, 3, 31, 22, 0);     // Mon 17:00 CDT
     CHECK_EQ_MS(session_period_open_ms(utc_ms(2025, 4, 1, 7, 0), CHI, CME, CalendarPeriod::DAY), mon_open);
     CHECK_EQ_MS(session_period_close_ms(utc_ms(2025, 4, 1, 7, 0), CHI, CME, CalendarPeriod::DAY),
@@ -365,6 +368,7 @@ void test_cme_grid_unchanged() {
     CHECK_EQ_MS(session_period_open_ms(utc_ms(2025, 4, 1, 7, 0), CHI, CME, CalendarPeriod::WEEK),
                 utc_ms(2025, 3, 30, 22, 0));
     CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 7, 0), "D", CHI, CME), mon_open);
+    CHECK_EQ_MS(hhmm_ny(T(utc_ms(2025, 4, 1, 7, 0), "D", CHI, CME)), 1800);
     CHECK_EQ_MS(TC(utc_ms(2025, 4, 1, 7, 0), "D", CHI, CME), utc_ms(2025, 4, 1, 21, 0) - 1);
     // request.security's "240" grid, exactly as test_oanda_day_stamp_grid
     // rule E pins it: 22:00Z / 02:00Z / 06:00Z / .. / 18:00Z.
@@ -378,11 +382,43 @@ void test_cme_grid_unchanged() {
     CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 1, 45), "240", CHI, CME), mon_open);
     CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 2, 0), "240", CHI, CME), utc_ms(2025, 4, 1, 2, 0));
     CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 20, 45), "240", CHI, CME), utc_ms(2025, 4, 1, 18, 0));
+    CHECK_EQ_MS(hhmm_ny(T(utc_ms(2025, 4, 1, 20, 45), "240", CHI, CME)), 1400);
     CHECK_EQ_MS(T(utc_ms(2025, 3, 31, 22, 30), "60", CHI, CME), mon_open);
-    std::vector<int64_t> bars;
-    for (int i = 0; i < 92; ++i) bars.push_back(mon_open + i * k15m);   // 17:00 .. 15:45 CDT
-    CHECK(grid_disagreements(bars, "240", CHI, CME) == 0);
-    CHECK(grid_disagreements(bars, "60", CHI, CME) == 0);
+    CHECK_EQ_MS(hhmm_ny(T(utc_ms(2025, 3, 31, 22, 30), "60", CHI, CME)), 1800);
+    // The epoch grid (00:00Z-anchored) is not it.
+    CHECK_EQ_MS(T0(utc_ms(2025, 4, 1, 1, 45), "240"), utc_ms(2025, 4, 1, 0, 0));
+    CHECK(T(utc_ms(2025, 4, 1, 1, 45), "240", CHI, CME) != T0(utc_ms(2025, 4, 1, 1, 45), "240"));
+    // Every bar of every session in the tapes' range reads the tapes' Size
+    // values (ES1! and NQ1!: 147/147 D entries at 18:00 NY; H4 in the
+    // six-hour set; H1 on the hour and never 17:00 NY), and D closes at
+    // 16:00 CT.
+    int sessions = 0, bad_d = 0, bad_h4 = 0, bad_h1 = 0, bad_grid = 0;
+    for (int64_t day = utc_ms(2025, 3, 30); day < utc_ms(2025, 6, 30); day += k1d) {
+        const int wd = weekday_utc(day);
+        if (wd == 5 || wd == 6) continue;          // no Fri / Sat evening open
+        const int64_t open_z = day + 22 * k1h;      // 17:00 CDT
+        std::vector<int64_t> bars;
+        for (int i = 0; i < 92; ++i) bars.push_back(open_z + i * k15m);   // 17:00 .. 15:45 CDT
+        for (int64_t t : bars) {
+            const int64_t d = T(t, "D", CHI, CME);
+            if (d != open_z || hhmm_ny(d) != 1800) ++bad_d;
+            if (TC(t, "D", CHI, CME) != open_z + 23 * k1h - 1) ++bad_d;
+            const int64_t h4 = T(t, "240", CHI, CME);
+            if (!in_set(hhmm_ny(h4), {200, 600, 1000, 1400, 1800, 2200})) ++bad_h4;
+            if ((h4 - open_z) % k4h != 0 || h4 > t || t >= h4 + k4h) ++bad_h4;
+            if (TC(t, "240", CHI, CME) != h4 + k4h) ++bad_h4;
+            const int64_t h1 = T(t, "60", CHI, CME);
+            if (pine_minute(h1, NY) != 0 || hhmm_ny(h1) == 1700 || h1 > t || t >= h1 + k1h) ++bad_h1;
+        }
+        bad_grid += grid_disagreements(bars, "240", CHI, CME);
+        bad_grid += grid_disagreements(bars, "60", CHI, CME);
+        ++sessions;
+    }
+    CHECK(sessions == 66);   // Sun Mar 30 .. Sun Jun 29 evening opens
+    CHECK(bad_d == 0);
+    CHECK(bad_h4 == 0);
+    CHECK(bad_h1 == 0);
+    CHECK(bad_grid == 0);
 }
 
 }  // namespace

--- a/tests/test_pine_time_day_stamp_grid.cpp
+++ b/tests/test_pine_time_day_stamp_grid.cpp
@@ -1,0 +1,399 @@
+// time("<tf>") / time_close("<tf>") on the symbol clock: TradingView keys an
+// intraday tf on the symbol's DAY-STAMP-anchored HTF grid -- the same grid
+// request.security aggregates on (session_intraday_bucket_open_ms) -- and
+// time("D") on the D bar's stamp, which on OANDA's 1800-1700 metals session
+// is the 17:00 ET forex roll an hour before the session trades.
+//
+// Pinned with `lab tv` (pin-time-hours, 15m charts, 2025-04-01..07-01, all
+// EDT): strategy.entry(qty = hour(time(tf), "America/New_York") * 100 +
+// minute(time(tf), "America/New_York") + 10000 / 20000 / 30000 for "D" /
+// "240" / "60"), so every entry's Size column is the HHMM (New York) of the
+// tf bar open:
+//   OANDA:XAUUSD (America/New_York 1800-1700): "D" = 17:00 on 147/147
+//     entries (the engine used to report the 18:00 session open); "240" in
+//     {01:00, 05:00, 09:00, 13:00, 17:00, 21:00}; "60" every hour on the
+//     hour except 17:00 (nothing trades in the 17:00-18:00 break);
+//   NYSE:F (America/New_York 0930-1600): "D" = 09:30 on 41/41; "60" in
+//     {09:30, 10:30, .., 15:30} -- session-anchored, NOT the epoch hour the
+//     engine used to report; "240" in {09:30, 13:30};
+//   NSE:NIFTY (Asia/Kolkata 0915-1530): "D" = 23:45 NY (= 09:15 IST) on
+//     39/39; "240" in {23:45, 03:45} NY (= 09:15 / 13:15 IST);
+//   BINANCE:BTCUSDT (UTC 24x7): "D" = 20:00 NY (= 00:00 UTC) on 19/19 --
+//     the epoch grid, where the day stamp is 00:00 UTC.
+// CME_MINI:ES1! (America/Chicago 1700-1600) exported 0 rows, so its time()
+// values are the rule's extrapolation; what is pinned there is that its
+// request.security grid (test_oanda_day_stamp_grid rule E) does not move
+// and time("240") reads that grid.
+//
+// Rules pinned here:
+//   A. OANDA:XAUUSD: time("D") is the 17:00 ET stamp for every bar of the
+//      session, time_close("D") the next stamp; "240" / "60" are the
+//      stamp-anchored grid, bit-identical to TimeframeAggregator's bucket
+//      and tf_change; the same in EST;
+//   B. NYSE:F: "60" / "240" anchored at 09:30 ET; time("D") 09:30 ET;
+//   C. NSE:NIFTY: "240" anchored at 09:15 IST; time("D") 09:15 IST;
+//   D. 24x7 UTC: every form is the epoch grid, bit-identical to the
+//      five-argument (tz-less) forms;
+//   E. CME 1700-1600 CT: stamp == open; the "240" grid is the 17:00-CT one
+//      request.security already used; D / W anchors unchanged.
+#include <cstdio>
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+#include <pineforge/na.hpp>
+#include <pineforge/session_time.hpp>
+#include <pineforge/timeframe.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                        \
+        if (!(expr)) {                                                          \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                     \
+        } else {                                                                \
+            ++tests_passed;                                                     \
+        }                                                                       \
+    } while (0)
+
+#define CHECK_EQ_MS(actual, expected)                                          \
+    do {                                                                        \
+        const int64_t _a = (actual), _e = (expected);                          \
+        if (_a != _e) {                                                         \
+            std::printf("  FAIL  %s:%d  %s == %s  (got %lld, want %lld)\n",     \
+                        __FILE__, __LINE__, #actual, #expected,                 \
+                        (long long)_a, (long long)_e);                          \
+            ++tests_failed;                                                     \
+        } else {                                                                \
+            ++tests_passed;                                                     \
+        }                                                                       \
+    } while (0)
+
+namespace {
+
+// Unix ms of a UTC civil date-time (Howard Hinnant's days_from_civil).
+int64_t utc_ms(int y, int m, int d, int h = 0, int mi = 0) {
+    y -= (m <= 2);
+    long era = (y >= 0 ? y : y - 399) / 400;
+    unsigned yoe = (unsigned)(y - era * 400);
+    unsigned doy = (153u * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;
+    unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    long days = era * 146097L + (long)doe - 719468L;
+    return (static_cast<int64_t>(days) * 86400 + h * 3600 + mi * 60) * 1000;
+}
+
+const std::string NY  = "America/New_York";
+const std::string CHI = "America/Chicago";
+const std::string IST = "Asia/Kolkata";
+const std::string UTC = "UTC";
+const std::string XAU = "1800-1700";          // OANDA metals / CFDs
+const std::string RTH = "0930-1600";          // NYSE / NASDAQ
+const std::string NSE = "0915-1530";          // NSE India
+const std::string CME = "1700-1600";          // CME Globex (Chicago)
+const std::string ALL = "24x7";
+const std::string NONE;
+const std::string CHART = "15";
+const int64_t k15m = 15 * 60 * 1000;
+const int64_t k1h  = 60 * 60 * 1000;
+const int64_t k4h  = 4 * k1h;
+const int64_t k1d  = 24 * k1h;
+
+// The pin strategy's Size column: HHMM of `t` in New York.
+int64_t hhmm_ny(int64_t t) { return pine_hour(t, NY) * 100 + pine_minute(t, NY); }
+
+bool in_set(int64_t v, std::initializer_list<int64_t> s) {
+    for (int64_t x : s) if (x == v) return true;
+    return false;
+}
+
+int weekday_utc(int64_t ms) {           // 0 = Sunday .. 6 = Saturday
+    const int64_t days = ms / k1d;
+    return static_cast<int>(((days + 4) % 7 + 7) % 7);
+}
+
+// Symbol-clock time() / time_close() as codegen calls them (no session
+// argument, no tz argument, chart tf "15").
+int64_t T(int64_t t, const char* tf, const std::string& tz, const std::string& sess) {
+    return pine_time(t, tf, "", "", CHART, tz, sess);
+}
+int64_t TC(int64_t t, const char* tf, const std::string& tz, const std::string& sess) {
+    return pine_time_close(t, tf, "", "", CHART, tz, sess);
+}
+// The tz-less five-argument form: the epoch grid.
+int64_t T0(int64_t t, const char* tf) { return pine_time(t, tf, "", "", CHART); }
+
+// One grid: time(tf) is the aggregator's bucket open, and ta.change(time(tf))
+// fires exactly where tf_change does. Returns the number of disagreements.
+int grid_disagreements(const std::vector<int64_t>& bars, const char* tf,
+                       const std::string& tz, const std::string& sess) {
+    TimeframeAggregator agg(tf, CHART, tz, sess);
+    int bad = 0;
+    for (size_t i = 0; i < bars.size(); ++i) {
+        const int64_t open = T(bars[i], tf, tz, sess);
+        if (open != agg.bucket_open_ms(bars[i])) ++bad;
+        if (open > bars[i]) ++bad;
+        if (i > 0) {
+            const bool changed = open != T(bars[i - 1], tf, tz, sess);
+            if (changed != tf_change(bars[i - 1], bars[i], tf, tz, sess)) ++bad;
+        }
+    }
+    return bad;
+}
+
+// ─── A. OANDA:XAUUSD, 1800-1700 America/New_York ─────────────────────────────
+
+// One 1800-1700 session of 15m bars from `open_z` (18:00 ET): 92 bars up to
+// 16:45 ET; nothing trades in the 17:00-18:00 ET break.
+std::vector<int64_t> xau_session(int64_t open_z) {
+    std::vector<int64_t> v;
+    for (int i = 0; i < 92; ++i) v.push_back(open_z + i * k15m);
+    return v;
+}
+
+void test_xau_time_d_is_the_1700_stamp() {
+    std::printf("A. OANDA:XAUUSD time(\"D\") == 17:00 ET stamp; \"240\" / \"60\" on the stamp grid\n");
+    const int64_t mon_open = utc_ms(2025, 3, 31, 22, 0);     // Mon 18:00 EDT
+    const int64_t mon_stamp = utc_ms(2025, 3, 31, 21, 0);    // Mon 17:00 EDT
+    // The session's first bar: D opens an hour before it, at the stamp.
+    CHECK_EQ_MS(T(mon_open, "D", NY, XAU), mon_stamp);
+    CHECK_EQ_MS(hhmm_ny(T(mon_open, "D", NY, XAU)), 1700);
+    CHECK_EQ_MS(TC(mon_open, "D", NY, XAU), utc_ms(2025, 4, 1, 21, 0) - 1);
+    CHECK_EQ_MS(T(mon_open, "1D", NY, XAU), mon_stamp);
+    // "240": 21:00Z-anchored (17:00 EDT); the 17:00-21:00 ET bucket holds
+    // only the 18:00-20:45 bars.
+    CHECK_EQ_MS(T(mon_open, "240", NY, XAU), mon_stamp);
+    CHECK_EQ_MS(TC(mon_open, "240", NY, XAU), utc_ms(2025, 4, 1, 1, 0));
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 0, 45), "240", NY, XAU), mon_stamp);
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 1, 0), "240", NY, XAU), utc_ms(2025, 4, 1, 1, 0));
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 20, 45), "240", NY, XAU), utc_ms(2025, 4, 1, 17, 0));
+    CHECK_EQ_MS(hhmm_ny(T(utc_ms(2025, 4, 1, 20, 45), "240", NY, XAU)), 1300);
+    // The epoch grid the engine used to report (00:00Z-anchored) is not it.
+    CHECK_EQ_MS(T0(utc_ms(2025, 4, 1, 0, 45), "240"), utc_ms(2025, 4, 1, 0, 0));
+    CHECK(T(utc_ms(2025, 4, 1, 0, 45), "240", NY, XAU) != T0(utc_ms(2025, 4, 1, 0, 45), "240"));
+    // "60": on the hour (the stamp is on the hour, so it coincides with the
+    // epoch hour), never 17:00.
+    CHECK_EQ_MS(T(mon_open, "60", NY, XAU), mon_open);
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 20, 45), "60", NY, XAU), utc_ms(2025, 4, 1, 20, 0));
+    CHECK_EQ_MS(TC(utc_ms(2025, 4, 1, 20, 45), "60", NY, XAU), utc_ms(2025, 4, 1, 21, 0));
+    // Last bar of the session: still Monday's D bar; it closes at the stamp.
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 20, 45), "D", NY, XAU), mon_stamp);
+    CHECK_EQ_MS(TC(utc_ms(2025, 4, 1, 20, 45), "D", NY, XAU), utc_ms(2025, 4, 1, 21, 0) - 1);
+    // Next session's first bar: the next stamp.
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 22, 0), "D", NY, XAU), utc_ms(2025, 4, 1, 21, 0));
+    // Every bar of every session in the tape's range reads the tape's
+    // Size values (147/147 D entries at 17:00; H4 in the six-hour set; H1
+    // on the hour and never 17:00), and the D value never moves within a
+    // session.
+    int sessions = 0, bad_d = 0, bad_h4 = 0, bad_h1 = 0, bad_grid = 0;
+    for (int64_t day = utc_ms(2025, 3, 30); day < utc_ms(2025, 6, 30); day += k1d) {
+        const int wd = weekday_utc(day);
+        if (wd == 5 || wd == 6) continue;          // no Fri / Sat evening open
+        const int64_t open_z = day + 22 * k1h;      // 18:00 EDT
+        const std::vector<int64_t> bars = xau_session(open_z);
+        for (int64_t t : bars) {
+            const int64_t d = T(t, "D", NY, XAU);
+            if (d != open_z - k1h || hhmm_ny(d) != 1700) ++bad_d;
+            if (TC(t, "D", NY, XAU) != open_z - k1h + k1d - 1) ++bad_d;
+            const int64_t h4 = T(t, "240", NY, XAU);
+            if (!in_set(hhmm_ny(h4), {100, 500, 900, 1300, 1700, 2100})) ++bad_h4;
+            if ((h4 - (open_z - k1h)) % k4h != 0 || h4 > t || t >= h4 + k4h) ++bad_h4;
+            if (TC(t, "240", NY, XAU) != h4 + k4h) ++bad_h4;
+            const int64_t h1 = T(t, "60", NY, XAU);
+            if (pine_minute(h1, NY) != 0 || hhmm_ny(h1) == 1700 || h1 > t || t >= h1 + k1h) ++bad_h1;
+        }
+        bad_grid += grid_disagreements(bars, "240", NY, XAU);
+        bad_grid += grid_disagreements(bars, "60", NY, XAU);
+        bad_grid += grid_disagreements(bars, "45", NY, XAU);
+        ++sessions;
+    }
+    CHECK(sessions == 66);   // Sun Mar 30 .. Sun Jun 29 evening opens
+    CHECK(bad_d == 0);
+    CHECK(bad_h4 == 0);
+    CHECK(bad_h1 == 0);
+    CHECK(bad_grid == 0);
+    // Winter (EST): the stamp is 17:00 EST = 22:00Z; the "240" grid follows
+    // it (22:00Z / 02:00Z / 06:00Z / 10:00Z ..), the same New York hours.
+    const int64_t tue_0700_est = utc_ms(2025, 1, 14, 12, 0);
+    CHECK_EQ_MS(T(tue_0700_est, "D", NY, XAU), utc_ms(2025, 1, 13, 22, 0));
+    CHECK_EQ_MS(hhmm_ny(T(tue_0700_est, "D", NY, XAU)), 1700);
+    CHECK_EQ_MS(T(tue_0700_est, "240", NY, XAU), utc_ms(2025, 1, 14, 10, 0));
+    CHECK_EQ_MS(hhmm_ny(T(tue_0700_est, "240", NY, XAU)), 500);
+    CHECK_EQ_MS(T(utc_ms(2025, 1, 13, 23, 0), "240", NY, XAU), utc_ms(2025, 1, 13, 22, 0));
+    // A session argument only filters; the grid is the symbol's.
+    CHECK_EQ_MS(pine_time(utc_ms(2025, 4, 1, 0, 45), "240", XAU, "", CHART, NY, XAU), mon_stamp);
+    CHECK(is_na(pine_time(utc_ms(2025, 4, 1, 21, 30), "240", XAU, "", CHART, NY, XAU)));
+}
+
+// ─── B. NYSE:F, 0930-1600 America/New_York ───────────────────────────────────
+
+std::vector<int64_t> rth_session(int64_t open_z) {
+    std::vector<int64_t> v;
+    for (int i = 0; i < 26; ++i) v.push_back(open_z + i * k15m);   // 09:30 .. 15:45
+    return v;
+}
+
+void test_nyse_intraday_grid_anchored_at_0930() {
+    std::printf("B. NYSE:F time(\"60\") == 09:30 + k h, \"240\" in {09:30, 13:30}, \"D\" 09:30 ET\n");
+    const int64_t tue_open = utc_ms(2025, 4, 1, 13, 30);     // Tue 09:30 EDT
+    CHECK_EQ_MS(T(tue_open, "D", NY, RTH), tue_open);
+    CHECK_EQ_MS(hhmm_ny(T(tue_open, "D", NY, RTH)), 930);
+    CHECK_EQ_MS(TC(tue_open, "D", NY, RTH), utc_ms(2025, 4, 1, 20, 0) - 1);
+    // "60" anchored at 09:30: the 09:45 bar belongs to the 09:30 bar, not to
+    // the epoch 09:00 hour the engine used to report.
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 13, 45), "60", NY, RTH), tue_open);
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 14, 0), "60", NY, RTH), tue_open);
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 14, 30), "60", NY, RTH), utc_ms(2025, 4, 1, 14, 30));
+    CHECK_EQ_MS(hhmm_ny(T(utc_ms(2025, 4, 1, 14, 30), "60", NY, RTH)), 1030);
+    CHECK_EQ_MS(TC(utc_ms(2025, 4, 1, 13, 45), "60", NY, RTH), utc_ms(2025, 4, 1, 14, 30));
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 19, 45), "60", NY, RTH), utc_ms(2025, 4, 1, 19, 30));
+    CHECK_EQ_MS(hhmm_ny(T(utc_ms(2025, 4, 1, 19, 45), "60", NY, RTH)), 1530);
+    CHECK_EQ_MS(T0(utc_ms(2025, 4, 1, 13, 45), "60"), utc_ms(2025, 4, 1, 13, 0));
+    CHECK(T(utc_ms(2025, 4, 1, 13, 45), "60", NY, RTH) != T0(utc_ms(2025, 4, 1, 13, 45), "60"));
+    // "240": 09:30 and 13:30.
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 17, 15), "240", NY, RTH), tue_open);
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 17, 30), "240", NY, RTH), utc_ms(2025, 4, 1, 17, 30));
+    CHECK_EQ_MS(hhmm_ny(T(utc_ms(2025, 4, 1, 19, 45), "240", NY, RTH)), 1330);
+    CHECK_EQ_MS(TC(utc_ms(2025, 4, 1, 17, 30), "240", NY, RTH), utc_ms(2025, 4, 1, 21, 30));
+    // With a session argument (only a filter) the grid is the same.
+    CHECK_EQ_MS(pine_time(utc_ms(2025, 4, 1, 14, 0), "60", RTH, "", CHART, NY, RTH), tue_open);
+    CHECK_EQ_MS(pine_time(utc_ms(2025, 4, 1, 14, 0), "60", RTH, NY, CHART, NY, RTH), tue_open);
+    CHECK(is_na(pine_time(utc_ms(2025, 4, 1, 12, 0), "60", RTH, "", CHART, NY, RTH)));
+    // Every weekday session in the tape's range.
+    int sessions = 0, bad_d = 0, bad_h4 = 0, bad_h1 = 0, bad_grid = 0;
+    for (int64_t day = utc_ms(2025, 4, 1); day < utc_ms(2025, 7, 1); day += k1d) {
+        const int wd = weekday_utc(day);
+        if (wd == 0 || wd == 6) continue;
+        const int64_t open_z = day + 13 * k1h + 30 * 60000;      // 09:30 EDT
+        const std::vector<int64_t> bars = rth_session(open_z);
+        for (int64_t t : bars) {
+            if (T(t, "D", NY, RTH) != open_z || hhmm_ny(T(t, "D", NY, RTH)) != 930) ++bad_d;
+            const int64_t h4 = T(t, "240", NY, RTH);
+            if (!in_set(hhmm_ny(h4), {930, 1330}) || h4 > t || t >= h4 + k4h) ++bad_h4;
+            const int64_t h1 = T(t, "60", NY, RTH);
+            if (!in_set(hhmm_ny(h1), {930, 1030, 1130, 1230, 1330, 1430, 1530})
+                || h1 > t || t >= h1 + k1h) ++bad_h1;
+        }
+        bad_grid += grid_disagreements(bars, "240", NY, RTH);
+        bad_grid += grid_disagreements(bars, "60", NY, RTH);
+        ++sessions;
+    }
+    CHECK(sessions == 65);
+    CHECK(bad_d == 0);
+    CHECK(bad_h4 == 0);
+    CHECK(bad_h1 == 0);
+    CHECK(bad_grid == 0);
+}
+
+// ─── C. NSE:NIFTY, 0915-1530 Asia/Kolkata ────────────────────────────────────
+
+void test_nse_intraday_grid_anchored_at_0915_ist() {
+    std::printf("C. NSE:NIFTY time(\"240\") in {09:15, 13:15} IST (23:45 / 03:45 NY); \"D\" 09:15 IST\n");
+    const int64_t tue_open = utc_ms(2025, 4, 1, 3, 45);      // Tue 09:15 IST
+    CHECK_EQ_MS(T(tue_open, "D", IST, NSE), tue_open);
+    CHECK_EQ_MS(hhmm_ny(T(tue_open, "D", IST, NSE)), 2345);
+    CHECK_EQ_MS(TC(tue_open, "D", IST, NSE), utc_ms(2025, 4, 1, 10, 0) - 1);
+    // "240": 03:45Z (09:15 IST) and 07:45Z (13:15 IST).
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 4, 0), "240", IST, NSE), tue_open);
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 7, 30), "240", IST, NSE), tue_open);
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 7, 45), "240", IST, NSE), utc_ms(2025, 4, 1, 7, 45));
+    CHECK_EQ_MS(hhmm_ny(T(utc_ms(2025, 4, 1, 9, 45), "240", IST, NSE)), 345);
+    CHECK_EQ_MS(TC(utc_ms(2025, 4, 1, 7, 45), "240", IST, NSE), utc_ms(2025, 4, 1, 11, 45));
+    // The epoch grid (04:00Z / 08:00Z) is not it.
+    CHECK_EQ_MS(T0(utc_ms(2025, 4, 1, 4, 0), "240"), utc_ms(2025, 4, 1, 4, 0));
+    CHECK(T(utc_ms(2025, 4, 1, 4, 0), "240", IST, NSE) != T0(utc_ms(2025, 4, 1, 4, 0), "240"));
+    // "60" (no H1 entries on this tape: the pin strategy ran out of equity)
+    // follows the same grid: 09:15 / 10:15 / .. IST.
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 4, 30), "60", IST, NSE), tue_open);
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 4, 45), "60", IST, NSE), utc_ms(2025, 4, 1, 4, 45));
+    int sessions = 0, bad_d = 0, bad_h4 = 0, bad_grid = 0;
+    for (int64_t day = utc_ms(2025, 4, 1); day < utc_ms(2025, 7, 1); day += k1d) {
+        const int wd = weekday_utc(day);
+        if (wd == 0 || wd == 6) continue;
+        const int64_t open_z = day + 3 * k1h + 45 * 60000;       // 09:15 IST
+        std::vector<int64_t> bars;
+        for (int i = 0; i < 25; ++i) bars.push_back(open_z + i * k15m);   // 09:15 .. 15:15
+        for (int64_t t : bars) {
+            if (T(t, "D", IST, NSE) != open_z || hhmm_ny(T(t, "D", IST, NSE)) != 2345) ++bad_d;
+            const int64_t h4 = T(t, "240", IST, NSE);
+            if (!in_set(hhmm_ny(h4), {2345, 345}) || h4 > t || t >= h4 + k4h) ++bad_h4;
+        }
+        bad_grid += grid_disagreements(bars, "240", IST, NSE);
+        bad_grid += grid_disagreements(bars, "60", IST, NSE);
+        ++sessions;
+    }
+    CHECK(sessions == 65);
+    CHECK(bad_d == 0);
+    CHECK(bad_h4 == 0);
+    CHECK(bad_grid == 0);
+}
+
+// ─── D. BINANCE:BTCUSDT, 24x7 UTC ────────────────────────────────────────────
+
+void test_24x7_utc_is_the_epoch_grid() {
+    std::printf("D. 24x7 UTC: time(\"D\") == 00:00 UTC (20:00 NY); every form is the epoch grid\n");
+    const int64_t t = utc_ms(2025, 4, 1, 8, 15);
+    CHECK_EQ_MS(T(t, "D", UTC, ALL), utc_ms(2025, 4, 1, 0, 0));
+    CHECK_EQ_MS(hhmm_ny(T(t, "D", UTC, ALL)), 2000);
+    CHECK_EQ_MS(T(t, "240", UTC, ALL), utc_ms(2025, 4, 1, 8, 0));
+    CHECK_EQ_MS(T(t, "60", UTC, ALL), utc_ms(2025, 4, 1, 8, 0));
+    int bad = 0, n = 0;
+    for (int64_t ms = utc_ms(2025, 4, 1); ms < utc_ms(2025, 7, 1); ms += 7 * k1h + 37 * 60000) {
+        for (const char* tf : {"D", "240", "60", "45", "15"}) {
+            for (const std::string* sess : {&ALL, &NONE}) {
+                if (T(ms, tf, UTC, *sess) != T0(ms, tf)) ++bad;
+                if (TC(ms, tf, UTC, *sess) != pine_time_close(ms, tf, "", "", CHART)) ++bad;
+            }
+        }
+        ++n;
+    }
+    CHECK(n > 200);
+    CHECK(bad == 0);
+}
+
+// ─── E. CME 1700-1600 America/Chicago: the grid does not move ────────────────
+
+void test_cme_grid_unchanged() {
+    std::printf("E. CME 1700-1600 CT: stamp == open; \"240\" is the 17:00-CT grid request.security keeps\n");
+    const int64_t mon_open = utc_ms(2025, 3, 31, 22, 0);     // Mon 17:00 CDT
+    CHECK_EQ_MS(session_period_open_ms(utc_ms(2025, 4, 1, 7, 0), CHI, CME, CalendarPeriod::DAY), mon_open);
+    CHECK_EQ_MS(session_period_close_ms(utc_ms(2025, 4, 1, 7, 0), CHI, CME, CalendarPeriod::DAY),
+                utc_ms(2025, 4, 1, 21, 0));
+    CHECK_EQ_MS(session_period_open_ms(utc_ms(2025, 4, 1, 7, 0), CHI, CME, CalendarPeriod::WEEK),
+                utc_ms(2025, 3, 30, 22, 0));
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 7, 0), "D", CHI, CME), mon_open);
+    CHECK_EQ_MS(TC(utc_ms(2025, 4, 1, 7, 0), "D", CHI, CME), utc_ms(2025, 4, 1, 21, 0) - 1);
+    // request.security's "240" grid, exactly as test_oanda_day_stamp_grid
+    // rule E pins it: 22:00Z / 02:00Z / 06:00Z / .. / 18:00Z.
+    TimeframeAggregator agg("240", CHART, CHI, CME);
+    CHECK_EQ_MS(agg.bucket_open_ms(mon_open), mon_open);
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 1, 45)), mon_open);
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 2, 0)), utc_ms(2025, 4, 1, 2, 0));
+    CHECK_EQ_MS(agg.bucket_open_ms(utc_ms(2025, 4, 1, 20, 45)), utc_ms(2025, 4, 1, 18, 0));
+    // time("240") reads that grid.
+    CHECK_EQ_MS(T(mon_open, "240", CHI, CME), mon_open);
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 1, 45), "240", CHI, CME), mon_open);
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 2, 0), "240", CHI, CME), utc_ms(2025, 4, 1, 2, 0));
+    CHECK_EQ_MS(T(utc_ms(2025, 4, 1, 20, 45), "240", CHI, CME), utc_ms(2025, 4, 1, 18, 0));
+    CHECK_EQ_MS(T(utc_ms(2025, 3, 31, 22, 30), "60", CHI, CME), mon_open);
+    std::vector<int64_t> bars;
+    for (int i = 0; i < 92; ++i) bars.push_back(mon_open + i * k15m);   // 17:00 .. 15:45 CDT
+    CHECK(grid_disagreements(bars, "240", CHI, CME) == 0);
+    CHECK(grid_disagreements(bars, "60", CHI, CME) == 0);
+}
+
+}  // namespace
+
+int main() {
+    std::printf("=== time(<tf>) on the day-stamp grid ===\n\n");
+    test_xau_time_d_is_the_1700_stamp();
+    test_nyse_intraday_grid_anchored_at_0930();
+    test_nse_intraday_grid_anchored_at_0915_ist();
+    test_24x7_utc_is_the_epoch_grid();
+    test_cme_grid_unchanged();
+    std::printf("\n=== Results: %d passed, %d failed ===\n", tests_passed, tests_failed);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/tests/test_session_day_anchors.cpp
+++ b/tests/test_session_day_anchors.cpp
@@ -183,8 +183,20 @@ static void test_forex_pine_time_symbol_clock() {
                 utc_ms(2025, 6, 9, 4, 0));
     CHECK_EQ_MS(pine_time_close(utc_ms(2025, 6, 10, 1, 0), "D", "0000-2359", NY, "15", UTC, "24x7"),
                 pine_time_close(utc_ms(2025, 6, 10, 1, 0), "D", "0000-2359", NY, "15"));
-    // Intraday tfs keep the epoch grid.
+    // Intraday tfs sit on the symbol's day-stamp-anchored HTF grid, the one
+    // request.security aggregates on. (Re-pinned: the rule "intraday tfs
+    // keep the epoch grid" arrived with b1449c3 as a design statement with
+    // no tape behind it, and this "60" check on 1700-1700 never told the two
+    // grids apart -- 17:00 ET is on the hour in EDT and EST. pin-time-hours
+    // on NYSE:F / NSE:NIFTY / OANDA:XAUUSD 15, 2025-04-01..07-01, reads the
+    // session-anchored grid on every session symbol; see
+    // test_pine_time_day_stamp_grid.) On forex "60" still coincides with
+    // the epoch hour; "240" is the 17:00-ET-anchored grid: Tue 03:00 EDT
+    // sits in the 01:00-05:00 EDT bucket, not the epoch 04:00Z-08:00Z one.
     CHECK_EQ_MS(pine_time(bar, "60", "", "", "15", NY, FX), pine_time(bar, "60", "", "", "15"));
+    CHECK_EQ_MS(pine_time(bar, "240", "", "", "15", NY, FX), utc_ms(2025, 6, 10, 5, 0));
+    CHECK_EQ_MS(pine_time_close(bar, "240", "", "", "15", NY, FX), utc_ms(2025, 6, 10, 9, 0));
+    CHECK_EQ_MS(pine_time(bar, "240", "", "", "15"), utc_ms(2025, 6, 10, 4, 0));
     // Empty tf falls back to the chart tf.
     CHECK_EQ_MS(pine_time(bar, "", "", "", "D", NY, FX), utc_ms(2025, 6, 9, 21, 0));
 }
@@ -328,14 +340,21 @@ static void test_session_length_edge_cases() {
                 utc_ms(2025, 6, 11, 0, 0));
     CHECK_EQ_MS(session_period_open_ms(utc_ms(2025, 6, 10, 7, 0), UTC, ALLDAY, CalendarPeriod::WEEK),
                 utc_ms(2025, 6, 9, 0, 0));
-    // CME-style 1800-1700 wraps midnight like forex: trading date == close date.
+    // A 1800-1700 session wraps midnight like forex: trading date == close
+    // date, the day closing 17:00 ET. (Re-pinned: b1449c3 wrote this parser
+    // edge case as "CME-style" with the New York zone, which makes it
+    // OANDA's 1800-1700 metals session -- whose D bar is stamped at the
+    // 17:00 ET roll an hour before it trades, so its D / W open is the
+    // stamp: pin-time-hours on OANDA:XAUUSD, see test_pine_time_day_stamp_grid.
+    // A real CME session is 1700-1600 America/Chicago, whose open IS its
+    // stamp; test_pine_time_day_stamp_grid rule E pins that grid.)
     const std::string CME = "1800-1700";
     CHECK_EQ_MS(session_period_open_ms(utc_ms(2025, 6, 10, 7, 0), NY, CME, CalendarPeriod::DAY),
-                utc_ms(2025, 6, 9, 22, 0));
+                utc_ms(2025, 6, 9, 21, 0));
     CHECK_EQ_MS(session_period_close_ms(utc_ms(2025, 6, 10, 7, 0), NY, CME, CalendarPeriod::DAY),
                 utc_ms(2025, 6, 10, 21, 0));
     CHECK_EQ_MS(session_period_open_ms(utc_ms(2025, 6, 10, 7, 0), NY, CME, CalendarPeriod::WEEK),
-                utc_ms(2025, 6, 8, 22, 0));
+                utc_ms(2025, 6, 8, 21, 0));
     // Day-of-week suffix does not disturb parsing.
     CHECK_EQ_MS(session_period_open_ms(utc_ms(2025, 6, 10, 14, 0), NY, "0930-1600:23456", CalendarPeriod::DAY),
                 utc_ms(2025, 6, 10, 13, 30));

--- a/tests/test_session_predicates_daily_chart.cpp
+++ b/tests/test_session_predicates_daily_chart.cpp
@@ -1,0 +1,372 @@
+// test_session_predicates_daily_chart.cpp — session.ismarket / ispremarket /
+// ispostmarket / isfirstbar / islastbar on a DAILY-OR-HIGHER chart.
+//
+// TradingView ground truth (Pine reference, Sessions): on "1D" and above
+// session.ismarket is true on every bar and session.ispremarket /
+// session.ispostmarket are false — a daily bar covers whole session days,
+// not a time of day. Intraday charts keep the time-of-day test unchanged.
+//
+// Evidence: roi10x-shiva-lt-ls-blend on OANDA:XAUUSD @1D. The symbol's
+// session is 1800-1700 America/New_York and its daily bars are stamped at
+// the 17:00 ET break (minute 1020, outside the wrapped window [1080, 1020)),
+// so the time-of-day test never held, every signal ANDed with
+// session.ismarket stayed false, and the engine took 0 trades against
+// TradingView's 57.
+//
+// Codegen lowers the three predicates to the UNQUALIFIED call
+//   pine_session_ismarket(syminfo_.session, syminfo_.timezone, current_bar_.timestamp)
+// inside the generated `class GeneratedStrategy : public BacktestEngine`
+// (pineforge_codegen/codegen/visit_expr.py). The harness below makes the
+// same unqualified calls from a BacktestEngine subclass, so it proves the
+// class-scope members (engine.hpp) shadow the namespace-scope time-of-day
+// forms for the emitted code — if that shadowing ever broke, the daily
+// assertions here would fail at runtime.
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include <pineforge/bar.hpp>
+#include <pineforge/engine.hpp>
+#include <pineforge/session_time.hpp>
+#include <pineforge/timeframe.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                        \
+        if (!(expr)) {                                                          \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                     \
+        } else {                                                                \
+            ++tests_passed;                                                     \
+        }                                                                       \
+    } while (0)
+
+namespace {
+
+// One dispatched chart bar as the generated strategy would observe it.
+struct SeenBar {
+    int64_t ts = 0;
+    // The three predicates exactly as codegen emits them (unqualified).
+    bool ismarket = false;
+    bool ispremarket = false;
+    bool ispostmarket = false;
+    // The pump's own per-bar state (session.isfirstbar / islastbar lower
+    // to these members directly).
+    bool engine_ismarket = false;
+    bool isfirstbar = false;
+    bool islastbar = false;
+    // The raw time-of-day forms for the same stamp (namespace-scope,
+    // three arguments) — what the pump evaluated before the chart rule.
+    bool raw_ismarket = false;
+    bool raw_ispremarket = false;
+    bool raw_ispostmarket = false;
+};
+
+class SessionProbeEngine : public BacktestEngine {
+public:
+    std::vector<SeenBar> seen;
+
+    void on_bar(const Bar&) override {
+        SeenBar s;
+        s.ts = current_bar_.timestamp;
+        // Byte-for-byte the expressions visit_expr.py emits for
+        // session.ismarket / session.ispremarket / session.ispostmarket.
+        s.ismarket = pine_session_ismarket(syminfo_.session, syminfo_.timezone, current_bar_.timestamp);
+        s.ispremarket = pine_session_ispremarket(syminfo_.session, syminfo_.timezone, current_bar_.timestamp);
+        s.ispostmarket = pine_session_ispostmarket(syminfo_.session, syminfo_.timezone, current_bar_.timestamp);
+        s.engine_ismarket = session_ismarket_;
+        s.isfirstbar = session_isfirstbar_;
+        s.islastbar = session_islastbar_;
+        s.raw_ismarket = pineforge::pine_session_ismarket(
+            syminfo_.session, syminfo_.timezone, current_bar_.timestamp);
+        s.raw_ispremarket = pineforge::pine_session_ispremarket(
+            syminfo_.session, syminfo_.timezone, current_bar_.timestamp);
+        s.raw_ispostmarket = pineforge::pine_session_ispostmarket(
+            syminfo_.session, syminfo_.timezone, current_bar_.timestamp);
+        seen.push_back(s);
+    }
+};
+
+Bar make_bar(int64_t ts_ms) {
+    Bar b;
+    b.open = 100.0;
+    b.high = 101.0;
+    b.low = 99.0;
+    b.close = 100.5;
+    b.volume = 1000.0;
+    b.timestamp = ts_ms;
+    return b;
+}
+
+constexpr int64_t kMinuteMs = 60'000LL;
+constexpr int64_t kHourMs = 60 * kMinuteMs;
+constexpr int64_t kDayMs = 24 * kHourMs;
+
+// OANDA:XAUUSD: session 1800-1700 America/New_York. The week of
+// 2026-04-06 (Mon) .. 2026-04-10 (Fri) is EDT (UTC-4).
+const std::string kXauSession = "1800-1700";
+const std::string kNyTz = "America/New_York";
+// 2026-04-06 17:00 ET == 21:00 UTC — the daily-bar stamp of the tape.
+constexpr int64_t kMon_1700_ET = 1775509200000LL;
+// 2026-04-07 16:45 ET == 20:45 UTC — base of the 15m ladder.
+constexpr int64_t kTue_1645_ET = 1775594700000LL;
+
+// NASDAQ-style regular session.
+const std::string kRthSession = "0930-1600";
+// 2026-04-06 00:00 UTC (20:00 ET on 2026-04-05) — a midnight-UTC daily stamp.
+constexpr int64_t kMon_0000_UTC = 1775433600000LL;
+// 2026-04-07 05:00 ET — premarket by time of day.
+constexpr int64_t kTue_0500_ET = 1775552400000LL;
+// 2026-04-07 19:00 ET — postmarket by time of day.
+constexpr int64_t kTue_1900_ET = 1775602800000LL;
+// 2026-04-07 10:30 ET — inside RTH.
+constexpr int64_t kTue_1030_ET = 1775577000000LL;
+
+std::vector<Bar> daily_bars(int64_t first_ts, int n) {
+    std::vector<Bar> bars;
+    for (int i = 0; i < n; ++i) bars.push_back(make_bar(first_ts + i * kDayMs));
+    return bars;
+}
+
+void check_every_bar_is_the_session(const SessionProbeEngine& eng, size_t expect_n) {
+    CHECK(eng.last_error().empty());
+    if (!eng.last_error().empty())
+        std::printf("    last_error: %s\n", eng.last_error().c_str());
+    CHECK(eng.seen.size() == expect_n);
+    for (const SeenBar& s : eng.seen) {
+        CHECK(s.ismarket == true);
+        CHECK(s.ispremarket == false);
+        CHECK(s.ispostmarket == false);
+        CHECK(s.engine_ismarket == true);
+        // A D/W/M bar is its whole session: first and last bar at once.
+        CHECK(s.isfirstbar == true);
+        CHECK(s.islastbar == true);
+    }
+}
+
+// --- 1800-1700 America/New_York on a 1D feed stamped 17:00 ET -------------
+
+void test_xauusd_1d_feed_every_bar_is_market() {
+    std::printf("test_xauusd_1d_feed_every_bar_is_market\n");
+    SessionProbeEngine eng;
+    eng.set_syminfo_session(kXauSession);
+    eng.set_syminfo_timezone(kNyTz);
+    const auto bars = daily_bars(kMon_1700_ET, 5);  // Mon..Fri
+    // The cloud caller's shape: input_tf auto-detected ("D"), script_tf
+    // the probe's chart timeframe (run_backtest_full -> timeframe overload).
+    eng.run(bars.data(), (int)bars.size(), "", "1D");
+
+    check_every_bar_is_the_session(eng, 5);
+    // The evidence itself: by time of day every 17:00 ET stamp is OUTSIDE
+    // the wrapped [1080, 1020) window, which is why the old pump never
+    // saw the market open on this tape.
+    for (const SeenBar& s : eng.seen) {
+        CHECK(s.raw_ismarket == false);
+        CHECK(s.ismarket != s.raw_ismarket);
+    }
+}
+
+void test_xauusd_1d_feed_explicit_1D_spelling() {
+    std::printf("test_xauusd_1d_feed_explicit_1D_spelling\n");
+    SessionProbeEngine eng;
+    eng.set_syminfo_session(kXauSession);
+    eng.set_syminfo_timezone(kNyTz);
+    const auto bars = daily_bars(kMon_1700_ET, 5);
+    eng.run(bars.data(), (int)bars.size(), "1D", "1D");
+    check_every_bar_is_the_session(eng, 5);
+}
+
+void test_xauusd_1d_feed_single_timeframe_run() {
+    // The single-timeframe run(bars, n) overload (run_backtest_full takes
+    // it only when the caller passes neither a timeframe nor the
+    // magnifier). It detects "D" from the stamps, so the generated
+    // predicates follow the daily rule here too. Its inline bar loop does
+    // not maintain session_isfirstbar_ / session_islastbar_ (pre-existing,
+    // untouched by the chart rule), so only the emitted expressions are
+    // pinned on this path.
+    std::printf("test_xauusd_1d_feed_single_timeframe_run\n");
+    SessionProbeEngine eng;
+    eng.set_syminfo_session(kXauSession);
+    eng.set_syminfo_timezone(kNyTz);
+    const auto bars = daily_bars(kMon_1700_ET, 5);
+    eng.run(bars.data(), (int)bars.size());         // detect_timeframe -> "D"
+    CHECK(eng.last_error().empty());
+    CHECK(eng.seen.size() == 5);
+    for (const SeenBar& s : eng.seen) {
+        CHECK(s.ismarket == true);
+        CHECK(s.ispremarket == false);
+        CHECK(s.ispostmarket == false);
+        CHECK(s.raw_ismarket == false);
+    }
+}
+
+// --- the same session on a 15m feed: intraday byte-identical ---------------
+
+void test_xauusd_15m_feed_keeps_time_of_day_rule() {
+    std::printf("test_xauusd_15m_feed_keeps_time_of_day_rule\n");
+    SessionProbeEngine eng;
+    eng.set_syminfo_session(kXauSession);
+    eng.set_syminfo_timezone(kNyTz);
+    // 16:45, 17:00, 17:15, 17:30, 17:45, 18:00, 18:15, 18:30 ET (Tue).
+    std::vector<Bar> bars;
+    for (int i = 0; i < 8; ++i) bars.push_back(make_bar(kTue_1645_ET + i * 15 * kMinuteMs));
+    eng.run(bars.data(), (int)bars.size(), "", "15");
+
+    CHECK(eng.last_error().empty());
+    CHECK(eng.seen.size() == 8);
+    if (eng.seen.size() != 8) return;
+
+    // Intraday: the generated-code call, the pump state and the raw
+    // time-of-day form agree on every bar, for all three predicates.
+    for (const SeenBar& s : eng.seen) {
+        CHECK(s.ismarket == s.raw_ismarket);
+        CHECK(s.engine_ismarket == s.raw_ismarket);
+        CHECK(s.ispremarket == s.raw_ispremarket);
+        CHECK(s.ispostmarket == s.raw_ispostmarket);
+    }
+    // The pinned values: 16:45 in (last bar before the break), 17:00 ..
+    // 17:45 out (the 1700-1800 break), 18:00 in (first bar of the new
+    // session day), 18:15 in.
+    CHECK(eng.seen[0].ismarket == true);    // 16:45
+    CHECK(eng.seen[0].islastbar == true);
+    CHECK(eng.seen[1].ismarket == false);   // 17:00
+    CHECK(eng.seen[2].ismarket == false);   // 17:15
+    CHECK(eng.seen[2].isfirstbar == false);
+    CHECK(eng.seen[2].islastbar == false);
+    CHECK(eng.seen[3].ismarket == false);   // 17:30
+    CHECK(eng.seen[4].ismarket == false);   // 17:45
+    CHECK(eng.seen[5].ismarket == true);    // 18:00
+    CHECK(eng.seen[5].isfirstbar == true);
+    CHECK(eng.seen[5].islastbar == false);
+    CHECK(eng.seen[6].ismarket == true);    // 18:15
+    CHECK(eng.seen[6].isfirstbar == false);
+    CHECK(eng.seen[7].ismarket == true);    // 18:30
+}
+
+// --- 0930-1600 on a 1D feed ------------------------------------------------
+
+void test_rth_1d_feed_midnight_utc_stamp() {
+    std::printf("test_rth_1d_feed_midnight_utc_stamp\n");
+    SessionProbeEngine eng;
+    eng.set_syminfo_session(kRthSession);
+    eng.set_syminfo_timezone(kNyTz);
+    const auto bars = daily_bars(kMon_0000_UTC, 5);
+    eng.run(bars.data(), (int)bars.size(), "D", "D");
+
+    check_every_bar_is_the_session(eng, 5);
+    // 00:00 UTC is 20:00 ET — outside RTH by time of day.
+    for (const SeenBar& s : eng.seen) CHECK(s.raw_ismarket == false);
+}
+
+// --- a daily chart aggregated from an intraday feed ------------------------
+
+void test_xauusd_daily_chart_aggregated_from_60m_feed() {
+    std::printf("test_xauusd_daily_chart_aggregated_from_60m_feed\n");
+    SessionProbeEngine eng;
+    eng.set_syminfo_session(kXauSession);
+    eng.set_syminfo_timezone(kNyTz);
+    // 60m bars from Mon 18:00 ET through Wed 17:00 ET (two session days).
+    std::vector<Bar> bars;
+    const int64_t first = kMon_1700_ET + kHourMs;  // Mon 18:00 ET
+    for (int i = 0; i < 48; ++i) bars.push_back(make_bar(first + i * kHourMs));
+    eng.run(bars.data(), (int)bars.size(), "60", "D");
+
+    CHECK(eng.last_error().empty());
+    CHECK(!eng.seen.empty());
+    for (const SeenBar& s : eng.seen) {
+        CHECK(s.ismarket == true);
+        CHECK(s.ispremarket == false);
+        CHECK(s.ispostmarket == false);
+        CHECK(s.engine_ismarket == true);
+        CHECK(s.isfirstbar == true);
+        CHECK(s.islastbar == true);
+    }
+}
+
+// --- the streaming pump's realtime daily bar -------------------------------
+
+void test_xauusd_1d_stream_realtime_bar() {
+    std::printf("test_xauusd_1d_stream_realtime_bar\n");
+    SessionProbeEngine eng;
+    eng.set_syminfo_session(kXauSession);
+    eng.set_syminfo_timezone(kNyTz);
+    const auto warmup = daily_bars(kMon_1700_ET, 4);  // Mon..Thu
+    const bool began = eng.stream_begin(warmup.data(), (int)warmup.size(), "D", "D");
+    CHECK(began);
+    if (!began) {
+        std::printf("    last_error: %s\n", eng.last_error().c_str());
+        return;
+    }
+    // Friday's bar: a trade at 17:05 ET, then the clock passes Saturday
+    // 17:00 ET so the bar finalizes through stream_dispatch_script_bar.
+    const int64_t fri_1700 = kMon_1700_ET + 4 * kDayMs;
+    CHECK(eng.stream_push_tick(TradeTick{fri_1700 + 5 * kMinuteMs, 1, 100.25, 1.0}));
+    CHECK(eng.stream_advance_time(fri_1700 + kDayMs));
+    CHECK(eng.stream_end(false));
+
+    check_every_bar_is_the_session(eng, 5);
+    for (const SeenBar& s : eng.seen) CHECK(s.raw_ismarket == false);
+}
+
+// --- the chart-timeframe forms directly ------------------------------------
+
+void test_chart_tf_forms_direct() {
+    std::printf("test_chart_tf_forms_direct\n");
+    const char* daily_or_higher[] = {"D", "1D", "2D", "W", "1W", "M", "1M", "3M"};
+    for (const char* tf : daily_or_higher) {
+        CHECK(tf_is_daily_or_higher(tf));
+        // Premarket / postmarket stamps by time of day: the daily rule wins.
+        CHECK(pine_session_ismarket(kRthSession, kNyTz, kTue_0500_ET, tf) == true);
+        CHECK(pine_session_ismarket(kRthSession, kNyTz, kTue_1900_ET, tf) == true);
+        CHECK(pine_session_ismarket(kXauSession, kNyTz, kMon_1700_ET, tf) == true);
+        CHECK(pine_session_ispremarket(kRthSession, kNyTz, kTue_0500_ET, tf) == false);
+        CHECK(pine_session_ispostmarket(kRthSession, kNyTz, kTue_1900_ET, tf) == false);
+    }
+    // Controls: those stamps really are pre/post-market by time of day.
+    CHECK(pine_session_ispremarket(kRthSession, kNyTz, kTue_0500_ET) == true);
+    CHECK(pine_session_ispostmarket(kRthSession, kNyTz, kTue_1900_ET) == true);
+    CHECK(pine_session_ismarket(kRthSession, kNyTz, kTue_0500_ET) == false);
+    CHECK(pine_session_ismarket(kXauSession, kNyTz, kMon_1700_ET) == false);
+
+    // Intraday and undetected chart timeframes defer to the time-of-day
+    // forms byte for byte.
+    const char* intraday[] = {"", "1", "15", "60", "240"};
+    const int64_t stamps[] = {kTue_0500_ET, kTue_1030_ET, kTue_1900_ET, kMon_1700_ET, kTue_1645_ET};
+    for (const char* tf : intraday) {
+        CHECK(!tf_is_daily_or_higher(tf));
+        for (int64_t ts : stamps) {
+            CHECK(pine_session_ismarket(kRthSession, kNyTz, ts, tf)
+                  == pine_session_ismarket(kRthSession, kNyTz, ts));
+            CHECK(pine_session_ismarket(kXauSession, kNyTz, ts, tf)
+                  == pine_session_ismarket(kXauSession, kNyTz, ts));
+            CHECK(pine_session_ispremarket(kRthSession, kNyTz, ts, tf)
+                  == pine_session_ispremarket(kRthSession, kNyTz, ts));
+            CHECK(pine_session_ispostmarket(kRthSession, kNyTz, ts, tf)
+                  == pine_session_ispostmarket(kRthSession, kNyTz, ts));
+        }
+    }
+    CHECK(pine_session_ismarket(kRthSession, kNyTz, kTue_1030_ET, "15") == true);
+    CHECK(pine_session_ismarket(kRthSession, kNyTz, kTue_1900_ET, "15") == false);
+}
+
+}  // namespace
+
+int main() {
+    test_xauusd_1d_feed_every_bar_is_market();
+    test_xauusd_1d_feed_explicit_1D_spelling();
+    test_xauusd_1d_feed_single_timeframe_run();
+    test_xauusd_15m_feed_keeps_time_of_day_rule();
+    test_rth_1d_feed_midnight_utc_stamp();
+    test_xauusd_daily_chart_aggregated_from_60m_feed();
+    test_xauusd_1d_stream_realtime_bar();
+    test_chart_tf_forms_direct();
+
+    std::printf("\nsession_predicates_daily_chart: %d passed, %d failed\n",
+                tests_passed, tests_failed);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/tests/test_short_seed_close_collision.cpp
+++ b/tests/test_short_seed_close_collision.cpp
@@ -646,7 +646,12 @@ public:
             // Signal-time margin rejection: no PendingOrder/incarnation remains,
             // so the source-bar rejection tombstone is the only proof this was
             // not the exact three-call book.
-            strategy_entry("Rejected", true, kNaN, kNaN, 1'000'000.0);
+            // An over-notional SAME-direction add: rejected at placement, no
+            // order object. (It used to be an opposite-direction call; under
+            // design-market-entry-affordability a rejected REVERSAL keeps its
+            // closing leg as a queued close-only order, so it would no longer
+            // be an invisible rejection.)
+            strategy_entry("Rejected", false, kNaN, kNaN, 1'000'000.0);
         }
 
         strategy_entry("Long", true,

--- a/tests/test_ta_extremes_ring.cpp
+++ b/tests/test_ta_extremes_ring.cpp
@@ -506,6 +506,70 @@ static void test_htf_context_sanity() {
     CHECK(!ta::bar_context().installed);
 }
 
+
+// --- Cached extremum with an implied bar (pinned 2026-09-04: 8 NYSE:F 1D
+// alias tapes 696/696, BINANCE:ETHUSDT.P 15 geometry pin 82/82, jayentriken
+// BBWP ETH replay 593/593) ------------------------------------------------
+
+// t382 geometry (`m = bar_index % 49; exec = m < 4 or 37 <= m < 47 or m == 48`,
+// ta.lowest(low, 10)): bar 3's stale 9.20 aliases one slot behind bar 48, yet
+// TV answers the cached 9.88 (from bar 42) on bars 48..51 and only rescans to
+// 9.20 on bar 52, once the cache has aged `length` bars.
+static void test_cached_extremum_keeps_over_aliased_slot_until_expiry() {
+    std::printf("test_cached_extremum_keeps_over_aliased_slot_until_expiry\n");
+    ta::Lowest lo(10);
+    auto low_at = [](int b) {
+        if (b == 3) return 9.20;
+        if (b < 4) return 9.50;
+        if (b == 42) return 9.88;
+        if (b >= 37 && b <= 46) return 10.00;
+        return 10.50;                       // bars 48..52
+    };
+    auto executes = [](int b) {
+        const int m = b % 49;
+        return m < 4 || (m >= 37 && m < 47) || m == 48 || (b >= 49 && b <= 52);
+    };
+    for (int b = 0; b <= 52; ++b) {
+        ta::BarContextScope scope(b, 0);
+        if (!executes(b)) continue;
+        const double v = lo.compute(low_at(b));
+        if (b < 9) CHECK(is_na(v));                       // bar_index < length - 1
+        if (b == 46) CHECK(near(v, 9.88));                // fresh window minimum, bar 42
+        if (b >= 48 && b <= 51) CHECK(near(v, 9.88));     // cache (9.88, 42) younger than 10 bars: slot 3 unread
+        if (b == 52) CHECK(near(v, 9.20));                // aged out: rescan reads the aliased slot
+    }
+}
+
+// ETH #88 geometry (ta.lowest(low, 10) inside `if strategy.position_size > 0`):
+// a 17-bar run whose 7th bar leaves 2641.73 in the slot that aliases k=6
+// behind the next run's first bar, then a 50-bar gap. TV answers the run-start
+// bar's own low 2648.62 because it beats the expired cache (2650.47) — the
+// new-extremum test comes before the rescan. The control run-start (r17g50 @
+// bar 67: own low above the cache) rescans and reads the aliased slot.
+static void run_eth88_geometry(double run_start_low, double expected) {
+    ta::Lowest lo(10);
+    for (int b = 0; b <= 87; ++b) {
+        ta::BarContextScope scope(b, 0);
+        const bool in_run = b >= 20 && b <= 36;
+        if (!in_run && b != 87) continue;
+        double src;
+        if (b == 26) src = 2641.73;                       // the 7th bar of the run: slot 26 % 11 = 4
+        else if (in_run) src = 2650.47 + (b % 3) * 0.5;   // minimum 2650.47 at bars 21, 24, ...
+        else src = run_start_low;                          // bar 87: 87 - 6 = 81, 81 % 11 = 4 -> the aliased slot
+        const double v = lo.compute(src);
+        if (b == 35) CHECK(near(v, 2641.73));             // cache (2641.73, 26) still 9 bars young
+        if (b == 36) CHECK(near(v, 2650.47));             // aged out at 10 bars: rescan of 27..36
+        if (b == 87) CHECK(near(v, expected));
+    }
+}
+
+static void test_new_extremum_precedes_expiry_rescan() {
+    std::printf("test_new_extremum_precedes_expiry_rescan\n");
+    run_eth88_geometry(2648.62, 2648.62);   // ETH #88: below the expired cache -> own low, no rescan
+    run_eth88_geometry(2652.00, 2641.73);   // r17g50 @67: above the cache -> rescan reads the aliased slot
+    CHECK(!ta::bar_context().installed);
+}
+
 int main() {
     test_cadence7_pin();
     test_cadence9_pin();
@@ -514,6 +578,8 @@ int main() {
     test_bars_variants_ring();
     test_every_bar_identity();
     test_htf_context_sanity();
+    test_cached_extremum_keeps_over_aliased_slot_until_expiry();
+    test_new_extremum_precedes_expiry_rescan();
     std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
     return g_fail ? 1 : 0;
 }

--- a/tests/test_ta_extremes_ring.cpp
+++ b/tests/test_ta_extremes_ring.cpp
@@ -1,0 +1,519 @@
+/*
+ * test_ta_extremes_ring.cpp — TradingView's bar-addressed ring for the window
+ * extremes (ta.highest / ta.lowest / ta.highestbars / ta.lowestbars) and the
+ * per-context bar index the engine installs for it (ta::bar_context()).
+ *
+ * The rule (pinned 2026-09-03 with `lab tv` on NYSE:F 1D, range 2025-04-01..
+ * 2026-05-01, tapes scratchpad/r5/pins/out-pin-ring-highest{,-c9}): a window
+ * call site owns K = length + 1 slots addressed by bar_index % K; a call on
+ * bar b writes slot[b % K] = src and returns the extremum over the WRITTEN
+ * slots (b - k) % K, k in [0, length). Stale values from earlier executions
+ * survive in slots not rewritten, never-written slots are skipped, and the
+ * result is na iff bar_index < length - 1 — NOT until `length` executions.
+ *
+ *   pin-ring-highest.pine:  if bar_index % 7 == 3
+ *                               v = ta.highest(high, 5)
+ *                               strategy.entry("L", strategy.long, qty=math.round(v*100))
+ *   pin-ring-highest-c9.pine: the same with `% 9`.
+ *
+ * TV's entry sizes are round(v*100) (na -> default qty 1), so the tapes pin v
+ * at every execution bar: cadence 7 (bars 3,10,17,...) -> na, 9.73, 10.10,
+ * 10.62, 10.78 x5, 11.85 ...; cadence 9 (bars 3,12,21,...) -> na, 9.73, 10.32,
+ * 10.70, 10.70, 10.65, 10.87, 11.85 ... (call 6 = 10.65: a per-call buffer
+ * would still hold 10.70 — only the bar-addressed ring drops it).
+ *
+ * Every-bar callers must stay byte-identical to the previous positional deque
+ * in every context; the deque is reproduced here as the reference.
+ *
+ * NDEBUG-PROOF: self-rolled CHECK with a failure counter; main() returns
+ * nonzero on any failure.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <deque>
+#include <vector>
+
+#include <pineforge/ta.hpp>
+#include <pineforge/na.hpp>
+
+using namespace pineforge;
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            std::fprintf(stderr, "FAIL %s:%d %s\n", __FILE__, __LINE__, #cond); \
+            ++g_fail;                                                          \
+        } else {                                                               \
+            ++g_pass;                                                          \
+        }                                                                      \
+    } while (0)
+
+static bool near(double a, double b, double tol = 1e-9) {
+    return std::fabs(a - b) <= tol;
+}
+
+// Bitwise-equal-or-both-na: the identity the every-bar proofs demand.
+static bool same(double a, double b) {
+    if (is_na(a) || is_na(b)) return is_na(a) && is_na(b);
+    return a == b;
+}
+
+// NYSE:F 1D highs, bars 0..89 of the pinned chart range (bar 0 = 2025-04-01),
+// from the campaign feed (`lab bars NYSE:F 1D`). Bar 3 = 9.73, bar 10 = 9.63.
+static const double kHighs[90] = {
+    10.17, 10.27, 10.2, 9.73, 9.64, 9.52, 9.54, 9.28, 9.35, 9.81, 9.63, 9.62,
+    9.69, 9.63, 9.72, 10.0054, 10.09, 10.1, 10.18, 10.19, 10.13, 10.32, 10.39,
+    10.24, 10.62, 10.505, 10.464, 10.49, 10.73, 10.63, 10.7, 10.78, 10.81,
+    10.785, 10.84, 10.69, 10.5, 10.41, 10.4897, 10.335, 10.28, 10.46, 10.28,
+    10.225, 10.365, 10.25, 10.35, 10.45, 10.65, 10.77, 10.59, 10.51, 10.67,
+    10.63, 10.53, 10.6, 10.75, 10.87, 10.765, 10.65, 10.92, 10.86, 11.38,
+    11.78, 11.96, 11.79, 11.85, 11.9, 11.97, 11.86, 11.895, 11.93, 11.45,
+    11.3465, 11.24, 11.45, 11.29, 11.46, 11.429, 11.49, 11.49, 11.29, 11.125,
+    11.15, 10.92, 11.02, 11.1, 11.26, 11.385, 11.37};
+static const int kNumHighs = 90;
+
+// TV "Size (qty)" column of the pinned tapes at each execution bar
+// (round(v*100); 1 = na -> default qty). The first 13 / 10 entries fall
+// inside the 90-bar window above.
+static const int kTvSizesCadence7[13] = {1, 973, 1010, 1062, 1078, 1078, 1078,
+                                         1078, 1078, 1185, 1185, 1185, 1185};
+static const int kTvSizesCadence9[10] = {1, 973, 1032, 1070, 1070, 1065, 1087,
+                                         1185, 1185, 1145};
+
+static int tv_size(double v) {
+    return is_na(v) ? 1 : static_cast<int>(std::llround(v * 100.0));
+}
+
+// --- The previous implementation, kept verbatim as the every-bar reference ---
+
+struct RefHighest {
+    std::deque<double> buffer;
+    int length;
+    explicit RefHighest(int len) : length(len) {}
+    double compute(double src) {
+        buffer.push_back(src);
+        while ((int)buffer.size() > length) buffer.pop_front();
+        if ((int)buffer.size() < length) return na<double>();
+        double hi = na<double>();
+        for (int i = 0; i < (int)buffer.size(); i++)
+            if (!is_na(buffer[i]) && (is_na(hi) || buffer[i] > hi)) hi = buffer[i];
+        return hi;
+    }
+    double recompute(double src) {
+        if (buffer.empty()) return compute(src);
+        buffer.back() = src;
+        if ((int)buffer.size() < length) return na<double>();
+        double hi = na<double>();
+        for (int i = 0; i < (int)buffer.size(); i++)
+            if (!is_na(buffer[i]) && (is_na(hi) || buffer[i] > hi)) hi = buffer[i];
+        return hi;
+    }
+};
+
+struct RefLowest {
+    std::deque<double> buffer;
+    int length;
+    explicit RefLowest(int len) : length(len) {}
+    double compute(double src) {
+        buffer.push_back(src);
+        while ((int)buffer.size() > length) buffer.pop_front();
+        if ((int)buffer.size() < length) return na<double>();
+        double lo = na<double>();
+        for (int i = 0; i < (int)buffer.size(); i++)
+            if (!is_na(buffer[i]) && (is_na(lo) || buffer[i] < lo)) lo = buffer[i];
+        return lo;
+    }
+    double recompute(double src) {
+        if (buffer.empty()) return compute(src);
+        buffer.back() = src;
+        if ((int)buffer.size() < length) return na<double>();
+        double lo = na<double>();
+        for (int i = 0; i < (int)buffer.size(); i++)
+            if (!is_na(buffer[i]) && (is_na(lo) || buffer[i] < lo)) lo = buffer[i];
+        return lo;
+    }
+};
+
+struct RefHighestBars {
+    int length_;
+    std::deque<double> buffer_;
+    explicit RefHighestBars(int len) : length_(len) {}
+    double compute(double src) {
+        if (is_na(src)) return na<double>();
+        buffer_.push_back(src);
+        while ((int)buffer_.size() > length_) buffer_.pop_front();
+        if ((int)buffer_.size() < length_) return na<double>();
+        int max_idx = 0;
+        double max_val = buffer_[0];
+        for (int i = 1; i < (int)buffer_.size(); i++)
+            if (buffer_[i] > max_val) { max_val = buffer_[i]; max_idx = i; }
+        return (double)(max_idx - ((int)buffer_.size() - 1));
+    }
+    double recompute(double src) {
+        if (buffer_.empty()) return compute(src);
+        buffer_.back() = src;
+        if (is_na(src)) return na<double>();
+        if ((int)buffer_.size() < length_) return na<double>();
+        int max_idx = 0;
+        double max_val = buffer_[0];
+        for (int i = 1; i < (int)buffer_.size(); i++)
+            if (buffer_[i] > max_val) { max_val = buffer_[i]; max_idx = i; }
+        return (double)(max_idx - ((int)buffer_.size() - 1));
+    }
+};
+
+struct RefLowestBars {
+    int length_;
+    std::deque<double> buffer_;
+    explicit RefLowestBars(int len) : length_(len) {}
+    double compute(double src) {
+        if (is_na(src)) return na<double>();
+        buffer_.push_back(src);
+        while ((int)buffer_.size() > length_) buffer_.pop_front();
+        if ((int)buffer_.size() < length_) return na<double>();
+        int min_idx = 0;
+        double min_val = buffer_[0];
+        for (int i = 1; i < (int)buffer_.size(); i++)
+            if (buffer_[i] < min_val) { min_val = buffer_[i]; min_idx = i; }
+        return (double)(min_idx - ((int)buffer_.size() - 1));
+    }
+    double recompute(double src) {
+        if (buffer_.empty()) return compute(src);
+        buffer_.back() = src;
+        if (is_na(src)) return na<double>();
+        if ((int)buffer_.size() < length_) return na<double>();
+        int min_idx = 0;
+        double min_val = buffer_[0];
+        for (int i = 1; i < (int)buffer_.size(); i++)
+            if (buffer_[i] < min_val) { min_val = buffer_[i]; min_idx = i; }
+        return (double)(min_idx - ((int)buffer_.size() - 1));
+    }
+};
+
+// Deterministic LCG series; `na_every` > 0 plants an na gap every that many
+// bars (0 = gap-free).
+static std::vector<double> make_series(int n, unsigned seed, int na_every) {
+    std::vector<double> out;
+    out.reserve(static_cast<std::size_t>(n));
+    unsigned x = seed;
+    for (int i = 0; i < n; ++i) {
+        x = x * 1664525u + 1013904223u;
+        double v = 100.0 + static_cast<double>((x >> 8) % 100000) / 1000.0;
+        if (na_every > 0 && (i % na_every) == na_every - 1) v = na<double>();
+        out.push_back(v);
+    }
+    return out;
+}
+
+// --- Cadence pins: the two TV tapes, replayed bar by bar as the chart does ---
+
+static void test_cadence7_pin() {
+    std::printf("test_cadence7_pin\n");
+    ta::Highest hi(5);
+    int call = 0;
+    for (int b = 0; b < kNumHighs; ++b) {
+        ta::BarContextScope scope(b, 0);
+        if (b % 7 != 3) continue;
+        double v = hi.compute(kHighs[b]);
+        CHECK(call < 13);
+        if (call < 13) CHECK(tv_size(v) == kTvSizesCadence7[call]);
+        if (call == 0) CHECK(is_na(v));                 // bar 3 < length - 1 = 4
+        if (call == 1) CHECK(near(v, 9.73));            // max{bar 3, bar 10}: 2 executions, not na
+        if (call == 5) CHECK(near(v, 10.78));           // bar 31's 10.78 survives in slot 1
+        ++call;
+    }
+    CHECK(call == 13);
+    CHECK(!ta::bar_context().installed);   // every scope restored on exit
+}
+
+static void test_cadence9_pin() {
+    std::printf("test_cadence9_pin\n");
+    ta::Highest hi(5);
+    int call = 0;
+    for (int b = 0; b < kNumHighs; ++b) {
+        ta::BarContextScope scope(b, 0);
+        if (b % 9 != 3) continue;
+        double v = hi.compute(kHighs[b]);
+        CHECK(call < 10);
+        if (call < 10) CHECK(tv_size(v) == kTvSizesCadence9[call]);
+        // Call 6 (bar 48, high 10.65): slots read are bars 48,47,46,45,44 ->
+        // 48%6=0 (this call), 47%6=5, 46%6=4, 45%6=3, 44%6=2; 10.70 (bar 30,
+        // slot 0) was just overwritten and 10.335 (bar 39, slot 3) is beaten,
+        // so 10.65 — a per-call buffer would still answer 10.70.
+        if (call == 5) CHECK(near(v, 10.65));
+        ++call;
+    }
+    CHECK(call == 10);
+}
+
+// The same tapes with the cadence guard evaluated through the ring but the
+// remaining bars also *seen* by the context (no call) — i.e. the guard is the
+// only thing that differs from an every-bar caller, exactly as in Pine.
+static void test_cadence_pin_lowest_mirror() {
+    std::printf("test_cadence_pin_lowest_mirror\n");
+    for (int cadence : {7, 9}) {
+        ta::Highest hi(5);
+        ta::Lowest lo(5);
+        for (int b = 0; b < kNumHighs; ++b) {
+            ta::BarContextScope scope(b, 0);
+            if (b % cadence != 3) continue;
+            double h = hi.compute(kHighs[b]);
+            double l = lo.compute(-kHighs[b]);
+            CHECK(same(l, is_na(h) ? h : -h));   // lowest(-x) == -highest(x)
+        }
+    }
+}
+
+// --- na iff bar_index < length - 1 (never "until length executions") ---
+
+static void test_na_until_bar_length_minus_1() {
+    std::printf("test_na_until_bar_length_minus_1\n");
+    // A caller executing on bars 0..3 of a length-5 window: na on every one,
+    // then bar 4 answers from the written slots even though bar 4 is only
+    // the 2nd execution of the second object below.
+    {
+        ta::Highest every(5);
+        for (int b = 0; b < 4; ++b) {
+            ta::BarContextScope scope(b, 0);
+            CHECK(is_na(every.compute(1.0 + b)));
+        }
+        ta::BarContextScope scope(4, 0);
+        CHECK(near(every.compute(0.5), 4.0));
+    }
+    {
+        ta::Highest sparse(5);
+        { ta::BarContextScope scope(2, 0); CHECK(is_na(sparse.compute(7.0))); }
+        { ta::BarContextScope scope(4, 0); CHECK(near(sparse.compute(3.0), 7.0)); }  // max{bar 2, bar 4}
+        { ta::BarContextScope scope(5, 0); CHECK(near(sparse.compute(2.0), 7.0)); }  // bar 2 still in slot 2
+    }
+    // Slot walk: K = 6, bar 8 reads slots 8%6=2 (this call, 1.0), 7%6=1
+    // (never), 6%6=0 (never), 5%6=5 (bar 5, 2.0), 4%6=4 (bar 4, 3.0). Bar 2
+    // wrote slot 2 — overwritten by bar 8 — so the answer is 3.0, not 7.0.
+    {
+        ta::Highest sparse(5);
+        { ta::BarContextScope scope(2, 0); sparse.compute(7.0); }
+        { ta::BarContextScope scope(4, 0); sparse.compute(3.0); }
+        { ta::BarContextScope scope(5, 0); sparse.compute(2.0); }
+        { ta::BarContextScope scope(8, 0); CHECK(near(sparse.compute(1.0), 3.0)); }
+    }
+    // Origin: a feed whose first bar is Pine bar 7 warms up over ITS first
+    // `length` bars (identical to the deque), not TV's bar_index rule alone.
+    {
+        ta::Highest hi(3);
+        { ta::BarContextScope scope(7, 7); CHECK(is_na(hi.compute(1.0))); }
+        { ta::BarContextScope scope(8, 7); CHECK(is_na(hi.compute(2.0))); }
+        { ta::BarContextScope scope(9, 7); CHECK(near(hi.compute(0.5), 2.0)); }
+    }
+    // length <= 0 stays na forever (compat with the deque's empty window).
+    {
+        ta::Highest zero(0);
+        ta::Lowest neg(-2);
+        for (int b = 0; b < 4; ++b) {
+            ta::BarContextScope scope(b, 0);
+            CHECK(is_na(zero.compute(1.0)));
+            CHECK(is_na(neg.compute(1.0)));
+        }
+    }
+}
+
+// --- The *Bars variants: bars back = k of the extremum slot ---
+
+static void test_bars_variants_ring() {
+    std::printf("test_bars_variants_ring\n");
+    // Cadence 7, length 5, K = 6, over the pinned highs. Derived from the rule
+    // (no TV tape for highestbars): offsets are slot distances, so bar 3's
+    // stale 9.73 sits 1 slot behind bar 10 and beats it; bar 31's 10.78 walks
+    // back 1,2,3,4 slots across bars 38..59 and bar 66's 11.85 resets to 0.
+    static const double kExpect[10] = {0, -1, 0, 0, 0, -1, -2, -3, -4, 0};
+    ta::HighestBars hb(5);
+    ta::LowestBars lb(5);
+    int call = 0;
+    for (int b = 0; b < 70; ++b) {
+        ta::BarContextScope scope(b, 0);
+        if (b % 7 != 3) continue;
+        double v = hb.compute(kHighs[b]);
+        double w = lb.compute(-kHighs[b]);
+        if (call == 0) {
+            CHECK(is_na(v));
+            CHECK(is_na(w));
+        } else {
+            CHECK(near(v, kExpect[call]));
+            CHECK(near(w, kExpect[call]));   // mirror: lowestbars(-x) == highestbars(x)
+        }
+        ++call;
+    }
+    CHECK(call == 10);
+
+    // Fresh-window tie rule: the OLDEST equal extremum wins (as the deque scan
+    // did), in both context and standalone mode.
+    {
+        ta::HighestBars t(4);
+        ta::LowestBars u(4);
+        double xs[4] = {5.0, 9.0, 9.0, 1.0};
+        double ys[4] = {5.0, 1.0, 1.0, 9.0};
+        double v = na<double>(), w = na<double>();
+        for (int b = 0; b < 4; ++b) {
+            ta::BarContextScope scope(b, 0);
+            v = t.compute(xs[b]);
+            w = u.compute(ys[b]);
+        }
+        CHECK(near(v, -2.0));
+        CHECK(near(w, -2.0));
+        ta::HighestBars t2(4);
+        for (int b = 0; b < 4; ++b) v = t2.compute(xs[b]);
+        CHECK(near(v, -2.0));
+    }
+
+    // na input: recorded as a positional gap (skipped by the extremum) and
+    // answers na on that bar; the offset then points at the real bar. The
+    // deque skipped na without advancing, so {9, na, 7, 2} at length 3
+    // answered -2 (the 9, actually 3 bars back) — TV's series is positional.
+    {
+        ta::HighestBars t(3);
+        double v = na<double>();
+        double xs[4] = {9.0, na<double>(), 7.0, 2.0};
+        for (int b = 0; b < 4; ++b) {
+            ta::BarContextScope scope(b, 0);
+            v = t.compute(xs[b]);
+            if (b == 1) CHECK(is_na(v));
+        }
+        CHECK(near(v, -1.0));   // window {na, 7, 2} -> 7, one bar back
+    }
+}
+
+// --- Every-bar callers: byte-identical to the deque, in every mode ---
+
+// mode 0: no context installed (standalone / unit-test cadence)
+// mode 1: chart context, bars 0..n-1, origin 0
+// mode 2: chart context after a bar_index_offset: bars 1000.., origin 1000
+// Every third bar also issues a recompute() with a different value (bar
+// magnifier / lookahead partial ticks) before moving on.
+template <class Ring, class Ref>
+static void every_bar_identity(int length, int mode, int na_every, unsigned seed) {
+    const int n = 257;
+    std::vector<double> xs = make_series(n, seed, na_every);
+    std::vector<double> ys = make_series(n, seed ^ 0x9e3779b9u, na_every);
+    Ring ring(length);
+    Ref ref(length);
+    for (int b = 0; b < n; ++b) {
+        long long bar = mode == 2 ? 1000 + b : b;
+        long long origin = mode == 2 ? 1000 : 0;
+        if (mode == 0) {
+            CHECK(same(ring.compute(xs[b]), ref.compute(xs[b])));
+            if (b % 3 == 2) CHECK(same(ring.recompute(ys[b]), ref.recompute(ys[b])));
+        } else {
+            ta::BarContextScope scope(bar, origin);
+            CHECK(same(ring.compute(xs[b]), ref.compute(xs[b])));
+            if (b % 3 == 2) CHECK(same(ring.recompute(ys[b]), ref.recompute(ys[b])));
+        }
+    }
+}
+
+static void test_every_bar_identity() {
+    std::printf("test_every_bar_identity\n");
+    for (int length : {1, 2, 3, 5, 8, 13, 50}) {
+        for (int mode = 0; mode < 3; ++mode) {
+            // Highest / Lowest: positional deque incl. na gaps -> identical
+            // with gaps planted every 7th bar.
+            every_bar_identity<ta::Highest, RefHighest>(length, mode, 7, 17u + length);
+            every_bar_identity<ta::Lowest, RefLowest>(length, mode, 7, 29u + length);
+            every_bar_identity<ta::Highest, RefHighest>(length, mode, 0, 3u + length);
+            every_bar_identity<ta::Lowest, RefLowest>(length, mode, 0, 5u + length);
+            // *Bars: identical on gap-free series (the deque's na rule was
+            // non-positional; see test_bars_variants_ring).
+            every_bar_identity<ta::HighestBars, RefHighestBars>(length, mode, 0, 7u + length);
+            every_bar_identity<ta::LowestBars, RefLowestBars>(length, mode, 0, 11u + length);
+        }
+    }
+    // recompute() before the first compute() behaves as the first bar (the
+    // pristine rule the recompute suite pins), with and without a context.
+    {
+        ta::Highest a(3);
+        RefHighest r(3);
+        CHECK(same(a.recompute(2.0), r.recompute(2.0)));
+        CHECK(same(a.compute(5.0), r.compute(5.0)));
+        CHECK(same(a.compute(1.0), r.compute(1.0)));
+        ta::HighestBars hb(2);
+        CHECK(is_na(hb.recompute(1.0)));
+        ta::BarContextScope scope(0, 0);
+        ta::Lowest c(2);
+        CHECK(is_na(c.recompute(4.0)));
+    }
+}
+
+// --- request.security context: its own index, nested inside the chart's ---
+
+// Models the engine's dispatch: the chart scope wraps on_bar with the Pine
+// bar_index; each security evaluation is dispatched under the requested
+// context's evaluated-bar index (complete: eval_complete_count - 1, partial:
+// eval_complete_count). An HTF of ratio 4 with lookahead partial ticks: the
+// every-bar HTF caller must equal the deque fed one value per HTF bar, the
+// partial recomputes must not advance it, and the chart's own ring must be
+// unaffected by the nested scope.
+static void test_htf_context_sanity() {
+    std::printf("test_htf_context_sanity\n");
+    const int ratio = 4;
+    const int n = 200;
+    std::vector<double> chart = make_series(n, 99u, 0);
+    ta::Highest chart_hi(5);
+    RefHighest chart_ref(5);
+    ta::Highest htf_hi(3);
+    RefHighest htf_ref(3);
+    ta::Highest htf_cond(3);   // conditional HTF caller: executes on even HTF bars only
+    long long eval_complete = 0;
+    double bucket_high = na<double>();
+    int sub = 0;
+    for (int b = 0; b < n; ++b) {
+        ta::BarContextScope chart_scope(b, 0);
+        // --- security feed for this chart bar (engine: before on_bar) ---
+        bucket_high = is_na(bucket_high) ? chart[b] : std::fmax(bucket_high, chart[b]);
+        ++sub;
+        const bool complete = (sub == ratio);
+        if (complete) ++eval_complete;
+        const long long sec_bar = complete ? eval_complete - 1 : eval_complete;
+        {
+            ta::BarContextScope sec_scope(sec_bar, 0);
+            CHECK(ta::bar_context().bar_index == sec_bar);
+            // codegen: compute on the bucket's first tick, recompute after.
+            if (sub == 1) {
+                htf_hi.compute(bucket_high);
+                htf_ref.compute(bucket_high);
+            } else {
+                double v = htf_hi.recompute(bucket_high);
+                CHECK(same(v, htf_ref.recompute(bucket_high)));
+            }
+            if (complete && (sec_bar % 2 == 0)) {
+                double v = htf_cond.recompute(bucket_high);
+                // Conditional HTF caller, K = 4: HTF bar 2 reads slots 2,1,0
+                // -> bars 2 and 0 written -> max of the two even buckets so
+                // far; never na past HTF bar 1.
+                if (sec_bar >= 2) CHECK(!is_na(v));
+                if (sec_bar == 0) CHECK(is_na(v));
+            }
+        }
+        CHECK(ta::bar_context().installed && ta::bar_context().bar_index == b);
+        if (complete) {
+            sub = 0;
+            bucket_high = na<double>();
+        }
+        // --- chart on_bar ---
+        CHECK(same(chart_hi.compute(chart[b]), chart_ref.compute(chart[b])));
+    }
+    CHECK(!ta::bar_context().installed);
+}
+
+int main() {
+    test_cadence7_pin();
+    test_cadence9_pin();
+    test_cadence_pin_lowest_mirror();
+    test_na_until_bar_length_minus_1();
+    test_bars_variants_ring();
+    test_every_bar_identity();
+    test_htf_context_sanity();
+    std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail ? 1 : 0;
+}

--- a/tests/test_trail_open_arm_subtick_offset.cpp
+++ b/tests/test_trail_open_arm_subtick_offset.cpp
@@ -1,0 +1,493 @@
+/*
+ * test_trail_open_arm_subtick_offset.cpp — two trailing-exit rules pinned
+ * from TradingView tapes (winthetrade-ema-9-vwap-strategy-with-atr-trailing-
+ * stop family: strategy.exit("x", trail_points = atr*2, trail_offset = atr*2),
+ * a price-unit ATR passed as TICKS; 7 lanes, entry/exit timestamps exact,
+ * exit PRICE wrong on the same bar).
+ *
+ * (B) The bar's OPEN is the first price a resting trail observes. A trail
+ *     whose activation the open already sits past arms AT the open with
+ *     best = open, so an adverse-first leg fills at open -/+ offset. The
+ *     engine only folded prices in at the END of each path segment, stayed
+ *     dormant through the retrace, armed at the favourable extreme and
+ *     filled at extreme -/+ offset.
+ *       OANDA:XAUUSD 15m long 2025-04-04 10:45Z @3110.31 (POOC close fill);
+ *         11:00Z bar O 3110.40 H 3136.775 L 3109.24 C 3134.46, 15t/15t,
+ *         mintick 0.001: TV 3110.385 (open - 0.015), engine 3136.76.
+ *       NASDAQ:AAPL 15m short 2025-04-02 18:45Z @222.93; 04-03 13:30Z bar
+ *         O 205.54 L 202.52: TV 205.55 (open + 1t), engine 202.53 (low + 1t).
+ *       NYSE:F 1D long 2025-04-21 @9.47; 04-22 O 9.55 H 9.72: TV 9.54,
+ *         engine 9.71.
+ *
+ * (A) A trail_offset whose floor is ZERO ticks (any value in [0, 1)) is
+ *     TV's explicit-zero one-shot exit-at-activation trail, not a
+ *     zero-distance trail riding on the running extreme. `lab tv` pin on
+ *     OANDA:EURUSD 15m 2025-04-01 -> 05-01: strategy.exit("x", "L",
+ *     trail_points=3, trail_offset=0 / 0.5 / 0.9) produce byte-identical
+ *     tapes (190 rows, sha256 36aa80ac...).
+ *       EURUSD 15m short 2025-03-31 03:45Z @1.08330, atr*2 ~ 0.0006 ticks
+ *         (activation ceil -> 1t = 1.08329, offset floor -> 0); exit bar
+ *         O 1.08330 L 1.08314: TV 1.08329 (activation), engine 1.08314 (low).
+ *
+ * Resolver-level pins go straight through resolve_exit_path_fill (the
+ * runtime-private header, as test_path_resolve_extra.cpp does); engine-level
+ * pins run BacktestEngine end to end, including the POOC close-fill entry
+ * whose carried best is the entry price itself.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "../src/engine_internal.hpp"
+
+using namespace pineforge;
+using namespace pineforge::internal;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+namespace {
+
+constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+bool near(double a, double b, double tol = 1e-9) {
+    return std::fabs(a - b) <= tol;
+}
+
+Bar mk(double o, double h, double l, double c, int64_t ts = 0) {
+    Bar b{};
+    b.open = o; b.high = h; b.low = l; b.close = c;
+    b.volume = 1000.0; b.timestamp = ts;
+    return b;
+}
+
+// Resolver call for a lone trailing exit (no stop / limit legs) resting on
+// a NON-entry bar from the open, in the plain (non-magnifier) path.
+ExitPathFill trail_fill(const Bar& bar, PositionSide side,
+                        double trail_points, double trail_offset,
+                        double entry, double best_start, double mintick) {
+    return resolve_exit_path_fill(
+        bar, side, /*stop=*/kNaN, /*limit=*/kNaN,
+        trail_points, /*trail_price=*/kNaN, trail_offset, entry,
+        best_start, /*is_entry_bar=*/false, /*magnifier_active=*/false,
+        mintick);
+}
+
+// ── (B) resolver: the open arms the trail ─────────────────────────────
+
+void test_open_arms_trail_xauusd_long() {
+    std::printf("test_open_arms_trail_xauusd_long\n");
+    // Carried best = entry (POOC close fill, no entry-bar extremes folded).
+    // activation = 3110.31 + 15*0.001 = 3110.325 <= open 3110.40 -> armed at
+    // the open, best = open. |O-L| = 1.16 < |H-O| = 26.375 -> low-first path
+    // O -> L -> H -> C; the O->L leg crosses open - 0.015 = 3110.385.
+    Bar xau = mk(3110.40, 3136.775, 3109.24, 3134.46);
+    ExitPathFill f = trail_fill(xau, PositionSide::LONG,
+                                /*trail_points=*/15.0, /*trail_offset=*/15.0,
+                                /*entry=*/3110.31, /*best_start=*/3110.31,
+                                /*mintick=*/0.001);
+    CHECK(f.should_fill == true);
+    CHECK(near(f.fill_price, 3110.385));
+    CHECK(f.is_trail == true);
+    CHECK(f.is_limit == false);
+    CHECK(f.at_bar_open == false);
+    // On the O->L leg: (3110.385 - 3110.40) / (3109.24 - 3110.40).
+    CHECK(near(f.path_position, 0.015 / 1.16, 1e-6));
+}
+
+void test_open_arms_trail_aapl_short() {
+    std::printf("test_open_arms_trail_aapl_short\n");
+    // atr*2 ~ 1.7 ticks: activation ceil -> 2t = 222.91 >= open 205.54 ->
+    // armed at the open; offset floor -> 1t = 0.01. |H-O| = 1.46 <
+    // |O-L| = 3.02 -> high-first path; the O->H leg crosses open + 0.01.
+    Bar aapl = mk(205.54, 207.00, 202.52, 204.00);
+    ExitPathFill f = trail_fill(aapl, PositionSide::SHORT,
+                                /*trail_points=*/1.7, /*trail_offset=*/1.7,
+                                /*entry=*/222.93, /*best_start=*/222.93,
+                                /*mintick=*/0.01);
+    CHECK(f.should_fill == true);
+    CHECK(near(f.fill_price, 205.55));
+    CHECK(f.is_trail == true);
+    CHECK(f.at_bar_open == false);
+}
+
+void test_open_arms_trail_ford_daily_long() {
+    std::printf("test_open_arms_trail_ford_daily_long\n");
+    // activation = 9.47 + 2*0.01 = 9.49 <= open 9.55; offset 1t. Adverse-first
+    // path (|O-L| = 0.05 < |H-O| = 0.17) crosses open - 0.01 = 9.54.
+    Bar ford = mk(9.55, 9.72, 9.50, 9.70);
+    ExitPathFill f = trail_fill(ford, PositionSide::LONG,
+                                /*trail_points=*/1.5, /*trail_offset=*/1.5,
+                                /*entry=*/9.47, /*best_start=*/9.47,
+                                /*mintick=*/0.01);
+    CHECK(f.should_fill == true);
+    CHECK(near(f.fill_price, 9.54));
+}
+
+void test_open_is_a_new_best_for_an_armed_trail() {
+    std::printf("test_open_is_a_new_best_for_an_armed_trail\n");
+    // Consequence of the same rule (not a separately tape-pinned value): a
+    // trail already armed from the carried best (102 >= activation 101) sees
+    // a gap-up open 103 as its new best, so the adverse-first leg fills at
+    // 103 - 0.5 = 102.5 rather than trailing the stale 102 - 0.5 = 101.5
+    // (which this bar never reaches — the old walk produced NO fill here).
+    Bar gap_up = mk(103.0, 104.0, 102.4, 103.8);
+    ExitPathFill f = trail_fill(gap_up, PositionSide::LONG,
+                                /*trail_points=*/100, /*trail_offset=*/50,
+                                /*entry=*/100.0, /*best_start=*/102.0,
+                                /*mintick=*/0.01);
+    CHECK(f.should_fill == true);
+    CHECK(near(f.fill_price, 102.5));
+}
+
+void test_open_below_activation_does_not_arm() {
+    std::printf("test_open_below_activation_does_not_arm\n");
+    // Control: open 100.5 < activation 101 -> nothing changes; the trail
+    // still arms at the high and retraces from it (the established
+    // test_resolve_exit_trail_fills pin: fill 101.5).
+    Bar bar = mk(100.5, 102, 100, 100.2);
+    ExitPathFill f = trail_fill(bar, PositionSide::LONG,
+                                /*trail_points=*/100, /*trail_offset=*/50,
+                                /*entry=*/100.0, /*best_start=*/kNaN,
+                                /*mintick=*/0.01);
+    CHECK(f.should_fill == true);
+    CHECK(near(f.fill_price, 101.5));
+}
+
+// ── (A) resolver: sub-tick offset == explicit zero ────────────────────
+
+void test_subtick_offset_fills_at_activation_eurusd_short() {
+    std::printf("test_subtick_offset_fills_at_activation_eurusd_short\n");
+    // trail_points 0.6 -> ceil 1t -> activation 1.08329; offsets 0 / 0.5 /
+    // 0.9 / 0.6 all floor to 0 ticks -> the one-shot rule fills AT 1.08329
+    // on the O->L leg (|H-O| = 0.0002 >= |O-L| = 0.00016 -> low-first path).
+    // The old finite-zero distance armed at the low and filled at 1.08314.
+    Bar eur = mk(1.08330, 1.08350, 1.08314, 1.08320);
+    const double offsets[] = {0.0, 0.5, 0.9, 0.6};
+    for (double off : offsets) {
+        ExitPathFill f = trail_fill(eur, PositionSide::SHORT,
+                                    /*trail_points=*/0.6, off,
+                                    /*entry=*/1.08330, /*best_start=*/1.08330,
+                                    /*mintick=*/0.00001);
+        CHECK(f.should_fill == true);
+        CHECK(near(f.fill_price, 1.08329));
+        CHECK(f.is_trail == true);
+        CHECK(f.at_bar_open == false);
+    }
+}
+
+void test_subtick_offset_fills_at_activation_long() {
+    std::printf("test_subtick_offset_fills_at_activation_long\n");
+    // Long mirror: activation 100.03 crossed on the rising L->H leg
+    // (|H-O| = 0.10 >= |O-L| = 0.05 -> low-first). Old code with 0.5: armed
+    // at the high 100.10 and filled there.
+    Bar bar = mk(100.00, 100.10, 99.95, 100.05);
+    const double offsets[] = {0.0, 0.5, 0.9};
+    for (double off : offsets) {
+        ExitPathFill f = trail_fill(bar, PositionSide::LONG,
+                                    /*trail_points=*/3.0, off,
+                                    /*entry=*/100.0, /*best_start=*/100.0,
+                                    /*mintick=*/0.01);
+        CHECK(f.should_fill == true);
+        CHECK(near(f.fill_price, 100.03));
+    }
+}
+
+void test_subtick_offset_gapped_open_fills_at_open() {
+    std::printf("test_subtick_offset_gapped_open_fills_at_open\n");
+    // The bar opens past the activation (1.08320 <= 1.08329 for a short):
+    // the zero-offset gap rule fills at the open for 0 / 0.5 / 0.9 alike.
+    // Old code with 0.5: not armed at the open, armed at the low, filled at
+    // the low 1.08300.
+    Bar gap = mk(1.08320, 1.08340, 1.08300, 1.08330);
+    const double offsets[] = {0.0, 0.5, 0.9};
+    for (double off : offsets) {
+        ExitPathFill f = trail_fill(gap, PositionSide::SHORT,
+                                    /*trail_points=*/0.6, off,
+                                    /*entry=*/1.08330, /*best_start=*/1.08330,
+                                    /*mintick=*/0.00001);
+        CHECK(f.should_fill == true);
+        CHECK(near(f.fill_price, 1.08320));
+        CHECK(f.at_bar_open == true);
+        CHECK(near(f.path_position, 0.0));
+    }
+}
+
+void test_whole_tick_offsets_keep_floored_trailing_distance() {
+    std::printf("test_whole_tick_offsets_keep_floored_trailing_distance\n");
+    // Guard against over-reach: 1.0 and 1.4 ticks both floor to ONE tick
+    // (the nils123456-orb / legalrice rule) and keep trailing the running
+    // extreme: armed at the low 1.08314, filled at 1.08315 on the L->H leg.
+    Bar eur = mk(1.08330, 1.08350, 1.08314, 1.08320);
+    const double offsets[] = {1.0, 1.4};
+    for (double off : offsets) {
+        ExitPathFill f = trail_fill(eur, PositionSide::SHORT,
+                                    /*trail_points=*/0.6, off,
+                                    /*entry=*/1.08330, /*best_start=*/1.08330,
+                                    /*mintick=*/0.00001);
+        CHECK(f.should_fill == true);
+        CHECK(near(f.fill_price, 1.08315));
+    }
+}
+
+void test_subtick_offset_never_retro_arms() {
+    std::printf("test_subtick_offset_never_retro_arms\n");
+    // The #148 one-shot pin (test_zero_offset_trail_never_retro_arms,
+    // boztilkiserhan 14:15 bar) extended to a sub-tick offset: carried best
+    // 1501.03 >= activation 1500.98, the bar opens BELOW the activation and
+    // never crosses it -> HOLD. (And the open observation added for (B)
+    // must not arm it from the carried best either.)
+    Bar serhan_hold = mk(1475.99, 1491.82, 1475.89, 1486.23);
+    const double offsets[] = {0.0, 0.5, 0.9};
+    for (double off : offsets) {
+        ExitPathFill f = trail_fill(serhan_hold, PositionSide::LONG,
+                                    /*trail_points=*/2213.985, off,
+                                    /*entry=*/1478.84, /*best_start=*/1501.03,
+                                    /*mintick=*/0.01);
+        CHECK(f.should_fill == false);
+    }
+    // Omitted-offset control keeps the durable carried arming (gap-fill at
+    // the open), exactly as pinned in test_path_resolve_extra.
+    ExitPathFill omitted = trail_fill(serhan_hold, PositionSide::LONG,
+                                      /*trail_points=*/2213.985, kNaN,
+                                      /*entry=*/1478.84, /*best_start=*/1501.03,
+                                      /*mintick=*/0.01);
+    CHECK(omitted.should_fill == true);
+    CHECK(near(omitted.fill_price, 1475.99));
+}
+
+// ── engine-level fixtures ─────────────────────────────────────────────
+
+class TrailEngine : public BacktestEngine {
+public:
+    double exit_price(int i) const { return closed_trade_exit_price(i); }
+    double entry_price(int i) const { return closed_trade_entry_price(i); }
+    int exit_bar(int i) const { return closed_trade_exit_bar_index(i); }
+    double position_size() const { return signed_position_size(); }
+};
+
+// The family's shape: a POOC market entry (fills at the signal bar's close)
+// with strategy.exit(trail_points, trail_offset) issued alongside it and
+// re-issued on every bar the position is live.
+class PoocAtrTrailProbe : public TrailEngine {
+public:
+    PoocAtrTrailProbe(bool is_long, double trail_points, double trail_offset,
+                      double mintick)
+        : is_long_(is_long), trail_points_(trail_points),
+          trail_offset_(trail_offset) {
+        initial_capital_ = 1'000'000.0;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        process_orders_on_close_ = true;
+        syminfo_mintick_ = mintick;
+    }
+
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry("E", is_long_, kNaN, kNaN, /*qty=*/1.0);
+        }
+        if (bar_index_ == 0 || position_side_ != PositionSide::FLAT) {
+            strategy_exit("x", "E", /*limit=*/kNaN, /*stop=*/kNaN,
+                          trail_points_, trail_offset_, /*trail_price=*/kNaN);
+        }
+    }
+
+private:
+    bool is_long_;
+    double trail_points_;
+    double trail_offset_;
+};
+
+void test_engine_pooc_xauusd_long_exit_at_open_minus_offset() {
+    std::printf("test_engine_pooc_xauusd_long_exit_at_open_minus_offset\n");
+    // Bar 0 is the signal bar (POOC close fill @3110.31, no extremes folded
+    // into the carried best); bar 1 is the tape bar; bar 2 proves nothing
+    // else fires.
+    std::vector<Bar> bars = {
+        mk(3110.31, 3110.31, 3110.31, 3110.31, 1000),
+        mk(3110.40, 3136.775, 3109.24, 3134.46, 2000),
+        mk(3134.46, 3135.00, 3133.00, 3134.00, 3000),
+    };
+    PoocAtrTrailProbe eng(/*is_long=*/true, 15.0, 15.0, /*mintick=*/0.001);
+    eng.run(bars.data(), (int)bars.size());
+
+    CHECK(eng.last_error().empty());
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() == 1) {
+        CHECK(near(eng.entry_price(0), 3110.31));
+        CHECK(near(eng.exit_price(0), 3110.385));   // TV; was 3136.76
+        CHECK(eng.exit_bar(0) == 1);
+    }
+    CHECK(near(eng.position_size(), 0.0));
+}
+
+void test_engine_pooc_aapl_short_exit_at_open_plus_tick() {
+    std::printf("test_engine_pooc_aapl_short_exit_at_open_plus_tick\n");
+    std::vector<Bar> bars = {
+        mk(222.93, 222.93, 222.93, 222.93, 1000),
+        mk(205.54, 207.00, 202.52, 204.00, 2000),
+        mk(204.00, 204.50, 203.50, 204.20, 3000),
+    };
+    PoocAtrTrailProbe eng(/*is_long=*/false, 1.7, 1.7, /*mintick=*/0.01);
+    eng.run(bars.data(), (int)bars.size());
+
+    CHECK(eng.last_error().empty());
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() == 1) {
+        CHECK(near(eng.entry_price(0), 222.93));
+        CHECK(near(eng.exit_price(0), 205.55));     // TV; was 202.53
+        CHECK(eng.exit_bar(0) == 1);
+    }
+    CHECK(near(eng.position_size(), 0.0));
+}
+
+// Non-POOC short @100 (entry fills at bar 1's open), trail_points = 3 ticks
+// (activation 99.97) armed on bar 1 while the position is live, event bar 2.
+class ShortTrailProbe : public TrailEngine {
+public:
+    explicit ShortTrailProbe(double trail_offset) : trail_offset_(trail_offset) {
+        initial_capital_ = 1'000'000.0;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        process_orders_on_close_ = false;
+        syminfo_mintick_ = 0.01;
+    }
+
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry("S", false, kNaN, kNaN, /*qty=*/1.0);
+        } else if (bar_index_ == 1) {
+            strategy_exit("X", "S", /*limit=*/kNaN, /*stop=*/kNaN,
+                          /*trail_points=*/3.0, trail_offset_,
+                          /*trail_price=*/kNaN);
+        }
+    }
+
+private:
+    double trail_offset_;
+};
+
+struct Outcome {
+    int trades;
+    double exit_price;
+    int exit_bar;
+    double position;
+};
+
+Outcome run_short(double trail_offset, const std::vector<Bar>& bars) {
+    ShortTrailProbe eng(trail_offset);
+    eng.run(bars.data(), (int)bars.size());
+    Outcome o{eng.trade_count(), kNaN, -1, eng.position_size()};
+    if (eng.trade_count() >= 1) {
+        o.exit_price = eng.exit_price(0);
+        o.exit_bar = eng.exit_bar(0);
+    }
+    return o;
+}
+
+void test_engine_subtick_offsets_match_explicit_zero() {
+    std::printf("test_engine_subtick_offsets_match_explicit_zero\n");
+    // I. Intrabar cross: high-first event bar (|H-O| = 0.05 < |O-L| = 0.10),
+    //    the H->L leg crosses the activation 99.97. Old code with 0.5 / 0.9
+    //    armed at the low and filled at 99.90.
+    std::vector<Bar> cross = {
+        mk(100.00, 100.00, 100.00, 100.00, 1000),
+        mk(100.00, 100.00, 100.00, 100.00, 2000),
+        mk(100.00, 100.05, 99.90, 99.95, 3000),
+    };
+    // II. Gapped open: the event bar opens at 99.90, past the activation ->
+    //     fill at the open. Old code with 0.5 / 0.9 filled at the low 99.80.
+    std::vector<Bar> gapped = {
+        mk(100.00, 100.00, 100.00, 100.00, 1000),
+        mk(100.00, 100.00, 100.00, 100.00, 2000),
+        mk(99.90, 99.95, 99.80, 99.85, 3000),
+    };
+    struct Scenario { const std::vector<Bar>* bars; double expected; };
+    const Scenario scenarios[] = {{&cross, 99.97}, {&gapped, 99.90}};
+    for (const Scenario& sc : scenarios) {
+        Outcome zero = run_short(0.0, *sc.bars);
+        CHECK(zero.trades == 1);
+        CHECK(near(zero.exit_price, sc.expected));
+        CHECK(zero.exit_bar == 2);
+        CHECK(near(zero.position, 0.0));
+        const double subtick[] = {0.5, 0.9};
+        for (double off : subtick) {
+            Outcome o = run_short(off, *sc.bars);
+            CHECK(o.trades == zero.trades);
+            CHECK(near(o.exit_price, zero.exit_price));
+            CHECK(o.exit_bar == zero.exit_bar);
+            CHECK(near(o.position, zero.position));
+        }
+    }
+}
+
+void test_engine_subtick_offset_does_not_retro_arm() {
+    std::printf("test_engine_subtick_offset_does_not_retro_arm\n");
+    // Bar 1 trades down to 99.50 (carried best past the 99.97 activation),
+    // bar 2 opens ABOVE the activation and never trades down to it. A
+    // one-shot trail (0 / 0.5 / 0.9) must HOLD; the old finite-zero 0.5
+    // retro-armed a level ON the carried best 99.50 and gap-filled at bar
+    // 2's open 100.20 — a losing exit TV never prints. The omitted offset
+    // keeps the durable carried arming and fills at that open (the #148
+    // control, as in test_margin_call_trail_exit_chronology fixture D).
+    std::vector<Bar> bars = {
+        mk(100.00, 100.00, 100.00, 100.00, 1000),
+        mk(100.00, 100.00, 99.50, 99.60, 2000),
+        mk(100.20, 100.30, 100.05, 100.10, 3000),
+        mk(100.10, 100.15, 100.00, 100.05, 4000),
+    };
+    const double one_shot[] = {0.0, 0.5, 0.9};
+    for (double off : one_shot) {
+        Outcome o = run_short(off, bars);
+        CHECK(o.trades == 0);
+        CHECK(near(o.position, -1.0));
+    }
+    Outcome omitted = run_short(kNaN, bars);
+    CHECK(omitted.trades == 1);
+    CHECK(near(omitted.exit_price, 100.20));
+    CHECK(omitted.exit_bar == 2);
+    CHECK(near(omitted.position, 0.0));
+}
+
+}  // namespace
+
+int main() {
+    std::printf("=== test_trail_open_arm_subtick_offset ===\n");
+
+    test_open_arms_trail_xauusd_long();
+    test_open_arms_trail_aapl_short();
+    test_open_arms_trail_ford_daily_long();
+    test_open_is_a_new_best_for_an_armed_trail();
+    test_open_below_activation_does_not_arm();
+
+    test_subtick_offset_fills_at_activation_eurusd_short();
+    test_subtick_offset_fills_at_activation_long();
+    test_subtick_offset_gapped_open_fills_at_open();
+    test_whole_tick_offsets_keep_floored_trailing_distance();
+    test_subtick_offset_never_retro_arms();
+
+    test_engine_pooc_xauusd_long_exit_at_open_minus_offset();
+    test_engine_pooc_aapl_short_exit_at_open_plus_tick();
+    test_engine_subtick_offsets_match_explicit_zero();
+    test_engine_subtick_offset_does_not_retro_arm();
+
+    std::printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    return (tests_failed > 0) ? 1 : 0;
+}


### PR DESCRIPTION
Round-5 engine candidate — every rule pinned with `lab tv` synthetic probes before coding (ledger: "Round 5 pins"), measured like-for-like on Cloud Run against the round-5 harness pin.

- **Trail exits** (7e20b07): the bar open is folded into the trail state before the intra-bar walk (TV arms at the open); a sub-tick `trail_offset` is an explicit zero (EURUSD tapes for 0/0.5/0.9 byte-identical). winthetrade on 7 lanes.
- **OANDA 1800-1700 day stamp** (88cd0c8, 72ae4f1, ae47824): intraday request.security grids and `time(tf)`/`time("D")` anchor at the 17:00 ET day stamp (pinned on XAUUSD/F/NIFTY/BTC/ES/NQ); CME/NYSE/NSE grids unchanged and pinned.
- **session.is\*** on daily-or-higher charts (23cc8c5): ismarket/isfirstbar/islastbar true on every bar (pinned 1111 on XAUUSD/F 1D); roi10x XAUUSD@1D 0 → 57 trades.
- **Affordability / admission** (bab9a25): lot-floored resulting-position qty × max(rounded signal close, rounded fill) × margin% ≤ MTM equity, checked at placement and at fill, entry leg only dropped (NQ 10,212 decisions 0 mismatches incl. gap-anchored probes; XAUUSD 1279/1279, F 352/352). BTC over-trading group (rampatel 23,605 → ~1,486) and mdfe3757.
- **Conditional ta.highest/lowest** (f631685 + refinement): bar-indexed K=length+1 ring with a cached extremum (new-extremum check before the expiry rescan) — 696/696 pin entries, jayentriken BBWP ETH 593/593.

Measured (with pineforge-codegen-oss round5/hoist-lazy-rhs-ta): +138 / −2 tiers vs the like-for-like pin, excellent+strong 96.0% → 97.8%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dwbd239WT9zfcTLYM5UpUU