### PR TITLE
round 6: ring written-na poison, stop/limit triggers on the tick-quantized bar, pct>100 affordability, native daily security feed

### DIFF
--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -467,7 +467,9 @@ struct PendingOrder {
     // (apply_qty_step returns qty UNFLOORED for qty <= 0, so |qty|*price ==
     // |sizing_equity| while free_funds < 0 — every order, flat opens
     // included, would be declined forever). The re-check is restricted
-    // accordingly; orders outside it carry the snapshot and are admitted.
+    // accordingly; orders outside it carry the snapshot and are admitted
+    // here — CASH and pct > 100 MARKET entries by the unified
+    // design-market-entry-affordability gate instead (affordability_* below).
     // NaN = no snapshot, no re-check.
     double sizing_equity = std::numeric_limits<double>::quiet_NaN();
     double sizing_price = std::numeric_limits<double>::quiet_NaN();
@@ -570,9 +572,14 @@ struct PendingOrder {
     // to open it and cascade 4x-shortfall margin calls, 23,605 trades vs 1,486).
     //
     // Scope: high-level MARKET strategy.entry with an explicit qty OR default
-    // FIXED / CASH sizing. Default percent_of_equity entries keep their own
+    // FIXED / CASH sizing OR default percent_of_equity sizing ABOVE 100%
+    // (round 6, pin-pct-afford 2026-09-04: NYSE:F 15, percent_of_equity 200
+    // on 10,000 at margin 100 -> TV filled 0 entries, the same tape shape as
+    // strategy.cash 20,000 — pin-cash-afford-m100 0 entries, -m50 filled).
+    // Default percent_of_equity entries at or below 100% keep their own
     // pinned KI-54 / gap-reject / gross-admission family (not provably the
-    // same rule: their reversal decline is atomic and holds the position).
+    // same rule: their reversal decline is atomic and holds the position);
+    // the >100% regime had no admission at all (KI-54 requires pct <= 100).
     // NaN = no snapshot (out of scope, margin_pct == 0, non-finite close).
     double affordability_placement_equity =
         std::numeric_limits<double>::quiet_NaN();

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1520,6 +1520,72 @@ protected:
         return round_to_mintick(raw_bar_price);
     }
 
+    // design-stop-tick-rounding (round 6): the broker emulator TESTS a
+    // resting stop / limit against the bar's OHLC quantized to the tick
+    // (nearest, the finding-446 formula), while the order LEVEL stays raw;
+    // the fill keeps its existing directional / limit-or-better snap.
+    //
+    // Pinned on NYSE:F 1D (mintick 0.01, sub-penny prints; lab tv tapes
+    // scratchpad/r6/pins/stopround-*, 2026-09-04):
+    //   long sell-stops 13.74624 / 13.7451 / 13.7449 / 13.745 all SKIP
+    //     2026-02-02 (low 13.745 -> 13.75) and fill 02-03 @13.74, while
+    //     13.3449 fills 01-26 (low 13.3448 -> 13.34) @13.34 — neither a raw
+    //     compare (02-02 would fill) nor a floored/ceiled level (01-26
+    //     would not) explains both; only the quantized low does;
+    //   short buy-stops 14.0349 / 14.03505 / 14.0352 all fill 02-03 (high
+    //     14.0351 -> 14.04) @14.04; 13.225 skips 12-09 (high 13.2202 ->
+    //     13.22): the high rounds to NEAREST, not up;
+    //   sell-stop 13.776 over the 02-20 open 13.775 (-> 13.78) fills at the
+    //     level 13.77, not at the open: the open is quantized too;
+    //   the same bars/levels reproduce for strategy.exit(limit=),
+    //     strategy.entry(stop=) / (limit=) and strategy.order(stop=), long
+    //     and short (stopround-xl-*, -es-*, -el-*, -eo-*);
+    //   stopround-ohlc-0/1 encode Pine's own low/high in the trade qty:
+    //     13.745, 13.3448, 14.0351 — the RAW prints, identical to the feed,
+    //     so the quantization lives in the broker, not the data.
+    // The trail leg is NOT covered (stopround-xt-L-trail: trail_points 20 /
+    // trail_offset 3 over the 14.035 high exits at the next open, the raw-
+    // extreme behaviour the engine already has), so the trail keeps walking
+    // the raw path; stop-limit entries, the process_orders_on_close close
+    // compares and the calc_on_order_fills cursors were not pinned either
+    // and stay raw.
+    //
+    // The grid point is materialized as k / (1/mintick) when 1/mintick is
+    // integral (every decimal tick), which is the double a Pine literal on
+    // that tick parses to — so an on-grid level compares EQUAL to a
+    // quantized bar price bit-for-bit (14.04 vs k*0.01 = 14.040000000000001
+    // would not). Non-decimal ticks fall back to k*mintick.
+    double tick_grid_price(double price) const {
+        if (std::isnan(price) || syminfo_mintick_ <= 0.0) return price;
+        const double k = std::floor(price / syminfo_mintick_ + 0.5);
+        const double inv = 1.0 / syminfo_mintick_;
+        const double inv_int = std::floor(inv + 0.5);
+        if (inv_int > 0.0 && std::abs(inv - inv_int) <= 1e-6 * inv_int) {
+            return k / inv_int;
+        }
+        return k * syminfo_mintick_;
+    }
+    Bar broker_tick_bar(const Bar& bar) const {
+        Bar b = bar;
+        b.open = tick_grid_price(bar.open);
+        b.high = tick_grid_price(bar.high);
+        b.low = tick_grid_price(bar.low);
+        b.close = tick_grid_price(bar.close);
+        return b;
+    }
+    // The bar the stop / limit trigger tests run on. A synthetic bar — the
+    // calc_on_order_fills scheduler's point / monotonic-segment bars and the
+    // KI-67 cascade waypoint bar — is a slice of an already-decided path and
+    // is compared raw, exactly as before; a real chart / lower-TF bar is
+    // quantized.
+    Bar broker_trigger_bar(const Bar& bar) const {
+        if ((calc_on_order_fills_ && coof_scheduler_active_)
+            || coof_cascade_force_wp_gap_) {
+            return bar;
+        }
+        return broker_tick_bar(bar);
+    }
+
     // TradingView fills stop entries directionally to mintick rather than
     // rounding to nearest: long stops snap UP (ceil), short stops snap DOWN
     // (floor). Verified against basic/parabolic-asr where the 2,513

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -2425,6 +2425,16 @@ protected:
         std::vector<HistoricalSecurityProjection> historical_projections;
         std::size_t historical_projection_cursor = 0;
         std::size_t historical_projection_feed_index = 0;
+        // Native higher-timeframe feed routing, rebuilt per run by
+        // prepare_native_security_feeds(): the index into
+        // native_security_feeds_ serving this state's requested timeframe
+        // (-1: none, the aggregate stands), and that feed's bars keyed by
+        // the label this state's aggregator stamps on the same bucket --
+        // TimeframeAggregator::bar_label_ms of the native bar's covered
+        // session instant -- so a completed bucket finds its exchange bar by
+        // the timestamp the aggregate already carries.
+        int native_feed_index = -1;
+        std::unordered_map<int64_t, Bar> native_bars_by_label;
     };
 
     std::vector<SecurityEvalState> security_eval_states_;
@@ -2448,6 +2458,21 @@ protected:
     // The raw feed used by security aggregators in the active run. This is the
     // chart input TF on the legacy path and the auxiliary TF on the split path.
     std::string security_input_tf_;
+
+    // Native higher-timeframe request.security feeds: the exchange's own
+    // bars of one timeframe each (TradingView's "D" bar on an intraday chart
+    // is the settlement / official close, not the last intraday close). A
+    // completed request.security bucket of a fed timeframe takes the native
+    // bar's OHLCV; timing, other timeframes, chart and broker are untouched.
+    // Layout-unconditional like the aux feed's siblings above.
+    struct NativeSecurityFeed {
+        std::string tf;
+        int seconds = 0;
+        std::vector<Bar> bars;
+    };
+    std::vector<NativeSecurityFeed> native_security_feeds_;
+    int64_t diag_native_security_substitutions_ = 0;
+    int64_t diag_native_security_misses_ = 0;
 
     // --- Runtime trace state ---
     // Gated by ``trace_enabled_`` (default false) so production strategies
@@ -3072,6 +3097,12 @@ private:
     int  count_expected_script_bars(const Bar* input_bars, int n_input,
                                     bool needs_aggregation) const;
     void init_security_eval_states_for_run(const std::string& effective_input_tf);
+    // Native HTF feed routing (engine_aux_security.cpp): per-state label maps
+    // built after the evaluators' aggregators exist for this run, and the
+    // substitution a completed bucket applies. Returns whether `bar` was
+    // replaced by its native sibling.
+    void prepare_native_security_feeds();
+    bool substitute_native_security_bar(SecurityEvalState& state, Bar& bar);
     void prepare_historical_security_lookahead_projections(
         const Bar* input_bars, int n_input,
         const std::string& effective_input_tf);
@@ -3173,6 +3204,24 @@ public:
     bool set_aux_security_feed(const Bar* bars, int n,
                                const std::string& input_tf);
 #endif
+
+    // Copies the exchange's own bars of one higher timeframe for the
+    // request.security evaluators that request exactly it (see
+    // strategy_set_native_security_feed in pineforge.h). n == 0 clears that
+    // timeframe's feed. Routing is built per run once the evaluators exist.
+    bool set_native_security_feed(const std::string& timeframe,
+                                  const Bar* bars, int n);
+    bool native_security_feed_enabled() const {
+        return !native_security_feeds_.empty();
+    }
+    // Per-run diagnostics: completed buckets that took a native bar, and
+    // completed buckets of a fed timeframe that found none (kept aggregate).
+    int64_t native_security_substitutions() const {
+        return diag_native_security_substitutions_;
+    }
+    int64_t native_security_misses() const {
+        return diag_native_security_misses_;
+    }
 
     // Execute confirmed historical bars, then keep this exact instance alive
     // for realtime trade updates. The warmup feed must contain at least one

--- a/include/pineforge/pineforge.h
+++ b/include/pineforge/pineforge.h
@@ -83,6 +83,10 @@
  *  When defined, #strategy_set_aux_security_feed is available. */
 #define PINEFORGE_HAS_AUX_SECURITY_FEED_V1 1
 
+/** Feature probe for native higher-timeframe request.security feeds.
+ *  When defined, #strategy_set_native_security_feed is available. */
+#define PINEFORGE_HAS_NATIVE_SECURITY_FEED_V1 1
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -712,6 +716,32 @@ PF_API int strategy_set_aux_security_feed(pf_strategy_t s,
                                           const pf_bar_t* bars,
                                           int n,
                                           const char* input_tf);
+#endif
+
+#ifdef PINEFORGE_HAS_NATIVE_SECURITY_FEED_V1
+/** Copy the exchange's OWN bars of one higher timeframe for same-symbol
+ *  request.security calls that request exactly that timeframe.
+ *
+ *  On intraday charts of CME futures and US/Indian equities TradingView's
+ *  request.security(syminfo.tickerid, "D", close) returns the exchange's
+ *  daily bar -- the 15:00 CT settlement on ES1!/NQ1!, the official closing
+ *  print on NASDAQ/NYSE/NSE -- which no aggregation of the intraday feed can
+ *  reproduce. With a native feed installed for @p timeframe ("D", "1D", "W",
+ *  ...), every completed request.security bucket of that timeframe carries
+ *  the native bar's OHLCV (matched by the bucket's own label: the session-day
+ *  stamp for D/W/M, the grid open for intraday) instead of the aggregate;
+ *  bucket TIMING -- when the bar completes relative to the chart -- and every
+ *  other timeframe's request are unchanged, and so are chart OHLCV, broker
+ *  fills and bar_index. A completed bucket with no native bar keeps its
+ *  aggregate (counted, not fatal). Bars must be strictly increasing; arrays
+ *  are copied; pass @p n == 0 to clear the feed for @p timeframe. Historical
+ *  runs only: stream_begin() fails closed while a native feed is installed.
+ *
+ *  @return 0 on success, -1 for a null strategy or invalid input. */
+PF_API int strategy_set_native_security_feed(pf_strategy_t s,
+                                             const char* timeframe,
+                                             const pf_bar_t* bars,
+                                             int n);
 #endif
 
 /** Returns the error message captured by the most recent #run_backtest /

--- a/include/pineforge/ta.hpp
+++ b/include/pineforge/ta.hpp
@@ -387,6 +387,9 @@ public:
     explicit StdDev(int length, bool biased = true);
     double compute(double src);
     double recompute(double src);
+
+private:
+    double held_stdev() const;
 };
 
 // --- Supertrend ---

--- a/include/pineforge/ta.hpp
+++ b/include/pineforge/ta.hpp
@@ -105,7 +105,13 @@ public:
         double value;   // na: window not formed yet, or no written non-na member
         int bars_back;  // k of the extremum slot (0 = the current bar)
     };
-    explicit ExtremeRing(int length);
+    // na_src_answers_na: a direct ta.highest/lowest call answers na on an na
+    // source (pinned 2026-09-04, NYSE:F 1D every-bar ta.lowest over a source
+    // na on every 4th bar: na on exactly those bars, 11/11; OANDA:XAUUSD 15
+    // conditional calls likewise); the composites (Stoch, WPR, Range) keep the
+    // finding-331 oracle instead -- their extrema stay live over the non-na
+    // members -- and construct with false.
+    explicit ExtremeRing(int length, bool na_src_answers_na = true);
     // advance = true  -> compute():   records src for the context's current bar
     // advance = false -> recompute(): rewrites the current bar's slot
     // An na src is recorded as a gap (skipped by the extremum, never a member).
@@ -129,6 +135,7 @@ private:
     bool saved_cached_ = false;
     double saved_cval_ = 0.0;
     long long saved_cbar_ = 0;
+    bool na_src_answers_na_ = true;
 };
 
 class RMA {
@@ -263,7 +270,7 @@ class Highest {
     ExtremeRing ring_;
 
 public:
-    explicit Highest(int length);
+    explicit Highest(int length, bool na_src_answers_na = true);
     double compute(double src);
     double recompute(double src);
 };
@@ -274,7 +281,7 @@ class Lowest {
     ExtremeRing ring_;
 
 public:
-    explicit Lowest(int length);
+    explicit Lowest(int length, bool na_src_answers_na = true);
     double compute(double src);
     double recompute(double src);
 };
@@ -700,7 +707,7 @@ class HighestBars {
     ExtremeRing ring_;
 
 public:
-    explicit HighestBars(int length);
+    explicit HighestBars(int length, bool na_src_answers_na = true);
     double compute(double src);
     double recompute(double src);
 };
@@ -711,7 +718,7 @@ class LowestBars {
     ExtremeRing ring_;
 
 public:
-    explicit LowestBars(int length);
+    explicit LowestBars(int length, bool na_src_answers_na = true);
     double compute(double src);
     double recompute(double src);
 };
@@ -1126,7 +1133,7 @@ class Range {
     Highest highest_;
     Lowest lowest_;
 public:
-    explicit Range(int length) : highest_(length), lowest_(length) {}
+    explicit Range(int length) : highest_(length, false), lowest_(length, false) {}
     double compute(double src);
     double recompute(double src);
 };

--- a/include/pineforge/ta.hpp
+++ b/include/pineforge/ta.hpp
@@ -77,6 +77,29 @@ bool& ema_na_warmup_flag();
 // answers its own low and never reads the aliased 08:15 slot the plain ring
 // returned. For an every-bar caller the cache is exactly the positional
 // window, so nothing changes there.
+//
+// Never-written slots read 0 in a rescan, for every source kind (pinned
+// 2026-09-04 on BINANCE:BTCUSDT 1D and OANDA:XAUUSD 1D, cadence 13 / length
+// 10: ``low``, ``close - 2000``, ``sma(close, 5)``, ``low[1]``, ``hl2`` and
+// the sign-mixed ``sma(close, 5) - close`` each 13/13). A slot WRITTEN with
+// na POISONS the ring (pinned 2026-09-04 on OANDA:XAUUSD 1D, scratchpad
+// r6/pins/ringkind: leading-na sites 7 x 13/13, the market-logic replica
+// 32/32; and the every-bar NYSE:F 1D gap tape pin-lowest-na-everybar, 20/20;
+// ledger log-20260904t112527z-ea13dfcd): the rescan walks oldest first and a
+// written-na slot resets the running extremum, so the answer is the extremum
+// over the slots NEWER than the newest na slot in the window (never-written
+// 0 slots among them included) and na when the newest slot is itself na; the
+// na write also poisons the cache to ``(na, b)``, so the next valid call
+// restarts from its own src without reading the slots. ``ta.lowest(
+// sma(close, 14), 10)`` at cadence 13 answers na (bar 5 writes na), 2998
+// (bar 18: restart on src, the never-written slot behind it unread), 0, 0,
+// 0, 0 (rescans: never-written slots newer than the na slot), 3357.6 (bar
+// 83: the na slot re-entered at k = 1, src is the only live member), 3327.4
+// (new minimum), 2998, 2998, 2998, 2998 (the stale first valid write, once
+// newer than the na slot), 3112. Every-bar ``x = bar_index % 4 == 0 ? na :
+// low``: ``ta.lowest(x, 5) == ta.highest(x, 5)`` on the bar after every na
+// bar — a single live member — where the old "skip the gap" reading kept
+// the pre-gap extremum (bar 9: TV 9.20, the untouched cache 8.44).
 struct BarContext {
     bool installed = false;
     long long bar_index = 0;   // ring address: the context's current bar index
@@ -105,16 +128,15 @@ public:
         double value;   // na: window not formed yet, or no written non-na member
         int bars_back;  // k of the extremum slot (0 = the current bar)
     };
-    // na_src_answers_na: a direct ta.highest/lowest call answers na on an na
-    // source (pinned 2026-09-04, NYSE:F 1D every-bar ta.lowest over a source
-    // na on every 4th bar: na on exactly those bars, 11/11; OANDA:XAUUSD 15
-    // conditional calls likewise); the composites (Stoch, WPR, Range) keep the
-    // finding-331 oracle instead -- their extrema stay live over the non-na
-    // members -- and construct with false.
-    explicit ExtremeRing(int length, bool na_src_answers_na = true);
+    explicit ExtremeRing(int length);
     // advance = true  -> compute():   records src for the context's current bar
     // advance = false -> recompute(): rewrites the current bar's slot
-    // An na src is recorded as a gap (skipped by the extremum, never a member).
+    // An na src is WRITTEN: it answers na, poisons the cache and, in every
+    // later rescan, resets the running extremum (the poison rule documented
+    // at bar_context()). The composites (Stoch, WPR, Range) share the ring
+    // and the rule: their only oracle (finding 331, a stochRSI whose RSI is
+    // na for its warmup only) is a leading-na series, on which the poison
+    // answers exactly what "live over the non-na members" did.
     // Ties resolve to the OLDEST member (strict comparison, oldest slot first).
     Result update(double src, bool advance, bool want_max);
 
@@ -135,7 +157,6 @@ private:
     bool saved_cached_ = false;
     double saved_cval_ = 0.0;
     long long saved_cbar_ = 0;
-    bool na_src_answers_na_ = true;
 };
 
 class RMA {
@@ -270,7 +291,7 @@ class Highest {
     ExtremeRing ring_;
 
 public:
-    explicit Highest(int length, bool na_src_answers_na = true);
+    explicit Highest(int length);
     double compute(double src);
     double recompute(double src);
 };
@@ -281,7 +302,7 @@ class Lowest {
     ExtremeRing ring_;
 
 public:
-    explicit Lowest(int length, bool na_src_answers_na = true);
+    explicit Lowest(int length);
     double compute(double src);
     double recompute(double src);
 };
@@ -710,7 +731,7 @@ class HighestBars {
     ExtremeRing ring_;
 
 public:
-    explicit HighestBars(int length, bool na_src_answers_na = true);
+    explicit HighestBars(int length);
     double compute(double src);
     double recompute(double src);
 };
@@ -721,7 +742,7 @@ class LowestBars {
     ExtremeRing ring_;
 
 public:
-    explicit LowestBars(int length, bool na_src_answers_na = true);
+    explicit LowestBars(int length);
     double compute(double src);
     double recompute(double src);
 };
@@ -1136,7 +1157,7 @@ class Range {
     Highest highest_;
     Lowest lowest_;
 public:
-    explicit Range(int length) : highest_(length, false), lowest_(length, false) {}
+    explicit Range(int length) : highest_(length), lowest_(length) {}
     double compute(double src);
     double recompute(double src);
 };

--- a/scripts/check_c_abi_runtime.py
+++ b/scripts/check_c_abi_runtime.py
@@ -29,6 +29,7 @@ EXPECTED_RUNTIME = frozenset({
     "strategy_set_syminfo_metadata",
     "strategy_set_account_currency_fx_series",
     "strategy_set_aux_security_feed",
+    "strategy_set_native_security_feed",
     "strategy_get_last_error",
     "strategy_stream_begin",
     "strategy_stream_push_tick",

--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -78,6 +78,7 @@ _VALIDATION_META_KEYS = frozenset({
     "ohlcv_csv",
     "aux_security_ohlcv_csv",
     "aux_security_input_tf",
+    "native_security_feeds",
     "ohlcv_start_ms",
     "script_tf",
     "input_tf",
@@ -619,6 +620,19 @@ def build_runtime_provenance(run_kwargs: dict, trade_start_ms: int | None) -> di
             "source_values_sha256": run_kwargs.get(
                 "aux_security_source_feed_sha256") or "",
         }
+    native_feeds = run_kwargs.get("native_security_feeds")
+    if native_feeds:
+        # One entry per requested timeframe served by the exchange's own bars
+        # (strategy_set_native_security_feed): the file identity resolved at
+        # inputs time and, when the run supplied it, the parsed-values digest.
+        runtime["native_security_feeds"] = {
+            str(tf): {
+                "source_path": str(Path(entry["path"]).resolve()),
+                "source_file_sha256": entry.get("source_file_sha256") or "",
+                "source_values_sha256": entry.get("source_values_sha256") or "",
+            }
+            for tf, entry in sorted(native_feeds.items())
+        }
     return runtime
 
 
@@ -992,6 +1006,44 @@ def inputs_run_kwargs(params, strategy_dir: Path, default_ohlcv: Path,
             raise OSError(
                 "cannot hash auxiliary request.security OHLCV export: "
                 f"{aux_security_ohlcv_csv}")
+    # ``native_security_feeds``: {"D": "<csv>", ...} -- the exchange's own
+    # bars of one higher timeframe each, served to the request.security
+    # evaluators that request exactly that timeframe (TradingView's daily bar
+    # on an intraday CME / NASDAQ / NSE chart is the settlement or official
+    # close, which no aggregate of the chart feed reproduces). Paths resolve
+    # like ``aux_security_ohlcv_csv``; each file is hashed here so the run can
+    # refuse a file that changed between metadata resolution and execution.
+    native_security_feeds = None
+    if "native_security_feeds" in params:
+        raw_feeds = params.get("native_security_feeds")
+        if raw_feeds in (None, "", {}):
+            raw_feeds = {}
+        if not isinstance(raw_feeds, dict):
+            raise ValueError(
+                "native_security_feeds must map a timeframe to an OHLCV export path")
+        native_security_feeds = {}
+        for raw_tf, raw_path in raw_feeds.items():
+            tf = str(raw_tf or "").strip()
+            path_value = str(raw_path or "")
+            if not tf or not path_value:
+                raise ValueError(
+                    "native_security_feeds entries need a timeframe and a path")
+            feed_path = (
+                Path(path_value) if path_value.startswith("/")
+                else strategy_dir / path_value
+            ).resolve()
+            if not feed_path.is_file():
+                raise FileNotFoundError(
+                    f"native request.security OHLCV export not found for {tf}: "
+                    f"{feed_path}")
+            feed_sha = _sha256_file(feed_path)
+            if feed_sha is None:
+                raise OSError(
+                    f"cannot hash native request.security OHLCV export: {feed_path}")
+            native_security_feeds[tf] = {
+                "path": feed_path,
+                "source_file_sha256": feed_sha,
+            }
     # Per-probe chart tz override wins over the caller default. Empty
     # string is honoured (engine UTC fast path).
     if "chart_timezone" in params:
@@ -1093,6 +1145,8 @@ def inputs_run_kwargs(params, strategy_dir: Path, default_ohlcv: Path,
         kwargs["aux_security_input_tf"] = aux_security_input_tf
         kwargs["aux_security_source_file_sha256"] = \
             aux_security_source_file_sha256
+    if native_security_feeds:
+        kwargs["native_security_feeds"] = native_security_feeds
     return ohlcv_path, kwargs
 
 
@@ -1210,6 +1264,11 @@ class Strategy:
                 ctypes.c_void_p, ctypes.POINTER(BarC), ctypes.c_int,
                 ctypes.c_char_p]
             L.strategy_set_aux_security_feed.restype = ctypes.c_int
+        if hasattr(L, "strategy_set_native_security_feed"):
+            L.strategy_set_native_security_feed.argtypes = [
+                ctypes.c_void_p, ctypes.c_char_p, ctypes.POINTER(BarC),
+                ctypes.c_int]
+            L.strategy_set_native_security_feed.restype = ctypes.c_int
         if hasattr(L, "strategy_set_syminfo_mintick"):
             L.strategy_set_syminfo_mintick.argtypes = [ctypes.c_void_p, ctypes.c_double]
             L.strategy_set_syminfo_mintick.restype = None
@@ -1238,6 +1297,7 @@ class Strategy:
             aux_security_ohlcv_csv: Path | None = None,
             aux_security_input_tf: str | None = None,
             aux_security_source_file_sha256: str | None = None,
+            native_security_feeds: dict | None = None,
             ohlcv_start_ms: int | None = None,
             ohlcv_end_ms: int | None = None,
             bar_magnifier: bool = False,
@@ -1313,6 +1373,30 @@ class Strategy:
             if aux_n <= 0:
                 raise ValueError(
                     "auxiliary request.security OHLCV export contains no bars")
+        native_feed_arrays = []
+        native_feed_report = {}
+        if native_security_feeds:
+            if not hasattr(self.lib, "strategy_set_native_security_feed"):
+                raise RuntimeError(
+                    "strategy library lacks native request.security feed support; rebuild it")
+            for tf, entry in sorted(native_security_feeds.items()):
+                feed_path = Path(entry["path"])
+                (feed_bars, feed_n, feed_values_sha256,
+                 feed_file_sha256) = _load_aux_bars_snapshot(feed_path)
+                expected_sha = entry.get("source_file_sha256")
+                if expected_sha is not None and expected_sha != feed_file_sha256:
+                    raise RuntimeError(
+                        "native request.security OHLCV export changed after "
+                        f"metadata resolution: {tf}")
+                if feed_n <= 0:
+                    raise ValueError(
+                        f"native request.security OHLCV export for {tf} contains no bars")
+                native_feed_arrays.append((str(tf), feed_bars, feed_n))
+                native_feed_report[str(tf)] = {
+                    "path": str(feed_path.resolve()),
+                    "source_file_sha256": feed_file_sha256,
+                    "source_values_sha256": feed_values_sha256,
+                }
         params = params or {}
         params_json = json.dumps(params).encode()
 
@@ -1439,6 +1523,18 @@ class Strategy:
                     raise RuntimeError(
                         "engine rejected auxiliary request.security feed"
                         + (f": {detail}" if detail else ""))
+            for feed_tf, feed_bars, feed_n in native_feed_arrays:
+                rc = self.lib.strategy_set_native_security_feed(
+                    state, feed_tf.encode(), feed_bars, feed_n)
+                if rc != 0:
+                    detail = ""
+                    if hasattr(self.lib, "strategy_get_last_error"):
+                        err_ptr = self.lib.strategy_get_last_error(state)
+                        if err_ptr:
+                            detail = err_ptr.decode("utf-8", "replace")
+                    raise RuntimeError(
+                        f"engine rejected native request.security feed {feed_tf}"
+                        + (f": {detail}" if detail else ""))
             self.lib.run_backtest_full(
                 state, bars, n,
                 input_tf_b, script_tf_b,  # empty -> auto-detect input_tf, default script_tf=input_tf
@@ -1474,6 +1570,8 @@ class Strategy:
                     aux_source_file_sha256 or "")
                 result["aux_security_source_feed_sha256"] = (
                     aux_source_feed_sha256 or "")
+            if native_feed_report:
+                result["native_security_feeds"] = native_feed_report
             return result
         finally:
             self.lib.report_free(ctypes.byref(report))
@@ -2391,6 +2489,11 @@ def main() -> int:
                 "error: --runner docker does not support an auxiliary "
                 "request.security feed; use --runner ctypes with a freshly "
                 "built strategy library.")
+        if run_kwargs.get("native_security_feeds"):
+            sys.exit(
+                "error: --runner docker does not support native "
+                "request.security feeds; use --runner ctypes with a freshly "
+                "built strategy library.")
         strat = None
         report = _run_via_docker(strategy_dir, ohlcv_path, params, run_kwargs,
                                  trade_start_ms, args.image)
@@ -2434,6 +2537,9 @@ def main() -> int:
             if report.get("aux_security_source_feed_sha256"):
                 runtime_kwargs["aux_security_source_feed_sha256"] = \
                     report["aux_security_source_feed_sha256"]
+            if report.get("native_security_feeds"):
+                runtime_kwargs["native_security_feeds"] = \
+                    report["native_security_feeds"]
             runtime = build_runtime_provenance(
                 runtime_kwargs, trade_start_ms)
             fp = build_fingerprint(build_provenance(

--- a/scripts/test_run_strategy_native_feed.py
+++ b/scripts/test_run_strategy_native_feed.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Focused runner proof for native higher-timeframe request.security feeds.
+
+``inputs.json::native_security_feeds`` maps a requested timeframe ("D") to the
+exchange's own OHLCV export of that timeframe; the runner hashes each file at
+metadata time, loads it once, installs it through
+``strategy_set_native_security_feed`` before the chart run, and records every
+identity in the report and the runtime provenance.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from run_strategy import (
+    Strategy,
+    build_fingerprint,
+    build_runtime_provenance,
+    inputs_run_kwargs,
+)
+
+
+def _write_bars(path: Path, closes: list[float], step_ms: int = 60_000) -> None:
+    rows = ["timestamp,open,high,low,close,volume"]
+    for index, close in enumerate(closes):
+        timestamp = 1_704_205_800_000 + index * step_ms
+        rows.append(
+            f"{timestamp},{close},{close + 1},{close - 1},{close},10")
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+class _FakeLibrary:
+    def __init__(self, *, native_result: int = 0) -> None:
+        self.events = []
+        self.native_result = native_result
+
+    def strategy_create(self, _params):
+        self.events.append(("create",))
+        return 7
+
+    def run_backtest_full(self, _state, bars, count, *_rest):
+        self.events.append((
+            "run", count,
+            [float(bars[index].close) for index in range(count)],
+        ))
+
+    def strategy_get_last_error(self, _state):
+        return b"rejected native feed" if self.native_result != 0 else b""
+
+    def report_free(self, _report):
+        pass
+
+    def strategy_free(self, _state):
+        pass
+
+    def strategy_set_native_security_feed(self, _state, timeframe, bars, count):
+        self.events.append((
+            "native", timeframe.decode(), count,
+            [float(bars[index].close) for index in range(count)],
+        ))
+        return self.native_result
+
+
+class _FeatureAbsentLibrary(_FakeLibrary):
+    def __getattribute__(self, name):
+        if name == "strategy_set_native_security_feed":
+            raise AttributeError(name)
+        return super().__getattribute__(name)
+
+
+def _strategy(fake) -> Strategy:
+    strategy = Strategy.__new__(Strategy)
+    strategy.lib = fake
+    return strategy
+
+
+class NativeSecurityFeedRunnerTests(unittest.TestCase):
+    def test_metadata_resolves_relative_exports_and_hashes_them(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart = root / "chart.csv"
+            daily = root / "daily.csv"
+            _write_bars(chart, [100.0])
+            _write_bars(daily, [111.5], step_ms=86_400_000)
+            _, kwargs = inputs_run_kwargs(
+                {"native_security_feeds": {"D": "daily.csv"}}, root, chart)
+            feeds = kwargs["native_security_feeds"]
+            self.assertEqual(list(feeds), ["D"])
+            self.assertEqual(feeds["D"]["path"], daily.resolve())
+            self.assertEqual(len(feeds["D"]["source_file_sha256"]), 64)
+
+            _, legacy = inputs_run_kwargs({}, root, chart)
+            self.assertNotIn("native_security_feeds", legacy)
+            _, empty = inputs_run_kwargs(
+                {"native_security_feeds": {}}, root, chart)
+            self.assertNotIn("native_security_feeds", empty)
+
+            with self.assertRaises(FileNotFoundError):
+                inputs_run_kwargs(
+                    {"native_security_feeds": {"D": "missing.csv"}}, root, chart)
+            with self.assertRaises(ValueError):
+                inputs_run_kwargs(
+                    {"native_security_feeds": ["daily.csv"]}, root, chart)
+            with self.assertRaises(ValueError):
+                inputs_run_kwargs(
+                    {"native_security_feeds": {"": "daily.csv"}}, root, chart)
+
+    def test_feed_identity_mutates_runtime_provenance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart = root / "chart.csv"
+            daily_a = root / "daily-a.csv"
+            daily_b = root / "daily-b.csv"
+            _write_bars(chart, [100.0])
+            _write_bars(daily_a, [111.5, 222.5], step_ms=86_400_000)
+            _write_bars(daily_b, [111.5, 222.5], step_ms=86_400_000)
+
+            _, kwargs_a = inputs_run_kwargs(
+                {"native_security_feeds": {"D": "daily-a.csv"}}, root, chart)
+            _, kwargs_b = inputs_run_kwargs(
+                {"native_security_feeds": {"D": "daily-b.csv"}}, root, chart)
+            _, kwargs_w = inputs_run_kwargs(
+                {"native_security_feeds": {"W": "daily-a.csv"}}, root, chart)
+            _, kwargs_none = inputs_run_kwargs({}, root, chart)
+            provenance_a = build_runtime_provenance(kwargs_a, None)
+            self.assertEqual(
+                provenance_a["native_security_feeds"]["D"]["source_path"],
+                str(daily_a.resolve()))
+            self.assertNotIn("native_security_feeds",
+                             build_runtime_provenance(kwargs_none, None))
+            digest_a = build_fingerprint({"runtime": provenance_a})["digest"]
+            for other in (kwargs_b, kwargs_w, kwargs_none):
+                provenance = build_runtime_provenance(other, None)
+                self.assertNotEqual(provenance_a, provenance)
+                self.assertNotEqual(
+                    digest_a,
+                    build_fingerprint({"runtime": provenance})["digest"])
+
+            _write_bars(daily_a, [111.5, 333.5], step_ms=86_400_000)
+            _, kwargs_content = inputs_run_kwargs(
+                {"native_security_feeds": {"D": "daily-a.csv"}}, root, chart)
+            self.assertNotEqual(
+                provenance_a, build_runtime_provenance(kwargs_content, None))
+
+    def test_runner_installs_native_feeds_before_the_chart_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart = root / "chart.csv"
+            daily = root / "daily.csv"
+            _write_bars(chart, [100.0, 200.0])
+            _write_bars(daily, [111.5, 222.5], step_ms=86_400_000)
+            _, kwargs = inputs_run_kwargs(
+                {"native_security_feeds": {"D": "daily.csv"}}, root, chart)
+            fake = _FakeLibrary()
+
+            report = _strategy(fake).run(
+                chart, input_tf="15", script_tf="15",
+                native_security_feeds=kwargs["native_security_feeds"])
+
+            self.assertEqual(fake.events[1],
+                             ("native", "D", 2, [111.5, 222.5]))
+            self.assertEqual(fake.events[2], ("run", 2, [100.0, 200.0]))
+            recorded = report["native_security_feeds"]["D"]
+            self.assertEqual(recorded["path"], str(daily.resolve()))
+            self.assertEqual(recorded["source_file_sha256"],
+                             kwargs["native_security_feeds"]["D"]["source_file_sha256"])
+            self.assertEqual(len(recorded["source_values_sha256"]), 64)
+
+    def test_engine_rejection_and_missing_feature_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart = root / "chart.csv"
+            daily = root / "daily.csv"
+            _write_bars(chart, [100.0])
+            _write_bars(daily, [111.5], step_ms=86_400_000)
+            _, kwargs = inputs_run_kwargs(
+                {"native_security_feeds": {"D": "daily.csv"}}, root, chart)
+            with self.assertRaisesRegex(RuntimeError, "rejected native feed"):
+                _strategy(_FakeLibrary(native_result=-1)).run(
+                    chart, input_tf="15", script_tf="15",
+                    native_security_feeds=kwargs["native_security_feeds"])
+            with self.assertRaisesRegex(RuntimeError, "lacks native"):
+                _strategy(_FeatureAbsentLibrary()).run(
+                    chart, input_tf="15", script_tf="15",
+                    native_security_feeds=kwargs["native_security_feeds"])
+            # A file replaced after metadata resolution is refused by hash.
+            _write_bars(daily, [999.0], step_ms=86_400_000)
+            with self.assertRaisesRegex(RuntimeError, "changed after"):
+                _strategy(_FakeLibrary()).run(
+                    chart, input_tf="15", script_tf="15",
+                    native_security_feeds=kwargs["native_security_feeds"])
+
+    def test_feature_absent_without_native_request_keeps_legacy_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            chart = root / "chart.csv"
+            _write_bars(chart, [100.0])
+            fake = _FeatureAbsentLibrary()
+            report = _strategy(fake).run(chart, input_tf="15", script_tf="15")
+            self.assertEqual([event[0] for event in fake.events],
+                             ["create", "run"])
+            self.assertNotIn("native_security_feeds", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/c_abi.cpp
+++ b/src/c_abi.cpp
@@ -343,6 +343,19 @@ PF_API int strategy_set_aux_security_feed(pf_strategy_t s,
 }
 #endif
 
+#ifdef PINEFORGE_HAS_NATIVE_SECURITY_FEED_V1
+PF_API int strategy_set_native_security_feed(pf_strategy_t s,
+                                             const char* timeframe,
+                                             const pf_bar_t* bars,
+                                             int n) {
+    if (!s || !timeframe || n < 0 || (n > 0 && !bars)) return -1;
+    const auto* native = reinterpret_cast<const pineforge::Bar*>(bars);
+    return static_cast<pineforge::BacktestEngine*>(s)
+                   ->set_native_security_feed(std::string(timeframe), native, n)
+        ? 0 : -1;
+}
+#endif
+
 /* See PF_ABI_VERSION doc in pineforge.h. */
 PF_API int pf_abi_version(void) { return PF_ABI_VERSION; }
 

--- a/src/engine_aux_security.cpp
+++ b/src/engine_aux_security.cpp
@@ -289,4 +289,130 @@ void BacktestEngine::feed_aux_security_for_chart_bar(int chart_index) {
 
 #endif  // PINEFORGE_HAS_AUX_SECURITY_FEED_V1
 
+
+// ---- native higher-timeframe request.security feeds -------------------------
+//
+// TradingView's request.security(syminfo.tickerid, "D", close) on an intraday
+// chart of CME_MINI:ES1! returns the 15:00 CT settlement, on NASDAQ:AAPL the
+// official closing print, on NSE:NIFTY the exchange's official OHLC -- values
+// no aggregation of the intraday feed produces (pinned 2026-09-04 by lab tv
+// limit-fill probes: 9/9 ES1!, 5/5 AAPL and 2/2 NIFTY fills equal the 1D
+// feed's close and none the last 15m close). The campaign holds those daily
+// bars; this path lets a completed daily bucket carry them while the
+// aggregator keeps deciding WHEN the bucket completes.
+
+bool BacktestEngine::set_native_security_feed(const std::string& timeframe,
+                                              const Bar* bars, int n) {
+    int seconds = 0;
+    try {
+        seconds = tf_to_seconds(timeframe);
+    } catch (...) {
+        seconds = 0;
+    }
+    if (timeframe.empty() || seconds == 0) {
+        last_error_ =
+            "native request.security feed requires a parseable timeframe";
+        return false;
+    }
+    auto existing = native_security_feeds_.begin();
+    while (existing != native_security_feeds_.end()
+           && existing->seconds != seconds) {
+        ++existing;
+    }
+    if (n == 0) {
+        if (existing != native_security_feeds_.end()) {
+            native_security_feeds_.erase(existing);
+        }
+        last_error_.clear();
+        return true;
+    }
+    if (n < 0 || bars == nullptr) {
+        last_error_ =
+            "native request.security feed requires bars and a positive count";
+        return false;
+    }
+    for (int i = 1; i < n; ++i) {
+        if (bars[i].timestamp <= bars[i - 1].timestamp) {
+            last_error_ =
+                "native request.security feed timestamps must be strictly increasing";
+            return false;
+        }
+    }
+    NativeSecurityFeed feed;
+    feed.tf = timeframe;
+    feed.seconds = seconds;
+    feed.bars.assign(bars, bars + n);
+    if (existing != native_security_feeds_.end()) {
+        *existing = std::move(feed);
+    } else {
+        native_security_feeds_.push_back(std::move(feed));
+    }
+    last_error_.clear();
+    return true;
+}
+
+
+void BacktestEngine::prepare_native_security_feeds() {
+    diag_native_security_substitutions_ = 0;
+    diag_native_security_misses_ = 0;
+    for (auto& state : security_eval_states_) {
+        state.native_feed_index = -1;
+        state.native_bars_by_label.clear();
+        if (native_security_feeds_.empty()) continue;
+        // Only an aggregating (coarser-than-input) request has buckets to
+        // substitute; passthrough, lower-TF emulation and input passthrough
+        // read the feed itself.
+        if (state.lower_tf_emulation || state.lower_tf_use_input
+            || !state.aggregator.is_active()) {
+            continue;
+        }
+        int requested_seconds = 0;
+        try {
+            requested_seconds = tf_to_seconds(state.tf);
+        } catch (...) {
+            requested_seconds = 0;
+        }
+        if (requested_seconds == 0) continue;
+        for (std::size_t i = 0; i < native_security_feeds_.size(); ++i) {
+            if (native_security_feeds_[i].seconds != requested_seconds) continue;
+            state.native_feed_index = static_cast<int>(i);
+            const auto& bars = native_security_feeds_[i].bars;
+            state.native_bars_by_label.reserve(bars.size());
+            for (const Bar& bar : bars) {
+                // Key by the label the aggregate carries: the covered session
+                // instant (OANDA's 17:00 stamp covers the 18:00 session, see
+                // session_covered_instant_ms) labelled exactly as this
+                // state's aggregator labels its own buckets.
+                const int64_t label = state.aggregator.bar_label_ms(
+                    session_covered_instant_ms(bar.timestamp,
+                                               syminfo_.timezone,
+                                               syminfo_.session));
+                // A later native bar under one label (a session the run's
+                // calendar coalesces) is the period's final print: keep it.
+                state.native_bars_by_label[label] = bar;
+            }
+            break;
+        }
+    }
+}
+
+
+bool BacktestEngine::substitute_native_security_bar(SecurityEvalState& state,
+                                                    Bar& bar) {
+    if (state.native_feed_index < 0) return false;
+    const auto found = state.native_bars_by_label.find(bar.timestamp);
+    if (found == state.native_bars_by_label.end()) {
+        ++diag_native_security_misses_;
+        return false;
+    }
+    const Bar& native = found->second;
+    bar.open = native.open;
+    bar.high = native.high;
+    bar.low = native.low;
+    bar.close = native.close;
+    bar.volume = native.volume;
+    ++diag_native_security_substitutions_;
+    return true;
+}
+
 }  // namespace pineforge

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -176,8 +176,11 @@ void BacktestEngine::process_pending_orders(const Bar& bar) {
     pass0_opposing_skip_ids.clear();
     DualEntryStopPathWinner dual_entry_path_ = DualEntryStopPathWinner::None;
     if (position_side_ == PositionSide::FLAT) {
+        // design-stop-tick-rounding: stop touches on the tick-quantized bar,
+        // walked in the RAW bar's leg order.
         dual_entry_path_ = dual_entry_stop_path_winner(
-            bar, pending_orders_, bar_index_);
+            broker_trigger_bar(bar), internal::bar_path_uses_high_first(bar),
+            pending_orders_, bar_index_);
     }
     const bool continue_after_stop_margin_decline_scope =
         dual_stop_margin_decline_can_continue_path(
@@ -299,7 +302,8 @@ BacktestEngine::CoofFillResult BacktestEngine::process_next_pending_order(
     DualEntryStopPathWinner dual_entry_path = DualEntryStopPathWinner::None;
     if (position_side_ == PositionSide::FLAT) {
         dual_entry_path = dual_entry_stop_path_winner(
-            bar, pending_orders_, bar_index_);
+            broker_trigger_bar(bar), internal::bar_path_uses_high_first(bar),
+            pending_orders_, bar_index_);
     }
 
     auto commit_stop_limit_activation_through = [&](double cursor_price) {
@@ -1732,6 +1736,11 @@ void BacktestEngine::update_trail_best_for_bar_open(const Bar& bar) {
 // Correctness over perf: leave as two sequential stable_sorts.
 void BacktestEngine::sort_exit_siblings_by_path_fill(const Bar& bar) {
     if (pending_orders_.size() < 2) return;  // nothing to order; skips stable_sort's temp-buffer alloc
+    // design-stop-tick-rounding: the no-trail metric is a stop / limit
+    // trigger test, so it walks the tick-quantized bar — in the RAW bar's
+    // leg order, like every other path coordinate this bar.
+    const Bar trigger_bar = broker_trigger_bar(bar);
+    const bool high_first = internal::bar_path_uses_high_first(bar);
     std::stable_sort(pending_orders_.begin(), pending_orders_.end(),
         [&](const PendingOrder& a, const PendingOrder& b) {
             if (a.type != OrderType::EXIT || b.type != OrderType::EXIT
@@ -1754,9 +1763,11 @@ void BacktestEngine::sort_exit_siblings_by_path_fill(const Bar& bar) {
             }
             bool is_ent_bar = (position_open_bar_ == bar_index_);
             double ma = exit_order_earliest_path_metric_no_trail(
-                bar, a, position_side_, is_ent_bar, position_entry_price_);
+                trigger_bar, high_first, a, position_side_, is_ent_bar,
+                position_entry_price_);
             double mb = exit_order_earliest_path_metric_no_trail(
-                bar, b, position_side_, is_ent_bar, position_entry_price_);
+                trigger_bar, high_first, b, position_side_, is_ent_bar,
+                position_entry_price_);
             const double inf = std::numeric_limits<double>::infinity();
             const double eps = kPathPosEps;
             if (ma < inf && mb < inf) {
@@ -2380,6 +2391,11 @@ void BacktestEngine::sort_orders_by_fill_phase(const Bar& bar) {
     }
     if (pending_orders_.size() < 2) return;  // nothing to order; skips stable_sort's temp-buffer alloc
 
+    // design-stop-tick-rounding: every "already marketable at the open" test
+    // below is a stop / limit trigger test and runs on the tick-quantized
+    // open, matching evaluate_fill_price's gap decision.
+    const double tick_open = broker_trigger_bar(bar).open;
+
     // Validate pair links before stable_sort starts moving elements. Scanning
     // pending_orders_ from inside the comparator would make its result depend
     // on the sort algorithm's transient moves. The immutable sequence set
@@ -2481,8 +2497,8 @@ void BacktestEngine::sort_orders_by_fill_phase(const Bar& bar) {
                 && std::isnan(order.trail_price)
                 && std::isnan(order.trail_offset);
             const bool fills_at_open = pure_limit_parent
-                && (order.is_long ? bar.open <= order.limit_price
-                                  : bar.open >= order.limit_price);
+                && (order.is_long ? tick_open <= order.limit_price
+                                  : tick_open >= order.limit_price);
             if (pure_limit_parent && !fills_at_open) {
                 non_gap_limit_parents.emplace(
                     order.id,
@@ -2837,21 +2853,21 @@ void BacktestEngine::sort_orders_by_fill_phase(const Bar& bar) {
 
                 if (exit_style) {
                     if (position_side_ == PositionSide::LONG) {
-                        if (has_stop && bar.open <= o.stop_price) return 0;
-                        if (has_limit && bar.open >= o.limit_price) return 0;
+                        if (has_stop && tick_open <= o.stop_price) return 0;
+                        if (has_limit && tick_open >= o.limit_price) return 0;
                     } else if (position_side_ == PositionSide::SHORT) {
-                        if (has_stop && bar.open >= o.stop_price) return 0;
-                        if (has_limit && bar.open <= o.limit_price) return 0;
+                        if (has_stop && tick_open >= o.stop_price) return 0;
+                        if (has_limit && tick_open <= o.limit_price) return 0;
                     }
                     return 1;
                 }
 
                 if (o.is_long) {
-                    if (has_stop && bar.open >= o.stop_price) return 0;
-                    if (has_limit && bar.open <= o.limit_price) return 0;
+                    if (has_stop && tick_open >= o.stop_price) return 0;
+                    if (has_limit && tick_open <= o.limit_price) return 0;
                 } else {
-                    if (has_stop && bar.open <= o.stop_price) return 0;
-                    if (has_limit && bar.open >= o.limit_price) return 0;
+                    if (has_stop && tick_open <= o.stop_price) return 0;
+                    if (has_limit && tick_open >= o.limit_price) return 0;
                 }
                 return 1;
             };
@@ -2909,12 +2925,12 @@ void BacktestEngine::sort_orders_by_fill_phase(const Bar& bar) {
                 if (ex_trail || (!ex_stop && !ex_limit)) return -1;
                 int exit_prio;
                 if (position_side_ == PositionSide::LONG) {
-                    if (ex_stop && bar.open <= ex.stop_price) exit_prio = 2;
-                    else if (ex_limit && bar.open >= ex.limit_price) exit_prio = 3;
+                    if (ex_stop && tick_open <= ex.stop_price) exit_prio = 2;
+                    else if (ex_limit && tick_open >= ex.limit_price) exit_prio = 3;
                     else return -1;   // not gapped through a leg at the open
                 } else {  // SHORT
-                    if (ex_stop && bar.open >= ex.stop_price) exit_prio = 1;
-                    else if (ex_limit && bar.open <= ex.limit_price) exit_prio = 3;
+                    if (ex_stop && tick_open >= ex.stop_price) exit_prio = 1;
+                    else if (ex_limit && tick_open <= ex.limit_price) exit_prio = 3;
                     else return -1;
                 }
                 int add_prio = add.is_long ? 1 : 2;
@@ -3363,9 +3379,12 @@ bool BacktestEngine::use_stop_placement_open_qty(
     // established fill-time sizing. This covers favorable and adverse gaps:
     // both carry the placement qty, while only an adverse notional overshoot is
     // declined by the caller's margin comparison.
+    // design-stop-tick-rounding: the same tick-quantized open test
+    // evaluate_fill_price's gap fill uses.
+    const double tick_open = broker_trigger_bar(bar).open;
     const bool gap_open_marketable =
-        order.is_long ? bar.open >= order.stop_price
-                      : bar.open <= order.stop_price;
+        order.is_long ? tick_open >= order.stop_price
+                      : tick_open <= order.stop_price;
     const double placement_equity =
         order.stop_placement_open_equity;
     const double equity_guard = std::isfinite(placement_equity)
@@ -5127,12 +5146,20 @@ void BacktestEngine::apply_entry_order_fill(PendingOrder& order, double fill_pri
                 // fill price used by excursion accounting. Stop fills can be
                 // rounded or slipped; limit fills can improve at the open. The
                 // child becomes live at the actual parent trigger crossing.
+                // design-stop-tick-rounding: the crossing is located on the
+                // tick-quantized bar the fill was decided on (a 14.0352 stop
+                // that fired on the 14.0351 -> 14.04 high has no crossing on
+                // the raw path), walked in the RAW bar's leg order — the
+                // coordinate system resolve_exit_path_fill resumes the
+                // same-bar bracket in.
+                const Bar trigger_bar = broker_trigger_bar(bar);
+                const bool high_first = internal::bar_path_uses_high_first(bar);
                 if (!std::isnan(order.stop_price)
                     && std::isnan(order.limit_price)) {
                     double entry_path_position = 0.0;
                     if (internal::entry_stop_first_touch(
-                            bar, order.stop_price, order.is_long,
-                            &entry_path_position)) {
+                            trigger_bar, high_first, order.stop_price,
+                            order.is_long, &entry_path_position)) {
                         pyramid_entries_.back().entry_path_position =
                             entry_path_position;
                     }
@@ -5140,11 +5167,12 @@ void BacktestEngine::apply_entry_order_fill(PendingOrder& order, double fill_pri
                            && !std::isnan(order.limit_price)) {
                     double entry_path_position = 0.0;
                     const bool fills_at_open = order.is_long
-                        ? bar.open <= order.limit_price
-                        : bar.open >= order.limit_price;
+                        ? trigger_bar.open <= order.limit_price
+                        : trigger_bar.open >= order.limit_price;
                     if (fills_at_open
                         || internal::first_touch_position(
-                            bar, order.limit_price, &entry_path_position)) {
+                            trigger_bar, high_first, order.limit_price,
+                            &entry_path_position)) {
                         pyramid_entries_.back().entry_path_position =
                             entry_path_position;
                     }
@@ -5915,8 +5943,11 @@ BacktestEngine::OrderEligibility BacktestEngine::classify_order_eligibility(
                 return OrderEligibility::Skip;
             }
         }
+        // design-stop-tick-rounding: same tick-quantized open test as the
+        // fill in evaluate_fill_price.
         const bool prearmed_market_gap =
-            prearmed_market_parent_bracket_gaps_at_open(order, bar);
+            prearmed_market_parent_bracket_gaps_at_open(
+                order, broker_trigger_bar(bar));
         if (!prearmed_market_gap && !bar_magnifier_enabled_
             && !(calc_on_order_fills_ && coof_scheduler_active_
                  && order.created_during_coof_recalc)) {
@@ -5958,8 +5989,20 @@ BacktestEngine::FillEvaluation BacktestEngine::evaluate_fill_price(
 
     last_exit_fill_was_trail_ = false;
 
+    // design-stop-tick-rounding: every resting stop / limit trigger test in
+    // this function runs on the tick-quantized bar (broker_trigger_bar,
+    // engine.hpp); the fill prices below keep reading the raw `bar`, whose
+    // open / close go through bar_fill_price exactly as before. The trail
+    // legs, the stop-limit entry and the process_orders_on_close close
+    // compares stay on the raw bar (not pinned).
+    const Bar tick_bar = broker_trigger_bar(bar);
+    // The leg order stays the RAW bar's (resolve_exit_path_fill walks the
+    // twin in that order too), so every path coordinate this bar agrees.
+    const bool tick_high_first = internal::bar_path_uses_high_first(bar);
+
     if (order.type == OrderType::RAW_ORDER && exit_style
-        && oca_exit_sibling_hits_first(bar, pending_orders_, order_index, position_side_)) {
+        && oca_exit_sibling_hits_first(tick_bar, tick_high_first, pending_orders_,
+                                       order_index, position_side_)) {
         return {FillEvaluation::Kind::NoFill, 0.0};
     }
 
@@ -5978,7 +6021,7 @@ BacktestEngine::FillEvaluation BacktestEngine::evaluate_fill_price(
     // fills); the stop leg keeps its established slipped-stop booking.
     bool prearmed_bracket_limit_leg = false;
     if (exit_style && prearmed_market_parent_bracket_gaps_at_open(
-            order, bar, &prearmed_bracket_limit_leg)) {
+            order, tick_bar, &prearmed_bracket_limit_leg)) {
         fill_price = bar_fill_price(bar.open);
         should_fill = true;
         is_limit_fill = prearmed_bracket_limit_leg;
@@ -6075,6 +6118,7 @@ BacktestEngine::FillEvaluation BacktestEngine::evaluate_fill_price(
         }
         ExitPathFill exit_fill = resolve_exit_path_fill(
             bar,
+            tick_bar,
             position_side_,
             stop_price,
             limit_price,
@@ -6141,24 +6185,29 @@ BacktestEngine::FillEvaluation BacktestEngine::evaluate_fill_price(
         // Entry stop order
         if (position_side_ == PositionSide::FLAT && opposing_pass == 0 &&
             opposing_stop_entry_hits_first(
-                bar, pending_orders_, order_index, bar_index_)) {
+                tick_bar, tick_high_first, pending_orders_, order_index,
+                bar_index_)) {
             pass0_opposing_skip_ids.insert(order.id);
             return {FillEvaluation::Kind::DeferredToOpposingPass, 0.0};
         }
+        // Trigger and gap tests on the tick-quantized bar
+        // (design-stop-tick-rounding: NYSE:F 14.0349 / 14.03505 / 14.0352
+        // all fill on the 14.0351 high, 13.7451 / 13.7449 skip the 13.745
+        // low); the fill itself is unchanged.
         if (order.is_long) {
-            if (bar.high >= stop_price) {
+            if (tick_bar.high >= stop_price) {
                 // A stop the open already gapped through fills at the raw
                 // open, nearest-tick rounded (finding-446). Otherwise TV
                 // snaps the stop LEVEL to mintick in the conservative
                 // direction (long stop -> ceil).
-                fill_price = bar.open >= stop_price
+                fill_price = tick_bar.open >= stop_price
                     ? bar_fill_price(bar.open)
                     : round_to_mintick_directional(stop_price, true);
                 should_fill = true;
             }
         } else {
-            if (bar.low <= stop_price) {
-                fill_price = bar.open <= stop_price
+            if (tick_bar.low <= stop_price) {
+                fill_price = tick_bar.open <= stop_price
                     ? bar_fill_price(bar.open)
                     : round_to_mintick_directional(stop_price, false);
                 should_fill = true;
@@ -6190,18 +6239,22 @@ BacktestEngine::FillEvaluation BacktestEngine::evaluate_fill_price(
                 is_limit_fill = true;
             }
         } else if (order.is_long) {
-            if (bar.low <= limit_price) {
+            // Resting limit: trigger and gap tests on the tick-quantized bar
+            // (design-stop-tick-rounding: NYSE:F buy-limits 13.7451 /
+            // 13.7449 skip the 13.745 low, sell-limits 14.03505 / 14.0352
+            // fill on the 14.0351 high).
+            if (tick_bar.low <= limit_price) {
                 // Gap through the limit at the open: raw open, nearest tick
                 // (finding-446); otherwise the limit level (limit-or-better
                 // snap downstream in apply_limit_fill).
-                fill_price = bar.open <= limit_price
+                fill_price = tick_bar.open <= limit_price
                     ? bar_fill_price(bar.open) : limit_price;
                 should_fill = true;
                 is_limit_fill = true;
             }
         } else {
-            if (bar.high >= limit_price) {
-                fill_price = bar.open >= limit_price
+            if (tick_bar.high >= limit_price) {
+                fill_price = tick_bar.open >= limit_price
                     ? bar_fill_price(bar.open) : limit_price;
                 should_fill = true;
                 is_limit_fill = true;

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -3631,12 +3631,16 @@ void BacktestEngine::apply_filled_order_to_state(
     // sizing_equity and THIS gate's flat-open arm would decline ordinary
     // flat opens whenever cash_value > equity; pct > 100 (leveraged sizing)
     // breaks the invariant too. Frozen CASH / pct>100 orders keep their
-    // freeze and skip this gate. CASH (and FIXED) default MARKET entries are
-    // instead admitted by the unified design-market-entry-affordability gate
+    // freeze and skip this gate. CASH (and FIXED) default MARKET entries, and
+    // since round 6 the pct>100 percent_of_equity default MARKET entries as
+    // well, are instead admitted by the unified
+    // design-market-entry-affordability gate
     // below (resulting position costed at max(signal, fill) against the
     // placement MTM equity) — a cash 20k on 10k capital account at margin 100
     // is over-notional there and declines, exactly like a fixed-qty order of
-    // the same notional (pin-afford-gapdown).
+    // the same notional (pin-afford-gapdown), and so does percent_of_equity
+    // 200 on the same account (pin-pct-afford: TV 0 entries; at margin 50
+    // both size 1,982 F shares and fill).
     //
     // Frozen MARKET entries and frozen RAW market orders are checked; an
     // opposite-direction RAW fill only CLOSES the position
@@ -4017,8 +4021,9 @@ void BacktestEngine::apply_filled_order_to_state(
     // market-entry admission (rule, pins and evidence on
     // PendingOrder::affordability_placement_equity, engine.hpp; the placement
     // half is in strategy_entry). The quantity is exactly what the market
-    // kernel is about to dispatch (the frozen CASH default, the FIXED default,
-    // or the lot-floored explicit qty), a same-direction add is costed as
+    // kernel is about to dispatch (the frozen CASH or >100%-of-equity default,
+    // the FIXED default, or the lot-floored explicit qty), a same-direction
+    // add is costed as
     // held + add with "held" FROZEN AT PLACEMENT (a same-tick sibling that
     // filled first is not re-costed here — thula INR short pair, TV rows in
     // test_margin_call), a reversal as its own new side only, and the price is

--- a/src/engine_internal.hpp
+++ b/src/engine_internal.hpp
@@ -242,6 +242,17 @@ int price_path_priority(const Bar& bar, double stop_level, double limit_level);
 // price level is crossed on OHLC path. Returns false if never crossed.
 bool first_touch_position(const Bar& bar, double level, double* out_pos);
 
+// design-stop-tick-rounding: the path helpers below also come in a form whose
+// LEG ORDER (O->H->L->C vs O->L->H->C) is chosen by the caller. The engine
+// walks the tick-quantized twin of a bar (BacktestEngine::broker_trigger_bar)
+// with the RAW bar's order, so a path coordinate produced here — the
+// entry_path_position cursor a same-bar bracket resumes from, a sibling /
+// opposing-order tie-break — lives in the same coordinate system as
+// resolve_exit_path_fill's walk. The single-bar forms derive the order from
+// the bar they are given (bar_path_uses_high_first) and are unchanged.
+bool first_touch_position(const Bar& bar, bool high_first, double level,
+                          double* out_pos);
+
 
 // First path position where a stop ENTRY can fire, accounting for direction:
 // long stops only fire on up-segments (price rising through the stop), short
@@ -253,6 +264,8 @@ bool first_touch_position(const Bar& bar, double level, double* out_pos);
 // broker emulator on probe 83.
 bool entry_stop_first_touch(const Bar& bar, double stop_level,
                                    bool is_long, double* out_pos);
+bool entry_stop_first_touch(const Bar& bar, bool high_first, double stop_level,
+                            bool is_long, double* out_pos);
 
 
 // For flat-position opposing stop entries (long stop vs short stop), return
@@ -261,11 +274,18 @@ bool opposing_stop_entry_hits_first(const Bar& bar,
                                     const std::vector<PendingOrder>& orders,
                                     std::size_t current_idx,
                                     int current_bar_index = -1);
+bool opposing_stop_entry_hits_first(const Bar& bar, bool high_first,
+                                    const std::vector<PendingOrder>& orders,
+                                    std::size_t current_idx,
+                                    int current_bar_index);
 
 
 DualEntryStopPathWinner dual_entry_stop_path_winner(const Bar& bar,
                                                      const std::vector<PendingOrder>& orders,
                                                      int current_bar_index = -1);
+DualEntryStopPathWinner dual_entry_stop_path_winner(const Bar& bar, bool high_first,
+                                                     const std::vector<PendingOrder>& orders,
+                                                     int current_bar_index);
 
 
 // Exact scope for continuing the historical path after a dual-stop winner is
@@ -285,12 +305,20 @@ bool exit_order_touch_position(const Bar& bar,
                                       const PendingOrder& order,
                                       PositionSide pos,
                                       double* out_pos);
+bool exit_order_touch_position(const Bar& bar, bool high_first,
+                               const PendingOrder& order,
+                               PositionSide pos,
+                               double* out_pos);
 
 
 bool oca_exit_sibling_hits_first(const Bar& bar,
                                         const std::vector<PendingOrder>& orders,
                                         std::size_t current_idx,
                                         PositionSide pos);
+bool oca_exit_sibling_hits_first(const Bar& bar, bool high_first,
+                                 const std::vector<PendingOrder>& orders,
+                                 std::size_t current_idx,
+                                 PositionSide pos);
 
 
 // strategy.exit → OrderType::EXIT; strategy.order → RAW_ORDER. When a raw order's
@@ -300,6 +328,10 @@ bool order_is_exit_style(const PendingOrder& o, PositionSide pos);
 
 
 void fill_bar_path_points(const Bar& bar, double path[4]);
+
+// Same 4-waypoint path, but with the leg order chosen by the caller (so a
+// tick-quantized twin of a bar walks the raw bar's leg order).
+void fill_bar_path_points_ordered(const Bar& bar, bool high_first, double path[4]);
 
 
 int path_cross_kind_priority(PathCrossKind kind);
@@ -317,6 +349,17 @@ CrossEventList collect_cross_events(double from_price,
                                                         double stop_level,
                                                         double limit_level,
                                                         double trail_level);
+
+// design-stop-tick-rounding: stop and limit crossings are taken on the
+// tick-quantized segment (tick_from -> tick_to), the trail crossing on the raw
+// segment (from -> to); the merged list keeps collect_cross_events's order.
+CrossEventList collect_cross_events_split(double from_price,
+                                          double to_price,
+                                          double tick_from_price,
+                                          double tick_to_price,
+                                          double stop_level,
+                                          double limit_level,
+                                          double trail_level);
 
 
 // fill_at_bar_point (optional) reports whether the returned fill price is a
@@ -343,8 +386,36 @@ double exit_order_earliest_path_metric_no_trail(
     PositionSide position_side,
     bool is_entry_bar,
     double position_entry_price);
+double exit_order_earliest_path_metric_no_trail(
+    const Bar& bar,
+    bool high_first,
+    const PendingOrder& order,
+    PositionSide position_side,
+    bool is_entry_bar,
+    double position_entry_price);
 
 
+// design-stop-tick-rounding: `tick_bar` is the bar the STOP / LIMIT legs are
+// tested against (the engine passes BacktestEngine::broker_trigger_bar(bar):
+// OHLC quantized to the tick, level raw); the TRAIL leg walks `bar` itself.
+// The two share the raw bar's leg order and segment cursor.
+ExitPathFill resolve_exit_path_fill(const Bar& bar,
+                                           const Bar& tick_bar,
+                                           PositionSide position_side,
+                                           double stop_price,
+                                           double limit_price,
+                                           double trail_points,
+                                           double trail_price,
+                                           double trail_offset,
+                                           double position_entry_price,
+                                           double trail_best_start,
+                                           bool is_entry_bar,
+                                           bool magnifier_active,
+                                           double syminfo_mintick,
+                                           bool cascade_wp_gap = false,
+                                           double path_start_position = 0.0);
+
+// Raw-only form (tick_bar == bar): every leg walks the raw bar.
 ExitPathFill resolve_exit_path_fill(const Bar& bar,
                                            PositionSide position_side,
                                            double stop_price,

--- a/src/engine_path_resolve.cpp
+++ b/src/engine_path_resolve.cpp
@@ -71,16 +71,15 @@ int price_path_priority(const Bar& bar, double stop_level, double limit_level) {
 // Return earliest path position (segment index + [0..1] interpolation) where
 // price level is crossed on OHLC path. Returns false if never crossed.
 bool first_touch_position(const Bar& bar, double level, double* out_pos) {
+    return first_touch_position(bar, bar_path_uses_high_first(bar), level, out_pos);
+}
+
+bool first_touch_position(const Bar& bar, bool high_first, double level,
+                          double* out_pos) {
     if (std::isnan(level) || out_pos == nullptr) return false;
 
     double path[4];
-    if (bar_path_uses_high_first(bar)) {
-        // Open nearer high: O -> H -> L -> C
-        path[0] = bar.open; path[1] = bar.high; path[2] = bar.low; path[3] = bar.close;
-    } else {
-        // Open nearer low (or tied): O -> L -> H -> C
-        path[0] = bar.open; path[1] = bar.low; path[2] = bar.high; path[3] = bar.close;
-    }
+    fill_bar_path_points_ordered(bar, high_first, path);
 
     for (int i = 1; i < 4; ++i) {
         double prev = path[i - 1];
@@ -111,6 +110,12 @@ bool first_touch_position(const Bar& bar, double level, double* out_pos) {
 // broker emulator on probe 83.
 bool entry_stop_first_touch(const Bar& bar, double stop_level,
                                    bool is_long, double* out_pos) {
+    return entry_stop_first_touch(bar, bar_path_uses_high_first(bar),
+                                  stop_level, is_long, out_pos);
+}
+
+bool entry_stop_first_touch(const Bar& bar, bool high_first, double stop_level,
+                            bool is_long, double* out_pos) {
     if (std::isnan(stop_level) || out_pos == nullptr) return false;
 
     if (is_long) {
@@ -128,11 +133,7 @@ bool entry_stop_first_touch(const Bar& bar, double stop_level,
     }
 
     double path[4];
-    if (bar_path_uses_high_first(bar)) {
-        path[0] = bar.open; path[1] = bar.high; path[2] = bar.low; path[3] = bar.close;
-    } else {
-        path[0] = bar.open; path[1] = bar.low; path[2] = bar.high; path[3] = bar.close;
-    }
+    fill_bar_path_points_ordered(bar, high_first, path);
 
     for (int i = 1; i < 4; ++i) {
         double prev = path[i - 1];
@@ -166,6 +167,14 @@ bool opposing_stop_entry_hits_first(const Bar& bar,
                                            const std::vector<PendingOrder>& orders,
                                            std::size_t current_idx,
                                            int current_bar_index) {
+    return opposing_stop_entry_hits_first(bar, bar_path_uses_high_first(bar),
+                                          orders, current_idx, current_bar_index);
+}
+
+bool opposing_stop_entry_hits_first(const Bar& bar, bool high_first,
+                                    const std::vector<PendingOrder>& orders,
+                                    std::size_t current_idx,
+                                    int current_bar_index) {
     if (current_idx >= orders.size()) return false;
     const PendingOrder& current = orders[current_idx];
     auto deferred_at_consumed_close = [&](const PendingOrder& order) {
@@ -182,7 +191,8 @@ bool opposing_stop_entry_hits_first(const Bar& bar,
     if (!current_touched) return false;
 
     double cur_pos = 0.0;
-    if (!entry_stop_first_touch(bar, current.stop_price, current.is_long, &cur_pos))
+    if (!entry_stop_first_touch(bar, high_first, current.stop_price,
+                                current.is_long, &cur_pos))
         return false;
 
     const double eps = kPathPosEps;
@@ -199,7 +209,8 @@ bool opposing_stop_entry_hits_first(const Bar& bar,
         if (!other_touched) continue;
 
         double other_pos = 0.0;
-        if (!entry_stop_first_touch(bar, other.stop_price, other.is_long, &other_pos))
+        if (!entry_stop_first_touch(bar, high_first, other.stop_price,
+                                    other.is_long, &other_pos))
             continue;
         if (other_pos < cur_pos - eps) return true;
         // Path-tied opposing pair: prefer the long entry. Defer the short.
@@ -214,6 +225,13 @@ bool opposing_stop_entry_hits_first(const Bar& bar,
 DualEntryStopPathWinner dual_entry_stop_path_winner(const Bar& bar,
                                                           const std::vector<PendingOrder>& orders,
                                                           int current_bar_index) {
+    return dual_entry_stop_path_winner(bar, bar_path_uses_high_first(bar),
+                                       orders, current_bar_index);
+}
+
+DualEntryStopPathWinner dual_entry_stop_path_winner(const Bar& bar, bool high_first,
+                                                     const std::vector<PendingOrder>& orders,
+                                                     int current_bar_index) {
     const PendingOrder* long_ord = nullptr;
     const PendingOrder* short_ord = nullptr;
     for (const PendingOrder& o : orders) {
@@ -247,9 +265,9 @@ DualEntryStopPathWinner dual_entry_stop_path_winner(const Bar& bar,
     }
     double lp = 0.0;
     double sp = 0.0;
-    if (!entry_stop_first_touch(bar, long_ord->stop_price, true, &lp))
+    if (!entry_stop_first_touch(bar, high_first, long_ord->stop_price, true, &lp))
         return DualEntryStopPathWinner::None;
-    if (!entry_stop_first_touch(bar, short_ord->stop_price, false, &sp))
+    if (!entry_stop_first_touch(bar, high_first, short_ord->stop_price, false, &sp))
         return DualEntryStopPathWinner::None;
     const double eps = kPathPosEps;
     if (lp < sp - eps) {
@@ -271,6 +289,14 @@ bool exit_order_touch_position(const Bar& bar,
                                       const PendingOrder& order,
                                       PositionSide pos,
                                       double* out_pos) {
+    return exit_order_touch_position(bar, bar_path_uses_high_first(bar),
+                                     order, pos, out_pos);
+}
+
+bool exit_order_touch_position(const Bar& bar, bool high_first,
+                               const PendingOrder& order,
+                               PositionSide pos,
+                               double* out_pos) {
     if (out_pos == nullptr || pos == PositionSide::FLAT) return false;
 
     bool has_stop = !std::isnan(order.stop_price);
@@ -284,14 +310,14 @@ bool exit_order_touch_position(const Bar& bar,
                 *out_pos = 0.0;  // gap-through at bar open
                 return true;
             }
-            return first_touch_position(bar, order.stop_price, out_pos);
+            return first_touch_position(bar, high_first, order.stop_price, out_pos);
         }
         if (!(bar.high >= order.limit_price)) return false;
         if (bar.open >= order.limit_price) {
             *out_pos = 0.0;
             return true;
         }
-        return first_touch_position(bar, order.limit_price, out_pos);
+        return first_touch_position(bar, high_first, order.limit_price, out_pos);
     }
 
     // SHORT position
@@ -301,14 +327,14 @@ bool exit_order_touch_position(const Bar& bar,
             *out_pos = 0.0;
             return true;
         }
-        return first_touch_position(bar, order.stop_price, out_pos);
+        return first_touch_position(bar, high_first, order.stop_price, out_pos);
     }
     if (!(bar.low <= order.limit_price)) return false;
     if (bar.open <= order.limit_price) {
         *out_pos = 0.0;
         return true;
     }
-    return first_touch_position(bar, order.limit_price, out_pos);
+    return first_touch_position(bar, high_first, order.limit_price, out_pos);
 }
 
 
@@ -316,6 +342,14 @@ bool oca_exit_sibling_hits_first(const Bar& bar,
                                         const std::vector<PendingOrder>& orders,
                                         std::size_t current_idx,
                                         PositionSide pos) {
+    return oca_exit_sibling_hits_first(bar, bar_path_uses_high_first(bar),
+                                       orders, current_idx, pos);
+}
+
+bool oca_exit_sibling_hits_first(const Bar& bar, bool high_first,
+                                 const std::vector<PendingOrder>& orders,
+                                 std::size_t current_idx,
+                                 PositionSide pos) {
     if (current_idx >= orders.size() || pos == PositionSide::FLAT) return false;
     const PendingOrder& current = orders[current_idx];
     if (current.type != OrderType::RAW_ORDER) return false;
@@ -325,7 +359,7 @@ bool oca_exit_sibling_hits_first(const Bar& bar,
     if (!current_exit_style) return false;
 
     double cur_pos = 0.0;
-    if (!exit_order_touch_position(bar, current, pos, &cur_pos)) return false;
+    if (!exit_order_touch_position(bar, high_first, current, pos, &cur_pos)) return false;
 
     const double eps = kPathPosEps;
     for (std::size_t j = 0; j < orders.size(); ++j) {
@@ -337,7 +371,7 @@ bool oca_exit_sibling_hits_first(const Bar& bar,
         if (!other_exit_style) continue;
 
         double other_pos = 0.0;
-        if (!exit_order_touch_position(bar, other, pos, &other_pos)) continue;
+        if (!exit_order_touch_position(bar, high_first, other, pos, &other_pos)) continue;
         if (other_pos < cur_pos - eps) return true;
     }
     return false;
@@ -358,6 +392,21 @@ bool order_is_exit_style(const PendingOrder& o, PositionSide pos) {
 
 // PathCrossKind, PathCrossEvent, ExitPathFill, DualEntryStopPathWinner
 // are defined in engine_internal.hpp.
+
+void fill_bar_path_points_ordered(const Bar& bar, bool high_first, double path[4]) {
+    if (high_first) {
+        path[0] = bar.open;
+        path[1] = bar.high;
+        path[2] = bar.low;
+        path[3] = bar.close;
+    } else {
+        path[0] = bar.open;
+        path[1] = bar.low;
+        path[2] = bar.high;
+        path[3] = bar.close;
+    }
+}
+
 
 void fill_bar_path_points(const Bar& bar, double path[4]) {
     if (bar_path_uses_high_first(bar)) {
@@ -410,16 +459,9 @@ void append_cross_event(CrossEventList* events,
 }
 
 
-CrossEventList collect_cross_events(double from_price,
-                                                        double to_price,
-                                                        double stop_level,
-                                                        double limit_level,
-                                                        double trail_level) {
-    CrossEventList events;
-    append_cross_event(&events, from_price, to_price, stop_level, PathCrossKind::STOP);
-    append_cross_event(&events, from_price, to_price, limit_level, PathCrossKind::LIMIT);
-    append_cross_event(&events, from_price, to_price, trail_level, PathCrossKind::TRAIL);
+namespace {
 
+void sort_cross_events(CrossEventList& events) {
     // Insertion sort over <=3 elements with the same comparator the previous
     // std::sort used. The three kinds are pairwise distinct, so the comparator
     // is a strict total order here and any correct sort yields the identical
@@ -436,6 +478,37 @@ CrossEventList collect_cross_events(double from_price,
         while (j >= 0 && before(key, events.ev[j])) { events.ev[j + 1] = events.ev[j]; --j; }
         events.ev[j + 1] = key;
     }
+}
+
+}  // namespace
+
+
+CrossEventList collect_cross_events(double from_price,
+                                                        double to_price,
+                                                        double stop_level,
+                                                        double limit_level,
+                                                        double trail_level) {
+    CrossEventList events;
+    append_cross_event(&events, from_price, to_price, stop_level, PathCrossKind::STOP);
+    append_cross_event(&events, from_price, to_price, limit_level, PathCrossKind::LIMIT);
+    append_cross_event(&events, from_price, to_price, trail_level, PathCrossKind::TRAIL);
+    sort_cross_events(events);
+    return events;
+}
+
+
+CrossEventList collect_cross_events_split(double from_price,
+                                          double to_price,
+                                          double tick_from_price,
+                                          double tick_to_price,
+                                          double stop_level,
+                                          double limit_level,
+                                          double trail_level) {
+    CrossEventList events;
+    append_cross_event(&events, tick_from_price, tick_to_price, stop_level, PathCrossKind::STOP);
+    append_cross_event(&events, tick_from_price, tick_to_price, limit_level, PathCrossKind::LIMIT);
+    append_cross_event(&events, from_price, to_price, trail_level, PathCrossKind::TRAIL);
+    sort_cross_events(events);
     return events;
 }
 
@@ -651,7 +724,9 @@ double active_exit_trail_level(const ExitTrailState& s, bool is_long) {
 // active trail level, the activation-as-exit level, or the stop / limit in the
 // firing direction, the exit fills at bar.open. Order matters — trail first,
 // then activation-as-exit, then stop, then limit (matches the original cascade).
-bool try_exit_open_gap_fill(const Bar& bar, bool is_long,
+// design-stop-tick-rounding: the stop / limit legs test `tick_open` (the
+// tick-quantized open), the trail legs the raw open.
+bool try_exit_open_gap_fill(const Bar& bar, double tick_open, bool is_long,
                             bool has_stop, double stop_price,
                             bool has_limit, double limit_price,
                             const ExitTrailState& trail,
@@ -667,13 +742,13 @@ bool try_exit_open_gap_fill(const Bar& bar, bool is_long,
     if (is_long) {
         if (!std::isnan(trail_level) && bar.open <= trail_level) return fill_at_open(false);
         if (trail.exits_at_activation && bar.open >= trail.activation_level) return fill_at_open(false);
-        if (has_stop && bar.open <= stop_price) return fill_at_open(false);
-        if (has_limit && bar.open >= limit_price) return fill_at_open(true);
+        if (has_stop && tick_open <= stop_price) return fill_at_open(false);
+        if (has_limit && tick_open >= limit_price) return fill_at_open(true);
     } else {
         if (!std::isnan(trail_level) && bar.open >= trail_level) return fill_at_open(false);
         if (trail.exits_at_activation && bar.open <= trail.activation_level) return fill_at_open(false);
-        if (has_stop && bar.open >= stop_price) return fill_at_open(false);
-        if (has_limit && bar.open <= limit_price) return fill_at_open(true);
+        if (has_stop && tick_open >= stop_price) return fill_at_open(false);
+        if (has_limit && tick_open <= limit_price) return fill_at_open(true);
     }
     return false;
 }
@@ -837,6 +912,18 @@ double exit_order_earliest_path_metric_no_trail(
     PositionSide position_side,
     bool is_entry_bar,
     double position_entry_price) {
+    return exit_order_earliest_path_metric_no_trail(
+        bar, bar_path_uses_high_first(bar), order, position_side,
+        is_entry_bar, position_entry_price);
+}
+
+double exit_order_earliest_path_metric_no_trail(
+    const Bar& bar,
+    bool high_first,
+    const PendingOrder& order,
+    PositionSide position_side,
+    bool is_entry_bar,
+    double position_entry_price) {
     if (order.type != OrderType::EXIT) {
         return std::numeric_limits<double>::infinity();
     }
@@ -870,7 +957,7 @@ double exit_order_earliest_path_metric_no_trail(
     }
 
     double path[4];
-    fill_bar_path_points(bar, path);
+    fill_bar_path_points_ordered(bar, high_first, path);
 
     for (int seg_idx = 1; seg_idx < 4; ++seg_idx) {
         const double from_price = path[seg_idx - 1];
@@ -898,6 +985,29 @@ double exit_order_earliest_path_metric_no_trail(
 
 
 ExitPathFill resolve_exit_path_fill(const Bar& bar,
+                                           PositionSide position_side,
+                                           double stop_price,
+                                           double limit_price,
+                                           double trail_points,
+                                           double trail_price,
+                                           double trail_offset,
+                                           double position_entry_price,
+                                           double trail_best_start,
+                                           bool is_entry_bar,
+                                           bool magnifier_active,
+                                           double syminfo_mintick,
+                                           bool cascade_wp_gap,
+                                           double path_start_position) {
+    return resolve_exit_path_fill(bar, bar, position_side, stop_price, limit_price,
+                                  trail_points, trail_price, trail_offset,
+                                  position_entry_price, trail_best_start,
+                                  is_entry_bar, magnifier_active, syminfo_mintick,
+                                  cascade_wp_gap, path_start_position);
+}
+
+
+ExitPathFill resolve_exit_path_fill(const Bar& bar,
+                                           const Bar& tick_bar,
                                            PositionSide position_side,
                                            double stop_price,
                                            double limit_price,
@@ -940,7 +1050,7 @@ ExitPathFill resolve_exit_path_fill(const Bar& bar,
     const double path_cursor = std::clamp(path_start_position, 0.0, 3.0);
     if (path_cursor <= kPathPosEps
         && (!is_entry_bar || magnifier_active || cascade_wp_gap)) {
-        if (try_exit_open_gap_fill(bar, is_long, has_stop, stop_price,
+        if (try_exit_open_gap_fill(bar, tick_bar.open, is_long, has_stop, stop_price,
                                    has_limit, limit_price, trail, &fill)) {
             // A gap fill happens at the bar's open — path position 0.
             fill.path_position = 0.0;
@@ -956,8 +1066,15 @@ ExitPathFill resolve_exit_path_fill(const Bar& bar,
         observe_exit_trail_open(is_long, bar.open, &trail);
     }
 
+    // design-stop-tick-rounding: the tick-quantized twin walks the raw bar's
+    // leg order, so both paths share segment indices and the cursor; stop /
+    // limit crossings are taken on the tick path, trail crossings (and the
+    // trail's running best) on the raw path.
+    const bool high_first = bar_path_uses_high_first(bar);
     double path[4];
-    fill_bar_path_points(bar, path);
+    double tick_path[4];
+    fill_bar_path_points_ordered(bar, high_first, path);
+    fill_bar_path_points_ordered(tick_bar, high_first, tick_path);
 
     for (int seg_idx = 1; seg_idx < 4; ++seg_idx) {
         // A priced parent entry can activate a resting from_entry bracket in
@@ -970,10 +1087,13 @@ ExitPathFill resolve_exit_path_fill(const Bar& bar,
         }
         double from_price = path[seg_idx - 1];
         const double to_price = path[seg_idx];
+        double tick_from_price = tick_path[seg_idx - 1];
+        const double tick_to_price = tick_path[seg_idx];
         const double seg_start = static_cast<double>(seg_idx - 1);
         if (path_cursor > seg_start + kPathPosEps) {
             const double t = std::clamp(path_cursor - seg_start, 0.0, 1.0);
             from_price += (to_price - from_price) * t;
+            tick_from_price += (tick_to_price - tick_from_price) * t;
         }
         const bool rising = to_price > from_price;
         const bool falling = to_price < from_price;
@@ -985,8 +1105,9 @@ ExitPathFill resolve_exit_path_fill(const Bar& bar,
                                    stop_price, limit_price, trail,
                                    &stop_level, &limit_level, &trail_level);
 
-        CrossEventList events =
-            collect_cross_events(from_price, to_price, stop_level, limit_level, trail_level);
+        CrossEventList events = collect_cross_events_split(
+            from_price, to_price, tick_from_price, tick_to_price,
+            stop_level, limit_level, trail_level);
         if (events.n != 0) {
             fill.should_fill = true;
             fill.fill_price = events.ev[0].price;
@@ -995,9 +1116,13 @@ ExitPathFill resolve_exit_path_fill(const Bar& bar,
             // Chronology of the fill itself, in first_touch_position units.
             // Interpolate against the FULL segment (path[seg_idx-1] ->
             // path[seg_idx]) even when a mid-path cursor truncated it, so
-            // the scale matches first_touch_position's exactly.
-            const double seg_origin = path[seg_idx - 1];
-            const double seg_denom = to_price - seg_origin;
+            // the scale matches first_touch_position's exactly. A stop /
+            // limit crossing is placed on the tick path it was found on.
+            const bool on_tick_path = !fill.is_trail;
+            const double seg_origin = on_tick_path ? tick_path[seg_idx - 1]
+                                                   : path[seg_idx - 1];
+            const double seg_end = on_tick_path ? tick_to_price : to_price;
+            const double seg_denom = seg_end - seg_origin;
             double fill_pos = seg_start;
             if (std::abs(seg_denom) > kSegmentDenomEps) {
                 fill_pos += (fill.fill_price - seg_origin) / seg_denom;

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -1307,6 +1307,7 @@ void BacktestEngine::run(const Bar* input_bars, int n_input,
     validate_security_timeframes(security_input_tf_);
 
     init_security_eval_states_for_run(security_input_tf_);
+    prepare_native_security_feeds();
 #ifdef PINEFORGE_HAS_AUX_SECURITY_FEED_V1
     if (aux_security_feed_enabled()) {
         prepare_aux_security_chart_ranges(input_bars, n_input,
@@ -1386,6 +1387,8 @@ void BacktestEngine::init_security_eval_states_for_run(
         state.historical_projections.clear();
         state.historical_projection_cursor = 0;
         state.historical_projection_feed_index = 0;
+        state.native_feed_index = -1;
+        state.native_bars_by_label.clear();
         state.aggregator = TimeframeAggregator();
         if (state.lower_tf_emulation || state.lower_tf_use_input) {
             continue;

--- a/src/engine_security.cpp
+++ b/src/engine_security.cpp
@@ -544,6 +544,11 @@ void BacktestEngine::feed_security_eval_state(
         }
 
         Bar projected_bar = projection.bar;
+        // A projected bucket that reached its boundary is the exchange's
+        // bar wherever a native feed serves this timeframe.
+        if (projection.is_complete) {
+            substitute_native_security_bar(state, projected_bar);
+        }
         if (state.heikinashi) {
             apply_ha(projected_bar, projection.is_complete);
         }
@@ -568,6 +573,11 @@ void BacktestEngine::feed_security_eval_state(
     state.feed_count++;
     state.current_sub_bar_count = ab.sub_bar_count;
     if (ab.is_complete) {
+        // The aggregator decided WHEN the bucket completes; a native feed for
+        // this timeframe decides WHAT it closed at (the settlement / official
+        // print), before any Heikin-Ashi derivation. Partial (lookahead_on)
+        // peeks keep the running aggregate.
+        substitute_native_security_bar(state, ab.bar);
         if (state.heikinashi) apply_ha(ab.bar, /*commit=*/true);
         state.current_bar = ab.bar;
         state.eval_complete_count++;

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -193,18 +193,31 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
     // half in apply_filled_order_to_state costs the same quantity at
     // max(signal price, slipped fill) against the placement snapshot.
     //
-    // Scope: explicit-qty entries and DEFAULT FIXED / CASH sizing. Default
-    // percent_of_equity entries never reach it: their quantity is frozen at
+    // Scope: explicit-qty entries, DEFAULT FIXED / CASH sizing, and DEFAULT
+    // percent_of_equity sizing ABOVE 100% (round 6, pin-pct-afford: NYSE:F 15
+    // 2025-04-01..07-01, percent_of_equity 200 on 10,000 at margin 100 ->
+    // TV filled 0 of the every-50th-bar entries, exactly like strategy.cash
+    // 20,000 on the same account — pin-cash-afford-m100 0 entries, -m50
+    // 1,982 shares filled). A percent above 100/margin% sizes a notional the
+    // account cannot carry, and the broker declines it on the same rule as
+    // any other over-notional market entry. Default percent_of_equity
+    // entries at or below 100% never reach it: their quantity is frozen at
     // this bar's close further below (frozen_default_market_qty) and their
     // admission is the separately pinned KI-54 / gap-reject / gross-admission
-    // family in apply_filled_order_to_state. Priced (limit/stop) entries carry
+    // family in apply_filled_order_to_state, whose floor invariant
+    // (qty * sizing_price <= sizing_equity) makes this placement check a
+    // structural no-op there anyway. The two scopes partition on the same
+    // default_qty_value_ <= 100 test the KI-54 gate uses, so exactly 100%
+    // is byte-identical. Priced (limit/stop) entries carry
     // their own price and their own admission (KI-62). margin_pct == 0
     // disables the check, as it does in TradingView.
     const bool affordability_scope =
         std::isnan(limit_price) && std::isnan(stop_price)
         && (!std::isnan(qty)
             || default_qty_type_ == QtyType::FIXED
-            || default_qty_type_ == QtyType::CASH);
+            || default_qty_type_ == QtyType::CASH
+            || (default_qty_type_ == QtyType::PERCENT_OF_EQUITY
+                && default_qty_value_ > 100.0));
     bool affordability_close_only = false;
     double affordability_placement_equity =
         std::numeric_limits<double>::quiet_NaN();
@@ -223,8 +236,10 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
             // The on-tick signal close is the price the rule is stated on
             // (slippage ticks are in neither basis). The quantity is exactly
             // the one the fill kernel dispatches: the lot-floored explicit
-            // contracts, the FIXED default, or the CASH default frozen at its
-            // slipped sizing basis (frozen_default_market_qty).
+            // contracts, the FIXED default, or the CASH / >100%
+            // percent_of_equity default frozen at its slipped sizing basis
+            // (frozen_default_market_qty — the same call that fills
+            // order.frozen_default_qty below).
             const double signal_price = round_to_mintick(current_bar_.close);
             const double own_qty = std::isnan(qty)
                 ? frozen_default_market_qty(/*is_buy=*/is_long)

--- a/src/engine_stream.cpp
+++ b/src/engine_stream.cpp
@@ -35,6 +35,10 @@ bool BacktestEngine::stream_begin(const Bar* warmup_bars, int n_warmup,
                 "auxiliary request.security feed supports historical native-chart runs only");
         }
 #endif
+        if (native_security_feed_enabled()) {
+            throw std::runtime_error(
+                "native request.security feed supports historical runs only");
+        }
         if (stream_phase_ == StreamPhase::REALTIME) {
             throw std::runtime_error("stream is already realtime");
         }

--- a/src/ta_extremes_volume.cpp
+++ b/src/ta_extremes_volume.cpp
@@ -26,14 +26,18 @@ namespace ta {
 //
 // TradingView's rule (see <pineforge/ta.hpp> bar_context()): a window call site
 // owns K = length + 1 slots addressed by bar_index % K; a call on bar b writes
-// slot[b % K] = src and reads the extremum over the WRITTEN slots (b - k) % K,
-// k in [0, length). Every-bar callers get the positional window (findings
-// 331/332 oracle, KI-55 family): an na input advances the window as a gap, the
-// extremum is taken over the non-na members, na while the window has not
-// formed or has no non-na member. Conditional callers (inside an ``if`` that
-// does not run every bar) keep stale values in the slots they did not rewrite,
-// skip never-written slots, and are na iff bar_index < length - 1 — pinned
-// 2026-09-03 on NYSE:F 1D (cadence-7 39/39, cadence-9 30/30 entry sizes).
+// slot[b % K] = src and reads the extremum over the slots (b - k) % K, k in
+// [0, length). Every-bar callers get the positional window; an na input is
+// written and POISONS the ring: the answer is the extremum over the members
+// newer than the newest na slot (na on the na bar itself), and na while the
+// window has not formed — pinned 2026-09-04 on NYSE:F 1D (every-bar
+// ta.lowest / ta.highest over `bar_index % 4 == 0 ? na : low`, 20/20: equal
+// on the bar after each gap, a single live member). Conditional callers
+// (inside an ``if`` that does not run every bar) keep stale values in the
+// slots they did not rewrite, read never-written slots as 0, and are na iff
+// bar_index < length - 1 — pinned 2026-09-03 on NYSE:F 1D (cadence-7 39/39,
+// cadence-9 30/30 entry sizes) and 2026-09-04 on BTCUSDT / XAUUSD 1D
+// (cadence 13, every source kind 13/13).
 // The slots are read through a cached extremum with an implied bar: a src
 // that strictly beats the cache takes it without reading the slots (aged or
 // not); otherwise an aged-out cache (by bars, not calls) rescans the slots
@@ -73,11 +77,10 @@ inline std::size_t ring_slot(long long bar, long long K) {
 
 }  // namespace
 
-ExtremeRing::ExtremeRing(int length, bool na_src_answers_na)
+ExtremeRing::ExtremeRing(int length)
     : length_(length),
       values_(length > 0 ? static_cast<std::size_t>(length) + 1 : 0, na<double>()),
-      written_(length > 0 ? static_cast<std::size_t>(length) + 1 : 0, 0),
-      na_src_answers_na_(na_src_answers_na) {}
+      written_(length > 0 ? static_cast<std::size_t>(length) + 1 : 0, 0) {}
 
 ExtremeRing::Result ExtremeRing::update(double src, bool advance, bool want_max) {
     Result out{na<double>(), 0};
@@ -122,10 +125,7 @@ ExtremeRing::Result ExtremeRing::update(double src, bool advance, bool want_max)
     const auto rescan = [&]() {
         // Oldest slot first with a strict comparison: ties resolve to the
         // oldest member, exactly as the deque scan did (only the *Bars
-        // offsets can tell). Never-written slots are skipped, not zero: the
-        // campaign grades against UI-scraped tapes whose chart carried
-        // pre-range writes (TradingView's deep-backtest export reads them
-        // as 0 -- a documented, deliberate deviation).
+        // offsets can tell).
         double best = na<double>();
         int best_k = 0;
         for (int k = length_ - 1; k >= 0; --k) {
@@ -134,13 +134,31 @@ ExtremeRing::Result ExtremeRing::update(double src, bool advance, bool want_max)
             // 1D (`if bar_index % 13 == 5: v = ta.lowest(low, 10)`: every call
             // answers 0 while the window holds never-written slots; the same
             // cadence's ta.highest(-close, 10) answers 0 too, ta.highest(high,
-            // 10) is unaffected). Every scraped tape in the population is a
-            // deep-backtest export that starts cold at the range start, so
-            // this is the rule the campaign grades against (the round-5
-            // "skip" reading was wrong: shiroi-qqe's stops on five 1D lanes
-            // are TV's SL = 0 from exactly these reads).
+            // 10) is unaffected) and re-pinned on OANDA:XAUUSD 1D for every
+            // source kind (low, close - 2000, sma(close, 5), low[1], hl2, the
+            // sign-mixed sma(close, 5) - close: 13/13 each). Every scraped
+            // tape in the population is a deep-backtest export that starts
+            // cold at the range start, so this is the rule the campaign
+            // grades against (the round-5 "skip" reading was wrong:
+            // shiroi-qqe's stops on five 1D lanes are TV's SL = 0 from
+            // exactly these reads).
             const double v = written_[i] ? values_[i] : 0.0;
-            if (is_na(v)) continue;              // written gap: skipped
+            if (is_na(v)) {
+                // A slot WRITTEN with na poisons the running extremum; the
+                // next (newer) slot restarts it -- so the answer is the
+                // extremum over the slots newer than the newest na slot in
+                // the window, never-written 0s among them included, and na
+                // when the newest slot is itself na (pinned 2026-09-04 on
+                // OANDA:XAUUSD 1D: `ta.lowest(sma(close, 14), 10)` at cadence
+                // 13 answers 0 on bars 31..70 -- never-written slots newer
+                // than bar 5's na -- 3357.6 = src on bar 83 when the na slot
+                // sits at k = 1, and 2998 on bars 109..148, the stale bar-18
+                // write once it is newer than the na slot; leading-na sites
+                // 7 x 13/13, the market-logic osc replica 32/32).
+                best = na<double>();
+                best_k = k;
+                continue;
+            }
             if (is_na(best) || (want_max ? v > best : v < best)) {
                 best = v;
                 best_k = k;
@@ -149,27 +167,30 @@ ExtremeRing::Result ExtremeRing::update(double src, bool advance, bool want_max)
         cval_ = best;
         cbar_ = bar - best_k;    // the implied bar of an aliased slot
     };
-    if (is_na(src) && cached_ && na_src_answers_na_) {
-        // An na source answers na and leaves the cache alone (pinned
-        // 2026-09-04 on OANDA:XAUUSD 15: a `ta.lowest(na, 10)` call between
-        // two valid calls answers na and the next valid call continues from
-        // the previous cache); the slot keeps its written na, which later
-        // rescans skip.
-        if (bar - origin < static_cast<long long>(length_) - 1) return out;
-        return out;
-    }
-    if (!cached_) {
+    if (!cached_ || is_na(src)) {
+        // The first call caches (src, b). An na src does the same on every
+        // call: the na write POISONS the cache -- (na, b) -- so the call
+        // answers na and the next valid call restarts from its own src
+        // below, whatever the cache held and however young it was (pinned
+        // 2026-09-04 on NYSE:F 1D, every-bar `x = bar_index % 4 == 0 ? na :
+        // low`: ta.lowest(x, 5) == ta.highest(x, 5) on the bar after each na
+        // bar, 20/20 -- bar 9 answers 9.20, its own low, where the untouched
+        // 3-bar-old cache would have said 8.44; and on OANDA:XAUUSD 15 the
+        // inserted `ta.lowest(na, 10)` calls answer na, 34/34).
         cached_ = true;
         cval_ = src;
         cbar_ = bar;
-    } else if (!is_na(src) && (is_na(cval_) || (want_max ? src > cval_ : src < cval_))) {
+    } else if (is_na(cval_) || (want_max ? src > cval_ : src < cval_)) {
         // A strictly new extremum takes the cache without reading the slots,
-        // aged-out cache or not (ETH bar 4990). Ties never displace it.
+        // aged-out cache or not (ETH bar 4990). Ties never displace it. A
+        // poisoned (na) cache is taken by any valid src -- the restart: bar
+        // 18 of the sma(close, 14) site answers 2998, its own src, although
+        // the never-written slot one behind it would read 0 in a rescan.
         cval_ = src;
         cbar_ = bar;
     } else if (bar - cbar_ >= static_cast<long long>(length_)) {
         // The cached extremum has aged out of the window (by bars, not
-        // calls): rescan the slots, aliasing included.
+        // calls): rescan the slots, aliasing and poison included.
         rescan();
     }
     // else: the cache is younger than `length` bars and src did not beat it.
@@ -184,8 +205,7 @@ ExtremeRing::Result ExtremeRing::update(double src, bool advance, bool want_max)
 
 // --- Highest ---
 
-Highest::Highest(int length, bool na_src_answers_na)
-    : ring_(length, na_src_answers_na) {}
+Highest::Highest(int length) : ring_(length) {}
 
 double Highest::compute(double src) {
     return ring_.update(src, /*advance=*/true, /*want_max=*/true).value;
@@ -197,8 +217,7 @@ double Highest::recompute(double src) {
 
 // --- Lowest ---
 
-Lowest::Lowest(int length, bool na_src_answers_na)
-    : ring_(length, na_src_answers_na) {}
+Lowest::Lowest(int length) : ring_(length) {}
 
 double Lowest::compute(double src) {
     return ring_.update(src, /*advance=*/true, /*want_max=*/false).value;
@@ -395,9 +414,12 @@ double Median::compute(double src) {
 // --- HighestBars ---
 // Same ring as Highest; the result is the slot distance k of the extremum
 // (0 = the current bar, negative offsets as TV reports them). An na input is
-// recorded as a positional gap and answers na on that bar.
+// written (it poisons the ring) and answers na on that bar; afterwards the
+// offset is the bars-since of the extremum among the non-poisoned members --
+// 0 on the restart bar, the rescan's k (a never-written 0 slot included)
+// once the cache has aged.
 
-HighestBars::HighestBars(int length, bool na_src_answers_na) : ring_(length, na_src_answers_na) {}
+HighestBars::HighestBars(int length) : ring_(length) {}
 
 double HighestBars::compute(double src) {
     const ExtremeRing::Result r = ring_.update(src, /*advance=*/true, /*want_max=*/true);
@@ -413,7 +435,7 @@ double HighestBars::recompute(double src) {
 
 // --- LowestBars ---
 
-LowestBars::LowestBars(int length, bool na_src_answers_na) : ring_(length, na_src_answers_na) {}
+LowestBars::LowestBars(int length) : ring_(length) {}
 
 double LowestBars::compute(double src) {
     const ExtremeRing::Result r = ring_.update(src, /*advance=*/true, /*want_max=*/false);

--- a/src/ta_extremes_volume.cpp
+++ b/src/ta_extremes_volume.cpp
@@ -129,8 +129,16 @@ ExtremeRing::Result ExtremeRing::update(double src, bool advance, bool want_max)
         int best_k = 0;
         for (int k = length_ - 1; k >= 0; --k) {
             const std::size_t i = ring_slot(bar - k, K);
-            if (!written_[i]) continue;          // never written: skipped, not na
-            const double v = values_[i];
+            // Never written reads as 0 -- pinned 2026-09-04 on BINANCE:BTCUSDT
+            // 1D (`if bar_index % 13 == 5: v = ta.lowest(low, 10)`: every call
+            // answers 0 while the window holds never-written slots; the same
+            // cadence's ta.highest(-close, 10) answers 0 too, ta.highest(high,
+            // 10) is unaffected). Every scraped tape in the population is a
+            // deep-backtest export that starts cold at the range start, so
+            // this is the rule the campaign grades against (the round-5
+            // "skip" reading was wrong: shiroi-qqe's stops on five 1D lanes
+            // are TV's SL = 0 from exactly these reads).
+            const double v = written_[i] ? values_[i] : 0.0;
             if (is_na(v)) continue;              // written gap: skipped
             if (is_na(best) || (want_max ? v > best : v < best)) {
                 best = v;

--- a/src/ta_extremes_volume.cpp
+++ b/src/ta_extremes_volume.cpp
@@ -73,10 +73,11 @@ inline std::size_t ring_slot(long long bar, long long K) {
 
 }  // namespace
 
-ExtremeRing::ExtremeRing(int length)
+ExtremeRing::ExtremeRing(int length, bool na_src_answers_na)
     : length_(length),
       values_(length > 0 ? static_cast<std::size_t>(length) + 1 : 0, na<double>()),
-      written_(length > 0 ? static_cast<std::size_t>(length) + 1 : 0, 0) {}
+      written_(length > 0 ? static_cast<std::size_t>(length) + 1 : 0, 0),
+      na_src_answers_na_(na_src_answers_na) {}
 
 ExtremeRing::Result ExtremeRing::update(double src, bool advance, bool want_max) {
     Result out{na<double>(), 0};
@@ -148,6 +149,15 @@ ExtremeRing::Result ExtremeRing::update(double src, bool advance, bool want_max)
         cval_ = best;
         cbar_ = bar - best_k;    // the implied bar of an aliased slot
     };
+    if (is_na(src) && cached_ && na_src_answers_na_) {
+        // An na source answers na and leaves the cache alone (pinned
+        // 2026-09-04 on OANDA:XAUUSD 15: a `ta.lowest(na, 10)` call between
+        // two valid calls answers na and the next valid call continues from
+        // the previous cache); the slot keeps its written na, which later
+        // rescans skip.
+        if (bar - origin < static_cast<long long>(length_) - 1) return out;
+        return out;
+    }
     if (!cached_) {
         cached_ = true;
         cval_ = src;
@@ -174,8 +184,8 @@ ExtremeRing::Result ExtremeRing::update(double src, bool advance, bool want_max)
 
 // --- Highest ---
 
-Highest::Highest(int length)
-    : ring_(length) {}
+Highest::Highest(int length, bool na_src_answers_na)
+    : ring_(length, na_src_answers_na) {}
 
 double Highest::compute(double src) {
     return ring_.update(src, /*advance=*/true, /*want_max=*/true).value;
@@ -187,8 +197,8 @@ double Highest::recompute(double src) {
 
 // --- Lowest ---
 
-Lowest::Lowest(int length)
-    : ring_(length) {}
+Lowest::Lowest(int length, bool na_src_answers_na)
+    : ring_(length, na_src_answers_na) {}
 
 double Lowest::compute(double src) {
     return ring_.update(src, /*advance=*/true, /*want_max=*/false).value;
@@ -387,7 +397,7 @@ double Median::compute(double src) {
 // (0 = the current bar, negative offsets as TV reports them). An na input is
 // recorded as a positional gap and answers na on that bar.
 
-HighestBars::HighestBars(int length) : ring_(length) {}
+HighestBars::HighestBars(int length, bool na_src_answers_na) : ring_(length, na_src_answers_na) {}
 
 double HighestBars::compute(double src) {
     const ExtremeRing::Result r = ring_.update(src, /*advance=*/true, /*want_max=*/true);
@@ -403,7 +413,7 @@ double HighestBars::recompute(double src) {
 
 // --- LowestBars ---
 
-LowestBars::LowestBars(int length) : ring_(length) {}
+LowestBars::LowestBars(int length, bool na_src_answers_na) : ring_(length, na_src_answers_na) {}
 
 double LowestBars::compute(double src) {
     const ExtremeRing::Result r = ring_.update(src, /*advance=*/true, /*want_max=*/false);

--- a/src/ta_oscillators.cpp
+++ b/src/ta_oscillators.cpp
@@ -131,7 +131,7 @@ bool Crossunder::compute(double a, double b) {
 // --- Stoch ---
 
 Stoch::Stoch(int length)
-    : highest(length), lowest(length) {}
+    : highest(length, /*na_src_answers_na=*/false), lowest(length, /*na_src_answers_na=*/false) {}
 
 double Stoch::compute(double src, double high, double low) {
     double hi = highest.compute(high);
@@ -541,7 +541,7 @@ double TSI::compute(double src) {
 // WPR (Williams %R)
 // ============================================================================
 
-WPR::WPR(int length) : highest_(length), lowest_(length) {}
+WPR::WPR(int length) : highest_(length, false), lowest_(length, false) {}
 
 double WPR::compute(double close, double high, double low) {
     double hh = highest_.compute(high);

--- a/src/ta_oscillators.cpp
+++ b/src/ta_oscillators.cpp
@@ -131,7 +131,7 @@ bool Crossunder::compute(double a, double b) {
 // --- Stoch ---
 
 Stoch::Stoch(int length)
-    : highest(length, /*na_src_answers_na=*/false), lowest(length, /*na_src_answers_na=*/false) {}
+    : highest(length), lowest(length) {}
 
 double Stoch::compute(double src, double high, double low) {
     double hi = highest.compute(high);
@@ -541,7 +541,7 @@ double TSI::compute(double src) {
 // WPR (Williams %R)
 // ============================================================================
 
-WPR::WPR(int length) : highest_(length, false), lowest_(length, false) {}
+WPR::WPR(int length) : highest_(length), lowest_(length) {}
 
 double WPR::compute(double close, double high, double low) {
     double hh = highest_.compute(high);

--- a/src/ta_volatility_trend.cpp
+++ b/src/ta_volatility_trend.cpp
@@ -87,9 +87,30 @@ double ATR::compute(double high, double low, double close) {
 
 StdDev::StdDev(int length, bool biased) : length_(length), biased_(biased) {}
 
+double StdDev::held_stdev() const {
+    double sum = 0.0;
+    for (double v : buffer_) sum += v;
+    const double mean = sum / length_;
+    double sq_sum = 0.0;
+    for (double v : buffer_) {
+        const double diff = v - mean;
+        sq_sum += diff * diff;
+    }
+    const int denom = biased_ ? length_ : (length_ - 1);
+    return denom > 0 ? std::sqrt(sq_sum / denom) : na<double>();
+}
+
 double StdDev::compute(double src) {
     if (is_na(src)) {
-        return na<double>();
+        // Pine ta.stdev, like ta.sma (KI-66): an na input never enters the
+        // compact last-N-valid window; once `length` valid values have been
+        // seen the window's population stdev is HELD and re-emitted on the
+        // na-input bar; before seeding it is still na. State untouched.
+        // Pinned 2026-09-04 on OANDA:XAUUSD 15 (ta.stdev(z2, 20) with z2 na
+        // on every 5th bar: 310/310 with hold + population, 248/310 without
+        // the hold; ta.sma(z2, 20) 310/310 likewise).
+        if ((int)buffer_.size() < length_) return na<double>();
+        return held_stdev();
     }
 
     buffer_.push_back(src);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,6 +99,7 @@ set(TEST_SOURCES
     test_explicit_qty_fill_admission
     test_market_entry_affordability
     test_percent_equity_affordability
+    test_stop_tick_rounding
     test_zero_lot_entry_decline
     test_pooc_coof_reversal_gross_admission
     test_limit_fill_slippage

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set(TEST_SOURCES
     test_integration
     test_request_security
     test_aux_security_feed
+    test_native_security_feed
     test_historical_security_lookahead_projection
     test_pooc_global_full_exit
     test_security_range_start_na_warmup

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,6 +97,7 @@ set(TEST_SOURCES
     test_frozen_flat_gap_reject
     test_explicit_qty_fill_admission
     test_market_entry_affordability
+    test_percent_equity_affordability
     test_zero_lot_entry_decline
     test_pooc_coof_reversal_gross_admission
     test_limit_fill_slippage

--- a/tests/test_native_security_feed.cpp
+++ b/tests/test_native_security_feed.cpp
@@ -1,0 +1,326 @@
+// Native higher-timeframe request.security feeds (strategy_set_native_security_feed).
+//
+// TradingView's "D" request on an intraday chart of CME futures and US/Indian
+// equities returns the exchange's own daily bar (settlement / official close),
+// which no aggregation of the intraday feed reproduces. These pin that a
+// completed daily bucket takes the native bar's OHLCV while the aggregator
+// keeps deciding when it completes, that other timeframes, the chart and the
+// broker are untouched, that a missing native bar keeps the aggregate, and
+// that the split (1m auxiliary) feed path substitutes the same way.
+
+#include <pineforge/pineforge.h>
+#include <pineforge/engine.hpp>
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using namespace pineforge;
+
+#ifndef PINEFORGE_HAS_NATIVE_SECURITY_FEED_V1
+#error "native security feed test requires the V1 feature probe"
+#endif
+
+namespace {
+
+constexpr int64_t kMinute = 60000;
+constexpr int64_t kQuarter = 15 * kMinute;
+constexpr int64_t kDay = 86400000;
+
+class DailyProbe final : public BacktestEngine {
+public:
+    std::vector<double> chart_closes;
+    std::vector<double> daily_closes;        // sec 0: "D", completed buckets
+    std::vector<double> daily_opens;
+    std::vector<double> daily_volumes;
+    std::vector<double> hourly_closes;       // sec 1: "60", completed buckets
+    std::vector<double> daily_at_chart_close;
+    double latest_daily = na<double>();
+
+    void configure_security_evaluators() override {
+        security_eval_states_.clear();
+        register_security_eval(0, "D", input_tf_, false, false);
+        register_security_eval(1, "60", input_tf_, false, false);
+    }
+
+    void evaluate_security(int sec_id, const Bar& bar,
+                           bool is_complete) override {
+        if (!is_complete) return;
+        if (sec_id == 0) {
+            latest_daily = bar.close;
+            daily_closes.push_back(bar.close);
+            daily_opens.push_back(bar.open);
+            daily_volumes.push_back(bar.volume);
+        } else if (sec_id == 1) {
+            hourly_closes.push_back(bar.close);
+        }
+    }
+
+    void on_bar(const Bar& bar) override {
+        chart_closes.push_back(bar.close);
+        daily_at_chart_close.push_back(latest_daily);
+        if (bar_index_ == 0) strategy_entry("L", true);
+        if (bar_index_ == 1) strategy_close_all();
+    }
+};
+
+bool near(double a, double b) {
+    return std::abs(a - b) < 1e-9;
+}
+
+// One NYSE-style session (0930-1600 America/New_York) of 15m bars: 26 bars
+// from 09:30 to 15:45, closes 100*(day+1) + k so the last 15m close of day d
+// is 100*(d+1) + 25.
+std::vector<Bar> ny_session(int day, int64_t open_ms) {
+    std::vector<Bar> bars;
+    for (int k = 0; k < 26; ++k) {
+        const double base = 100.0 * (day + 1) + k;
+        bars.push_back({base - 0.5, base + 1.0, base - 1.0, base, 10.0,
+                        open_ms + k * kQuarter});
+    }
+    return bars;
+}
+
+constexpr int64_t kNyDay1 = 1704205800000;  // 2024-01-02 09:30 America/New_York
+constexpr int64_t kNyDay2 = kNyDay1 + kDay;
+
+void test_completed_daily_bucket_carries_the_native_bar() {
+    std::vector<Bar> chart = ny_session(0, kNyDay1);
+    const std::vector<Bar> day2 = ny_session(1, kNyDay2);
+    chart.insert(chart.end(), day2.begin(), day2.end());
+    // TradingView's own daily bars: the official close differs from the last
+    // 15m close (125 / 225), and so do open/volume.
+    const Bar daily[] = {
+        {99.0, 130.0, 90.0, 111.5, 5000.0, kNyDay1},
+        {199.0, 230.0, 190.0, 222.5, 6000.0, kNyDay2},
+    };
+
+    DailyProbe probe;
+    strategy_set_syminfo_timezone(
+        static_cast<pf_strategy_t>(&probe), "America/New_York");
+    strategy_set_syminfo_session(
+        static_cast<pf_strategy_t>(&probe), "0930-1600");
+    assert(strategy_set_native_security_feed(
+        static_cast<pf_strategy_t>(&probe), "D",
+        reinterpret_cast<const pf_bar_t*>(daily), 2) == 0);
+    assert(probe.native_security_feed_enabled());
+
+    probe.run(chart.data(), static_cast<int>(chart.size()), "15", "15",
+              false, 4, MagnifierDistribution::ENDPOINTS);
+    assert(probe.last_error().empty());
+
+    // The daily bucket completes on the session's last 15m bar (the
+    // aggregator's timing) and carries the native OHLCV, not the aggregate.
+    assert((probe.daily_closes == std::vector<double>{111.5, 222.5}));
+    assert((probe.daily_opens == std::vector<double>{99.0, 199.0}));
+    assert((probe.daily_volumes == std::vector<double>{5000.0, 6000.0}));
+    assert(probe.native_security_substitutions() == 2);
+    assert(probe.native_security_misses() == 0);
+    // Exposed at the day's last chart bar, na before the first completion.
+    assert(probe.daily_at_chart_close.size() == 52);
+    assert(std::isnan(probe.daily_at_chart_close[24]));
+    assert(near(probe.daily_at_chart_close[25], 111.5));
+    assert(near(probe.daily_at_chart_close[26], 111.5));
+    assert(near(probe.daily_at_chart_close[51], 222.5));
+    // The intraday "60" request is aggregated exactly as before: 09:30-10:29
+    // closes on the 10:15 bar (k = 3).
+    assert(!probe.hourly_closes.empty());
+    assert(near(probe.hourly_closes[0], 103.0));
+    // Chart and broker never see the native feed.
+    assert(probe.chart_closes.size() == 52);
+    assert(near(probe.chart_closes[25], 125.0));
+    assert(probe.trade_count() == 1);
+    assert(near(probe.get_trade(0).entry_price, chart[1].open));
+    assert(near(probe.get_trade(0).exit_price, chart[2].open));
+}
+
+
+void test_a_bucket_without_a_native_bar_keeps_its_aggregate() {
+    std::vector<Bar> chart = ny_session(0, kNyDay1);
+    const std::vector<Bar> day2 = ny_session(1, kNyDay2);
+    chart.insert(chart.end(), day2.begin(), day2.end());
+    const Bar daily[] = {
+        {99.0, 130.0, 90.0, 111.5, 5000.0, kNyDay1},
+    };
+
+    DailyProbe probe;
+    strategy_set_syminfo_timezone(
+        static_cast<pf_strategy_t>(&probe), "America/New_York");
+    strategy_set_syminfo_session(
+        static_cast<pf_strategy_t>(&probe), "0930-1600");
+    assert(strategy_set_native_security_feed(
+        static_cast<pf_strategy_t>(&probe), "1D",
+        reinterpret_cast<const pf_bar_t*>(daily), 1) == 0);
+    probe.run(chart.data(), static_cast<int>(chart.size()), "15", "15",
+              false, 4, MagnifierDistribution::ENDPOINTS);
+    assert(probe.last_error().empty());
+    assert((probe.daily_closes == std::vector<double>{111.5, 225.0}));
+    assert(probe.native_security_substitutions() == 1);
+    assert(probe.native_security_misses() == 1);
+}
+
+
+void test_without_a_native_feed_the_run_is_the_aggregate() {
+    std::vector<Bar> chart = ny_session(0, kNyDay1);
+    const std::vector<Bar> day2 = ny_session(1, kNyDay2);
+    chart.insert(chart.end(), day2.begin(), day2.end());
+    const Bar daily[] = {
+        {99.0, 130.0, 90.0, 111.5, 5000.0, kNyDay1},
+        {199.0, 230.0, 190.0, 222.5, 6000.0, kNyDay2},
+    };
+    DailyProbe probe;
+    strategy_set_syminfo_timezone(
+        static_cast<pf_strategy_t>(&probe), "America/New_York");
+    strategy_set_syminfo_session(
+        static_cast<pf_strategy_t>(&probe), "0930-1600");
+    assert(strategy_set_native_security_feed(
+        static_cast<pf_strategy_t>(&probe), "D",
+        reinterpret_cast<const pf_bar_t*>(daily), 2) == 0);
+    // n == 0 clears exactly that timeframe's feed.
+    assert(strategy_set_native_security_feed(
+        static_cast<pf_strategy_t>(&probe), "D", nullptr, 0) == 0);
+    assert(!probe.native_security_feed_enabled());
+    probe.run(chart.data(), static_cast<int>(chart.size()), "15", "15",
+              false, 4, MagnifierDistribution::ENDPOINTS);
+    assert(probe.last_error().empty());
+    assert((probe.daily_closes == std::vector<double>{125.0, 225.0}));
+    assert(probe.native_security_substitutions() == 0);
+    assert(probe.native_security_misses() == 0);
+}
+
+
+void test_feed_validation_fails_closed() {
+    const Bar unordered[] = {
+        {1.0, 1.0, 1.0, 1.0, 1.0, kNyDay2},
+        {1.0, 1.0, 1.0, 1.0, 1.0, kNyDay1},
+    };
+    DailyProbe probe;
+    assert(strategy_set_native_security_feed(
+        static_cast<pf_strategy_t>(&probe), "D",
+        reinterpret_cast<const pf_bar_t*>(unordered), 2) == -1);
+    assert(!probe.last_error().empty());
+    assert(strategy_set_native_security_feed(
+        static_cast<pf_strategy_t>(&probe), "",
+        reinterpret_cast<const pf_bar_t*>(unordered), 1) == -1);
+    assert(strategy_set_native_security_feed(
+        static_cast<pf_strategy_t>(&probe), "bogus",
+        reinterpret_cast<const pf_bar_t*>(unordered), 1) == -1);
+    assert(strategy_set_native_security_feed(
+        nullptr, "D", reinterpret_cast<const pf_bar_t*>(unordered), 1) == -1);
+    assert(!probe.native_security_feed_enabled());
+
+    // Historical runs only: a stream refuses to start over a native feed.
+    const Bar daily[] = {{1.0, 1.0, 1.0, 1.0, 1.0, kNyDay1}};
+    assert(strategy_set_native_security_feed(
+        static_cast<pf_strategy_t>(&probe), "D",
+        reinterpret_cast<const pf_bar_t*>(daily), 1) == 0);
+    std::vector<Bar> warmup = ny_session(0, kNyDay1);
+    assert(!probe.stream_begin(warmup.data(), static_cast<int>(warmup.size()),
+                               "15", "15"));
+    assert(probe.last_error().find("native request.security feed")
+           != std::string::npos);
+}
+
+
+// The campaign's finer-tf retry: native 15m chart + 1m auxiliary feed. The
+// "D" evaluator is then fed from the auxiliary slice, and its completed
+// bucket must take the native daily bar exactly as on the plain path.
+void test_split_aux_feed_path_substitutes_the_same_native_bar() {
+    std::vector<Bar> chart = ny_session(0, kNyDay1);
+    const std::vector<Bar> day2 = ny_session(1, kNyDay2);
+    chart.insert(chart.end(), day2.begin(), day2.end());
+    std::vector<Bar> aux;
+    for (const Bar& bar : chart) {
+        for (int m = 0; m < 15; ++m) {
+            const double v = bar.close - 1.0 + m / 15.0;
+            aux.push_back({v, v, v, v, 1.0, bar.timestamp + m * kMinute});
+        }
+    }
+    const Bar daily[] = {
+        {99.0, 130.0, 90.0, 111.5, 5000.0, kNyDay1},
+        {199.0, 230.0, 190.0, 222.5, 6000.0, kNyDay2},
+    };
+
+    DailyProbe probe;
+    strategy_set_syminfo_timezone(
+        static_cast<pf_strategy_t>(&probe), "America/New_York");
+    strategy_set_syminfo_session(
+        static_cast<pf_strategy_t>(&probe), "0930-1600");
+    assert(strategy_set_aux_security_feed(
+        static_cast<pf_strategy_t>(&probe),
+        reinterpret_cast<const pf_bar_t*>(aux.data()),
+        static_cast<int>(aux.size()), "1") == 0);
+    assert(strategy_set_native_security_feed(
+        static_cast<pf_strategy_t>(&probe), "D",
+        reinterpret_cast<const pf_bar_t*>(daily), 2) == 0);
+    probe.run(chart.data(), static_cast<int>(chart.size()), "15", "15",
+              false, 4, MagnifierDistribution::ENDPOINTS);
+    assert(probe.last_error().empty());
+    assert((probe.daily_closes == std::vector<double>{111.5, 222.5}));
+    assert(probe.native_security_substitutions() == 2);
+    assert(probe.native_security_misses() == 0);
+    assert(near(probe.chart_closes[25], 125.0));
+}
+
+
+// The CME shape: a 1700-1600 America/Chicago session whose daily bar is
+// stamped at the 17:00 open and closes at 16:00 the next calendar day, with
+// TradingView's close the 15:00 settlement rather than the 15:45 bar's close.
+void test_overnight_cme_session_labels_by_session_day() {
+    constexpr int64_t open1 = 1704236400000;  // 2024-01-02 17:00 America/Chicago
+    constexpr int64_t open2 = open1 + kDay;
+    constexpr int64_t open3 = open2 + kDay;
+    std::vector<Bar> chart;
+    for (int day = 0; day < 2; ++day) {
+        for (int k = 0; k < 92; ++k) {  // 17:00 .. 15:45 next day
+            const double base = 5000.0 + 100.0 * day + k;
+            chart.push_back({base - 0.25, base + 0.5, base - 0.5, base, 10.0,
+                             (day == 0 ? open1 : open2) + k * kQuarter});
+        }
+    }
+    // The third session's first bar: an overnight session's daily bucket is
+    // finalized by the next session's first chart bar.
+    chart.push_back({5200.0, 5200.5, 5199.5, 5200.0, 10.0, open3});
+    const Bar daily[] = {
+        {4999.0, 5100.0, 4990.0, 5077.25, 1.0, open1},
+        {5099.0, 5200.0, 5090.0, 5177.25, 1.0, open2},
+        {5199.0, 5300.0, 5190.0, 5277.25, 1.0, open3},
+    };
+    DailyProbe probe;
+    strategy_set_syminfo_timezone(
+        static_cast<pf_strategy_t>(&probe), "America/Chicago");
+    strategy_set_syminfo_session(
+        static_cast<pf_strategy_t>(&probe), "1700-1600");
+    assert(strategy_set_native_security_feed(
+        static_cast<pf_strategy_t>(&probe), "D",
+        reinterpret_cast<const pf_bar_t*>(daily), 3) == 0);
+    probe.run(chart.data(), static_cast<int>(chart.size()), "15", "15",
+              false, 4, MagnifierDistribution::ENDPOINTS);
+    assert(probe.last_error().empty());
+    // Both completed session-days carry the settlement print of the native
+    // bar stamped at their 17:00 open, matched by session-day label.
+    assert((probe.daily_closes == std::vector<double>{5077.25, 5177.25}));
+    assert(probe.native_security_substitutions() == 2);
+    assert(probe.native_security_misses() == 0);
+    // Completion timing stays the aggregator's: the first session's value is
+    // exposed no earlier than its last chart bar (15:45 CT, index 91) and no
+    // later than the next session's first bar (index 92).
+    assert(probe.daily_at_chart_close.size() == 185);
+    assert(std::isnan(probe.daily_at_chart_close[90]));
+    assert(near(probe.daily_at_chart_close[92], 5077.25));
+    assert(near(probe.daily_at_chart_close[184], 5177.25));
+}
+
+}  // namespace
+
+int main() {
+    test_completed_daily_bucket_carries_the_native_bar();
+    test_a_bucket_without_a_native_bar_keeps_its_aggregate();
+    test_without_a_native_feed_the_run_is_the_aggregate();
+    test_feed_validation_fails_closed();
+    test_split_aux_feed_path_substitutes_the_same_native_bar();
+    test_overnight_cme_session_labels_by_session_day();
+    return 0;
+}

--- a/tests/test_percent_equity_affordability.cpp
+++ b/tests/test_percent_equity_affordability.cpp
@@ -1,0 +1,353 @@
+/*
+ * test_percent_equity_affordability.cpp — round 6: default percent_of_equity
+ * sizing ABOVE 100% takes the unified design-market-entry-affordability gate
+ * (placement half in strategy_entry, fill half in apply_filled_order_to_state)
+ * exactly like default CASH / FIXED sizing:
+ *
+ *   admit iff lot_floored(resulting_position_qty)
+ *               * max(tick(close(S)), tick(fill)) * pv * fx * margin/100
+ *             <= placement_equity + max(1e-9, |placement_equity| * 1e-12)
+ *
+ * checked at placement against mark-to-market equity and again at the fill
+ * against the same snapshot; a declined reversal keeps its CLOSING leg only.
+ *
+ * Pins (`lab tv`, 2026-09-04, NYSE:F 15, 2025-04-01..07-01, capital 10,000,
+ * commission 0, entry every 50th bar while flat, close 5 bars later —
+ * scratchpad/r5/pins/out-pin-{pct-afford,cash-afford-m100,cash-afford-m50}):
+ *   pin-pct-afford       percent_of_equity 200, margin 100 -> 0 entries.
+ *   pin-cash-afford-m100 strategy.cash 20,000,  margin 100 -> 0 entries.
+ *   pin-cash-afford-m50  strategy.cash 20,000,  margin 50  -> entries fill:
+ *                        1,982 shares (20,000 / signal close 10.09, floored)
+ *                        at the 10.08 open.
+ * percent_of_equity 200 on 10,000 sizes the same 20,000 notional as cash
+ * 20,000, so its margin-50 shape mirrors the cash tape (no separate TV export).
+ *
+ * At or below 100% nothing changes: those entries never receive an
+ * affordability snapshot and keep the pinned KI-54 / gap-reject /
+ * gross-admission family (test_frozen_flat_gap_reject,
+ * test_default_flat_market_gross_admission, test_affordability_fx).
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <pineforge/bar.hpp>
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_NEAR(a, b, tol)                                                  \
+    do {                                                                       \
+        double _a = (a), _b = (b);                                             \
+        if (!(std::fabs(_a - _b) <= (tol))) {                                  \
+            std::printf("  FAIL  %s:%d  %s == %.10f, expected %.10f\n",        \
+                        __FILE__, __LINE__, #a, _a, _b);                       \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+static constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+static Bar mk_bar(int64_t ts, double o, double h, double l, double c) {
+    Bar b;
+    b.open = o; b.high = h; b.low = l; b.close = c;
+    b.volume = 1.0; b.timestamp = ts;
+    return b;
+}
+
+static Bar flat_bar(int64_t ts, double p) { return mk_bar(ts, p, p, p, p); }
+
+namespace {
+
+// NYSE:F — pointvalue 1, mintick 0.01, whole shares.
+// Script chars (indexed by bar_index_):
+//   'L' default-sized LONG market entry "L"    'S' default SHORT "S"
+//   'l' explicit LONG "L" qty = entry_qty_     'C' strategy.close("L")
+//   '.' nothing
+class Probe : public BacktestEngine {
+public:
+    Probe(double capital, double pct, double margin, bool enable_mc) {
+        initial_capital_ = capital;
+        syminfo_.pointvalue = 1.0;
+        syminfo_mintick_ = 0.01;
+        qty_step_ = 1.0;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = pct;
+        commission_type_ = CommissionType::PERCENT;
+        commission_value_ = 0.0;
+        margin_long_ = margin;
+        margin_short_ = margin;
+        pyramiding_ = 0;
+        slippage_ = 0;
+        process_orders_on_close_ = false;
+        margin_call_enabled_ = enable_mc;
+    }
+    std::string script;
+    double entry_qty_ = 1.0;
+    // Placement-time observations of the LAST default-sized entry call:
+    // did it survive placement (a PendingOrder exists), and did it carry an
+    // affordability snapshot (the unified gate's scope discriminator)?
+    int default_entries_placed = 0;
+    int default_entries_pending_after_call = 0;
+    int default_entries_with_snapshot = 0;
+
+    void on_bar(const Bar& /*bar*/) override {
+        if (bar_index_ < 0 || bar_index_ >= (int)script.size()) return;
+        switch (script[bar_index_]) {
+            case 'L': default_entry("L", true); break;
+            case 'S': default_entry("S", false); break;
+            case 'l': strategy_entry("L", true, kNaN, kNaN, entry_qty_); break;
+            case 'C': strategy_close("L"); break;
+            default: break;
+        }
+    }
+    using BacktestEngine::position_qty_;
+    using BacktestEngine::position_side_;
+    using BacktestEngine::process_orders_on_close_;
+    double position_size() const { return signed_position_size(); }
+    int trades_with_entry_id(const std::string& id) const {
+        int n = 0;
+        for (const auto& t : trades_) if (t.entry_id == id) ++n;
+        return n;
+    }
+
+private:
+    void default_entry(const std::string& id, bool is_long) {
+        ++default_entries_placed;
+        strategy_entry(id, is_long);
+        for (const auto& o : pending_orders_) {
+            if (o.id != id || o.type != OrderType::MARKET) continue;
+            ++default_entries_pending_after_call;
+            if (std::isfinite(o.affordability_placement_equity)) {
+                ++default_entries_with_snapshot;
+            }
+        }
+    }
+};
+
+// pin-pct-afford: 200% of 10,000 at margin 100 on F @10.09 sizes
+// floor(20,000 / 10.09) = 1,982 shares = 19,998.38 > 10,000 -> every entry is
+// declined AT PLACEMENT (no PendingOrder, no fill, no trade row). With margin
+// calls enabled nothing changes: no position ever opens, so nothing cascades.
+// Pre-fix the engine opened 1,982 shares on a 10,000 account (KI-54 skips
+// pct > 100 and no other gate ran).
+void test_f_200pct_margin100_declined() {
+    std::printf("-- F 200%% at margin 100: 0 entries (pin-pct-afford) --\n");
+    for (bool mc : {false, true}) {
+        Probe eng(10000.0, 200.0, 100.0, mc);
+        eng.script = "L....L....";
+        std::vector<Bar> bars;
+        for (int i = 0; i < 10; ++i) {
+            bars.push_back(mk_bar(1000 * (i + 1), 10.09, 10.12, 10.05, 10.09));
+        }
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::FLAT);
+        CHECK(eng.trade_count() == 0);
+        CHECK(eng.default_entries_placed == 2);
+        CHECK(eng.default_entries_pending_after_call == 0);   // placement decline
+        CHECK(eng.default_entries_with_snapshot == 0);
+    }
+}
+
+// Mirror of pin-cash-afford-m50 with percent sizing: 200% at margin 50 costs
+// 1,982 * 10.09 * 0.5 = 9,999.19 <= 10,000 at placement; the 10.08 open is a
+// favorable gap (max(10.09, 10.08) = 10.09) so the fill half admits, and the
+// 1,982 shares fill at 10.08 exactly as TV's cash tape does.
+void test_f_200pct_margin50_fills() {
+    std::printf("-- F 200%% at margin 50: fills 1,982 @10.08 (cash-m50 mirror) --\n");
+    Probe eng(10000.0, 200.0, 50.0, false);
+    eng.script = "L.C.";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 10.09),                          // L placed
+        mk_bar(2000, 10.08, 10.10, 10.06, 10.09),       // fills @10.08
+        flat_bar(3000, 10.09),                          // close placed
+        flat_bar(4000, 10.09),                          // close fills
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.default_entries_pending_after_call == 1);
+    CHECK(eng.default_entries_with_snapshot == 1);       // in scope: pct > 100
+    CHECK(eng.position_side_ == PositionSide::FLAT);
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() == 1) {
+        CHECK(eng.get_trade(0).is_long);
+        CHECK(eng.get_trade(0).entry_id == "L");
+        CHECK_NEAR(eng.get_trade(0).qty, 1982.0, 1e-9);
+        CHECK_NEAR(eng.get_trade(0).entry_price, 10.08, 1e-9);
+    }
+}
+
+// Exactly 100% is byte-identical: no affordability snapshot is attached (the
+// order stays on the KI-54 / gap-reject family) and the all-in entry fills as
+// before — floor(10,000 / 10.09) = 991 shares at the 10.08 open.
+void test_f_100pct_control_unchanged() {
+    std::printf("-- F 100%% control: no snapshot, fills 991 --\n");
+    Probe eng(10000.0, 100.0, 100.0, false);
+    eng.script = "L...";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 10.09),
+        mk_bar(2000, 10.08, 10.10, 10.06, 10.09),
+        flat_bar(3000, 10.09),
+        flat_bar(4000, 10.09),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.default_entries_pending_after_call == 1);
+    CHECK(eng.default_entries_with_snapshot == 0);       // out of scope
+    CHECK(eng.position_side_ == PositionSide::LONG);
+    CHECK_NEAR(eng.position_size(), 991.0, 1e-9);
+    CHECK(eng.trade_count() == 0);
+}
+
+// 150% at margin 50 is 75% of equity: pct > 100 is not a blanket decline,
+// the rule is the notional. floor(15,000 / 10) = 1,500 shares * 10 * 0.5 =
+// 7,500 <= 10,000 -> fills.
+void test_f_150pct_margin50_fills() {
+    std::printf("-- F 150%% at margin 50: 75%% of equity fills --\n");
+    Probe eng(10000.0, 150.0, 50.0, false);
+    eng.script = "L..";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 10.00), flat_bar(2000, 10.00), flat_bar(3000, 10.00),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::LONG);
+    CHECK_NEAR(eng.position_size(), 1500.0, 1e-9);
+}
+
+// The fill half: 200% at margin 50 on a 10.00 close sizes 2,000 shares
+// (10,000 * 0.5 = 10,000, an exact tie -> admitted at placement). A 10.01
+// open costs 10,010 > 10,000 -> NOT filled (no trade row, position flat);
+// a 9.99 open is favorable and fills 2,000 shares. POOC fills at the tie.
+void test_f_200pct_margin50_gap_up_declined_at_fill() {
+    std::printf("-- F 200%% at margin 50: gap-up fill declined, gap-down fills --\n");
+    {
+        Probe eng(10000.0, 200.0, 50.0, false);
+        eng.script = "L..";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 10.00),
+            mk_bar(2000, 10.01, 10.03, 9.99, 10.00),    // 2,000 * 10.01 * .5 > 10,000
+            flat_bar(3000, 10.00),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.default_entries_pending_after_call == 1);   // placement admitted
+        CHECK(eng.position_side_ == PositionSide::FLAT);
+        CHECK(eng.trade_count() == 0);
+    }
+    {
+        Probe eng(10000.0, 200.0, 50.0, false);
+        eng.script = "L..";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 10.00),
+            mk_bar(2000, 9.99, 10.02, 9.98, 10.00),
+            flat_bar(3000, 10.00),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::LONG);
+        CHECK_NEAR(eng.position_size(), 2000.0, 1e-9);
+    }
+    {
+        Probe eng(10000.0, 200.0, 50.0, false);
+        eng.process_orders_on_close_ = true;
+        eng.script = "L..";
+        std::vector<Bar> bars = {
+            flat_bar(1000, 10.00),
+            mk_bar(2000, 10.01, 10.03, 9.99, 10.00),
+            flat_bar(3000, 10.00),
+        };
+        eng.run(bars.data(), (int)bars.size());
+        CHECK(eng.position_side_ == PositionSide::LONG);
+        CHECK_NEAR(eng.position_size(), 2000.0, 1e-9);
+    }
+}
+
+// Reversal at 200% / margin 100: a 500-share long (explicit, 5,000 <= 10,000)
+// is held; the default short at close 10.20 sizes floor(2 * 10,100 / 10.20)
+// = 1,980 shares = 20,196 > MTM 10,100 -> the ENTRY leg is declined at
+// placement, the order survives close-only, and the CLOSING leg executes at
+// the next open under the short's id. No short is opened.
+void test_f_200pct_reversal_close_leg_only() {
+    std::printf("-- F 200%% reversal: close leg executes, no new entry --\n");
+    Probe eng(10000.0, 200.0, 100.0, false);
+    eng.entry_qty_ = 500.0;
+    eng.script = "l.S...";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 10.00),      // l placed
+        flat_bar(2000, 10.00),      // 500 @10.00 fills
+        flat_bar(3000, 10.20),      // S placed: 20,196 > 10,100 -> close-only
+        flat_bar(4000, 10.20),      // close leg fills
+        flat_bar(5000, 10.20),
+        flat_bar(6000, 10.20),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.default_entries_pending_after_call == 1);   // close-only survives
+    CHECK(eng.position_side_ == PositionSide::FLAT);      // pre-fix: SHORT 1,980
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() == 1) {
+        CHECK(eng.get_trade(0).is_long);
+        CHECK(eng.get_trade(0).exit_id == "S");
+        CHECK_NEAR(eng.get_trade(0).qty, 500.0, 1e-9);
+        CHECK_NEAR(eng.get_trade(0).exit_price, 10.20, 1e-9);
+    }
+    CHECK(eng.trades_with_entry_id("S") == 0);
+}
+
+// Reversal declined at the FILL: 200% / margin 50, long 500 @10.00 held, the
+// short at close 10.00 sizes 2,000 shares = 10,000 * 0.5 = 10,000 <= MTM
+// 10,000 (tie, admitted at placement); the fill opens at 10.10 -> 10,100 >
+// 10,000 -> entry leg dropped at the fill, closing leg executes at 10.10.
+void test_f_200pct_reversal_declined_at_fill_closes_only() {
+    std::printf("-- F 200%% reversal declined at fill: close leg only --\n");
+    Probe eng(10000.0, 200.0, 50.0, false);
+    eng.entry_qty_ = 500.0;
+    eng.script = "l.S...";
+    std::vector<Bar> bars = {
+        flat_bar(1000, 10.00),
+        flat_bar(2000, 10.00),
+        flat_bar(3000, 10.00),                          // S placed (tie)
+        mk_bar(4000, 10.10, 10.12, 10.08, 10.10),       // 2,000 * 10.10 * .5 > 10,000
+        flat_bar(5000, 10.10),
+        flat_bar(6000, 10.10),
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::FLAT);
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() == 1) {
+        CHECK(eng.get_trade(0).is_long);
+        CHECK(eng.get_trade(0).exit_id == "S");
+        CHECK_NEAR(eng.get_trade(0).qty, 500.0, 1e-9);
+        CHECK_NEAR(eng.get_trade(0).exit_price, 10.10, 1e-9);
+    }
+    CHECK(eng.trades_with_entry_id("S") == 0);
+}
+
+}  // namespace
+
+int main() {
+    std::printf("--- percent_equity_affordability ---\n");
+    test_f_200pct_margin100_declined();
+    test_f_200pct_margin50_fills();
+    test_f_100pct_control_unchanged();
+    test_f_150pct_margin50_fills();
+    test_f_200pct_margin50_gap_up_declined_at_fill();
+    test_f_200pct_reversal_close_leg_only();
+    test_f_200pct_reversal_declined_at_fill_closes_only();
+    std::printf("\n=== Results: %d passed, %d failed ===\n",
+                tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_stop_tick_rounding.cpp
+++ b/tests/test_stop_tick_rounding.cpp
@@ -1,0 +1,495 @@
+/*
+ * test_stop_tick_rounding.cpp — round 6, design-stop-tick-rounding:
+ * TradingView's broker emulator tests a resting stop / limit against the
+ * bar's OHLC QUANTIZED to the tick (nearest, floor(p / mintick + 0.5)) while
+ * the order LEVEL stays raw; the fill keeps its directional / limit-or-better
+ * snap. The engine used to compare the RAW bar prices, so a sell-stop at
+ * 13.74624 fired on a 13.745 low that TradingView (low -> 13.75) walks past.
+ *
+ * Every case below is a `lab tv` tape on NYSE:F 1D (mintick 0.01, sub-penny
+ * prints; scratchpad/r6/pins/stopround-*, 2026-09-04) replayed on the feed's
+ * own bars (tape times are UTC+8 evenings of the same trading day):
+ *
+ *   stopround-xs-L-{1374624,137451,137449,13745}  long sell-stop, entry
+ *       01-28 @13.88: every one SKIPS the 02-02 bar (low 13.745) and fills
+ *       02-03 @13.74.
+ *   stopround-xs-L-133449   long sell-stop 13.3449, entry 01-22 @13.78:
+ *       fills 01-26 (low 13.3448) @13.34 — so the level is NOT floored
+ *       before the compare (13.34 vs 13.3448 would not fire) and the bar is
+ *       NOT raw (02-02 would fire): only the quantized low explains both.
+ *   stopround-xs-S-{140349,1403505,140352}  short buy-stop, entry 01-30
+ *       @13.91: all fill 02-03 (high 14.0351 -> 14.04) @14.04.
+ *   stopround-xs-S-140351   short buy-stop 14.0351, entry 02-19 @13.77:
+ *       fills 02-20 (high 14.035 -> 14.04) @14.04.
+ *   stopround-xs-S-13225-high  short buy-stop 13.225, entry 12-08 @13.07:
+ *       skips 12-09 (high 13.2202 -> 13.22), fills 12-10 @13.23 — the
+ *       high rounds to NEAREST, not up.
+ *   stopround-xs-L-13776-open  long sell-stop 13.776, entry 02-19 @13.77:
+ *       the 02-20 open 13.775 (-> 13.78) is NOT a gap; fills at the level
+ *       13.77, not at the open.
+ *   stopround-xl-L-{140349,1403505,140352}  long sell-limit -> 02-03 @14.04;
+ *   stopround-xl-S-{137451,137449} short buy-limit -> 02-03 @13.74;
+ *   stopround-xl-S-133449  short buy-limit -> 01-26 @13.34.
+ *   stopround-es-L-{140349,1403505,140352} / stopround-eo-L-1403505
+ *       strategy.entry / strategy.order long stop placed 01-30 -> fill
+ *       02-03 @14.04; stopround-es-S-{137451,137449} short stop -> 02-03
+ *       @13.74.
+ *   stopround-el-L-{137451,137449} long limit entry placed 01-30 -> 02-03
+ *       @13.74; stopround-el-S-{1403505,140352} short limit entry -> 02-03
+ *       @14.04.
+ *   stopround-xt-L-trail  long entry 02-19 @13.77, trail_points 20 /
+ *       trail_offset 3: exits 02-23 at the open 13.98 — the raw-extreme
+ *       trail behaviour the engine already had (a quantized 14.04 best
+ *       would have filled 02-20 @14.01). The trail is NOT quantized.
+ *   stopround-ohlc-{0,1}  Pine's own low / high (encoded in the trade qty)
+ *       are the raw prints 13.745 / 13.3448 / 14.0351 — the feed's values —
+ *       so the quantization is the broker's, not the data's.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <pineforge/bar.hpp>
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_NEAR(a, b, tol)                                                  \
+    do {                                                                       \
+        double _a = (a), _b = (b);                                             \
+        if (!(std::fabs(_a - _b) <= (tol))) {                                  \
+            std::printf("  FAIL  %s:%d  %s == %.10f, expected %.10f\n",        \
+                        __FILE__, __LINE__, #a, _a, _b);                       \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+static constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+static Bar mk_bar(int64_t ts, double o, double h, double l, double c) {
+    Bar b;
+    b.open = o; b.high = h; b.low = l; b.close = c;
+    b.volume = 1.0; b.timestamp = ts;
+    return b;
+}
+
+// Bar index i carries timestamp ts(i) so a trade's entry/exit bar can be
+// read back from its entry_time / exit_time.
+static int64_t ts(int i) { return 1000 * (i + 1); }
+
+namespace {
+
+// NYSE:F daily bars (registry feed e3dd3a88e85b, UTC-day labels).
+const Bar kDec05 = mk_bar(0, 13.15, 13.28, 13.0, 13.03);
+const Bar kDec08 = mk_bar(0, 13.07, 13.16, 12.945, 13.14);
+const Bar kDec09 = mk_bar(0, 13.13, 13.2202, 13.06, 13.08);
+const Bar kDec10 = mk_bar(0, 13.08, 13.42, 13.07, 13.41);
+const Bar kJan21 = mk_bar(0, 13.405, 13.77, 13.405, 13.77);
+const Bar kJan22 = mk_bar(0, 13.78, 13.84, 13.7, 13.71);
+const Bar kJan23 = mk_bar(0, 13.7, 13.7, 13.55, 13.56);
+const Bar kJan26 = mk_bar(0, 13.56, 13.655, 13.3448, 13.44);
+const Bar kJan27 = mk_bar(0, 13.64, 13.945, 13.51, 13.93);
+const Bar kJan28 = mk_bar(0, 13.88, 13.89, 13.76, 13.82);
+const Bar kJan29 = mk_bar(0, 13.89, 14.09, 13.795, 14.0);
+const Bar kJan30 = mk_bar(0, 13.91, 13.98, 13.79, 13.88);
+const Bar kFeb02 = mk_bar(0, 13.86, 13.895, 13.745, 13.81);
+const Bar kFeb03 = mk_bar(0, 13.82, 14.0351, 13.61, 13.73);
+const Bar kFeb04 = mk_bar(0, 13.72, 14.0, 13.69, 13.82);
+const Bar kFeb05 = mk_bar(0, 13.75, 13.82, 13.53, 13.72);
+const Bar kFeb18 = mk_bar(0, 14.11, 14.14, 13.805, 13.85);
+const Bar kFeb19 = mk_bar(0, 13.77, 13.945, 13.69, 13.78);
+const Bar kFeb20 = mk_bar(0, 13.775, 14.035, 13.72, 14.01);
+const Bar kFeb23 = mk_bar(0, 13.98, 14.04, 13.57, 13.64);
+const Bar kFeb24 = mk_bar(0, 13.77, 14.325, 13.73, 14.2);
+
+std::vector<Bar> series(std::initializer_list<Bar> bars) {
+    std::vector<Bar> out;
+    int i = 0;
+    for (const Bar& b : bars) {
+        Bar c = b;
+        c.timestamp = ts(i++);
+        out.push_back(c);
+    }
+    return out;
+}
+
+// NYSE:F — pointvalue 1, mintick 0.01, whole shares, fixed 100 shares, no
+// commission / slippage, one position at a time (the pins' strategy()).
+// Script chars (indexed by bar_index_), all on entry id "E":
+//   'L' / 'S'  market entry long / short
+//   'e'        strategy.entry(stop = entry_level_)   in entry_long_ direction
+//   'm'        strategy.entry(limit = entry_level_)
+//   'o'        strategy.order(stop = entry_level_)
+//   'C'        strategy.close_all()
+//   '.'        nothing
+// While a position is open the bracket strategy.exit("X", "E", limit =
+// exit_limit_, stop = exit_stop_, trail_points_, trail_offset_) is re-issued
+// every bar, exactly like the pins' `if strategy.position_size != 0`.
+class Probe : public BacktestEngine {
+public:
+    Probe() {
+        initial_capital_ = 1000000000.0;
+        syminfo_.pointvalue = 1.0;
+        syminfo_mintick_ = 0.01;
+        qty_step_ = 1.0;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 100.0;
+        commission_type_ = CommissionType::PERCENT;
+        commission_value_ = 0.0;
+        margin_long_ = 100.0;
+        margin_short_ = 100.0;
+        pyramiding_ = 0;
+        slippage_ = 0;
+        process_orders_on_close_ = false;
+        margin_call_enabled_ = false;
+    }
+    std::string script;
+    bool entry_long_ = true;
+    double entry_level_ = kNaN;
+    double exit_stop_ = kNaN;
+    double exit_limit_ = kNaN;
+    double trail_points_ = kNaN;
+    double trail_offset_ = kNaN;
+    // Issue the bracket while flat as well, so it rests next to its stop
+    // entry and is live on the entry's own fill bar (same-bar bracket).
+    bool arm_exit_flat_ = false;
+
+    void on_bar(const Bar& /*bar*/) override {
+        if (bar_index_ >= 0 && bar_index_ < (int)script.size()) {
+            switch (script[bar_index_]) {
+                case 'L': strategy_entry("E", true); break;
+                case 'S': strategy_entry("E", false); break;
+                case 'e': strategy_entry("E", entry_long_, kNaN, entry_level_); break;
+                case 'm': strategy_entry("E", entry_long_, entry_level_, kNaN); break;
+                case 'o': strategy_order("E", entry_long_, kNaN, kNaN, entry_level_); break;
+                case 'C': strategy_close_all(); break;
+                default: break;
+            }
+        }
+        const bool armed = std::isfinite(exit_stop_) || std::isfinite(exit_limit_)
+            || std::isfinite(trail_points_);
+        if (armed && (arm_exit_flat_ || position_side_ != PositionSide::FLAT)) {
+            strategy_exit("X", "E", exit_limit_, exit_stop_,
+                          trail_points_, trail_offset_);
+        }
+    }
+    using BacktestEngine::position_side_;
+    using BacktestEngine::syminfo_mintick_;
+    double grid(double p) const { return tick_grid_price(p); }
+};
+
+// One closed trade: entered on bar entry_bar at entry_px, exited on bar
+// exit_bar at exit_px.
+void expect_single_trade(const Probe& eng, bool is_long,
+                         int entry_bar, double entry_px,
+                         int exit_bar, double exit_px) {
+    CHECK(eng.position_side_ == PositionSide::FLAT);
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() != 1) return;
+    const Trade& t = eng.get_trade(0);
+    CHECK(t.is_long == is_long);
+    CHECK(t.entry_time == ts(entry_bar));
+    CHECK_NEAR(t.entry_price, entry_px, 1e-9);
+    CHECK(t.exit_time == ts(exit_bar));
+    CHECK_NEAR(t.exit_price, exit_px, 1e-9);
+    CHECK_NEAR(t.qty, 100.0, 1e-9);
+    if (t.exit_time != ts(exit_bar) || std::fabs(t.exit_price - exit_px) > 1e-9) {
+        std::printf("        got exit bar %lld @%.5f (expected bar %d @%.5f)\n",
+                    (long long)(t.exit_time / 1000 - 1), t.exit_price,
+                    exit_bar, exit_px);
+    }
+}
+
+// --- the quantization itself ---------------------------------------------
+void test_tick_grid_price() {
+    std::printf("-- tick_grid_price: nearest tick, half up, literal-exact --\n");
+    Probe eng;
+    CHECK(eng.grid(13.745) == 13.75);      // 1374.5 exact -> up
+    CHECK(eng.grid(14.035) == 14.04);
+    CHECK(eng.grid(13.3448) == 13.34);
+    CHECK(eng.grid(14.0351) == 14.04);
+    CHECK(eng.grid(13.2202) == 13.22);     // nearest, not ceil
+    CHECK(eng.grid(13.775) == 13.78);
+    CHECK(eng.grid(13.61) == 13.61);       // on-grid input is a fixed point
+    CHECK(eng.grid(14.04) == 14.04);
+    CHECK(std::isnan(eng.grid(kNaN)));
+    // Every grid point is the double its decimal literal parses to, so an
+    // on-grid level compares equal bit-for-bit (k * 0.01 would give
+    // 14.040000000000001 for k = 1404).
+    CHECK(eng.grid(1404.0 * 0.01) == 14.04);
+    // The finding-446 binary-midpoint artifacts are preserved: 228.765 sits
+    // just under its midpoint and rounds DOWN, 214.385 sits on it and rounds
+    // up (the census the fill rounding was fitted to).
+    CHECK(eng.grid(228.765) == 228.76);
+    CHECK(eng.grid(214.385) == 214.39);
+    // No tick, no quantization.
+    eng.syminfo_mintick_ = 0.0;
+    CHECK(eng.grid(13.745) == 13.745);
+    // A binary tick (1/128) has an integral inverse and takes the k / 128
+    // branch: 13.7451 / 0.0078125 = 1759.37 -> k = 1759.
+    eng.syminfo_mintick_ = 0.0078125;
+    CHECK(eng.grid(13.7451) == 1759.0 * 0.0078125);
+    // A tick whose inverse is not integral (2.5 -> 0.4) falls back to
+    // k * mintick: 13.7451 / 2.5 = 5.498 -> k = 5.
+    eng.syminfo_mintick_ = 2.5;
+    CHECK(eng.grid(13.7451) == 5.0 * 2.5);
+    CHECK(eng.grid(13.75) == 6.0 * 2.5);        // 5.5 exact -> half up -> 15
+}
+
+// --- (a) long sell-stop -----------------------------------------------------
+void test_long_sell_stop_skips_subtick_low() {
+    std::printf("-- long sell-stop: 13.745 low -> 13.75 is not a touch (xs-L-*) --\n");
+    // bars: 0 Jan27 (signal) 1 Jan28 (fill 13.88) 2 Jan29 3 Jan30 4 Feb02 5 Feb03
+    for (double stop : {13.74624, 13.7451, 13.7449, 13.745}) {
+        Probe eng;
+        eng.script = "L.....";
+        eng.exit_stop_ = stop;
+        auto bars = series({kJan27, kJan28, kJan29, kJan30, kFeb02, kFeb03});
+        eng.run(bars.data(), (int)bars.size());
+        // pre-fix: 13.74624 / 13.7451 exited on Feb02 (bar 4) — the
+        // jayentriken NYSE:F trade-1 defect.
+        expect_single_trade(eng, true, 1, 13.88, 5, 13.74);
+    }
+}
+
+void test_long_sell_stop_fires_on_rounded_down_low() {
+    std::printf("-- long sell-stop 13.3449: 13.3448 low -> 13.34 IS a touch (xs-L-133449) --\n");
+    // bars: 0 Jan21 (signal) 1 Jan22 (fill 13.78) 2 Jan23 3 Jan26 (low 13.3448)
+    Probe eng;
+    eng.script = "L...";
+    eng.exit_stop_ = 13.3449;
+    auto bars = series({kJan21, kJan22, kJan23, kJan26});
+    eng.run(bars.data(), (int)bars.size());
+    expect_single_trade(eng, true, 1, 13.78, 3, 13.34);
+}
+
+void test_long_sell_stop_open_is_quantized() {
+    std::printf("-- long sell-stop 13.776: 13.775 open -> 13.78 is no gap (xs-L-13776-open) --\n");
+    // bars: 0 Feb18 (signal) 1 Feb19 (fill 13.77) 2 Feb20 (open 13.775, low 13.72)
+    Probe eng;
+    eng.script = "L..";
+    eng.exit_stop_ = 13.776;
+    auto bars = series({kFeb18, kFeb19, kFeb20});
+    eng.run(bars.data(), (int)bars.size());
+    // Level fill 13.77 (floor of 13.776), not the gap fill at the open 13.78.
+    expect_single_trade(eng, true, 1, 13.77, 2, 13.77);
+}
+
+// --- (b) short buy-stop -----------------------------------------------------
+void test_short_buy_stop_fires_on_rounded_up_high() {
+    std::printf("-- short buy-stop: 14.0351 high -> 14.04 touches 14.0352 (xs-S-*) --\n");
+    // bars: 0 Jan29 (signal) 1 Jan30 (fill 13.91) 2 Feb02 3 Feb03 (high 14.0351)
+    for (double stop : {14.0349, 14.03505, 14.0352}) {
+        Probe eng;
+        eng.script = "S...";
+        eng.exit_stop_ = stop;
+        auto bars = series({kJan29, kJan30, kFeb02, kFeb03});
+        eng.run(bars.data(), (int)bars.size());
+        // pre-fix: 14.0352 > 14.0351 never fired here.
+        expect_single_trade(eng, false, 1, 13.91, 3, 14.04);
+    }
+    // The exact half-tick high 14.035 -> 14.04 touches 14.0351 too
+    // (xs-S-140351): bars 0 Feb18 (signal) 1 Feb19 (fill 13.77) 2 Feb20.
+    {
+        Probe eng;
+        eng.script = "S..";
+        eng.exit_stop_ = 14.0351;
+        auto bars = series({kFeb18, kFeb19, kFeb20});
+        eng.run(bars.data(), (int)bars.size());
+        expect_single_trade(eng, false, 1, 13.77, 2, 14.04);
+    }
+}
+
+void test_short_buy_stop_high_rounds_nearest_not_up() {
+    std::printf("-- short buy-stop 13.225: 13.2202 high -> 13.22 is no touch (xs-S-13225-high) --\n");
+    // bars: 0 Dec05 (signal) 1 Dec08 (fill 13.07) 2 Dec09 (high 13.2202) 3 Dec10
+    Probe eng;
+    eng.script = "S...";
+    eng.exit_stop_ = 13.225;
+    auto bars = series({kDec05, kDec08, kDec09, kDec10});
+    eng.run(bars.data(), (int)bars.size());
+    expect_single_trade(eng, false, 1, 13.07, 3, 13.23);
+}
+
+// --- (c) strategy.exit(limit=) ---------------------------------------------
+void test_exit_limits() {
+    std::printf("-- exit limits: sell-limit on the 14.0351 high, buy-limit on the 13.745 / 13.3448 lows (xl-*) --\n");
+    for (double limit : {14.0349, 14.03505, 14.0352}) {
+        Probe eng;
+        eng.script = "L...";
+        eng.exit_limit_ = limit;
+        auto bars = series({kJan29, kJan30, kFeb02, kFeb03});
+        eng.run(bars.data(), (int)bars.size());
+        expect_single_trade(eng, true, 1, 13.91, 3, 14.04);
+    }
+    for (double limit : {13.7451, 13.7449}) {
+        Probe eng;
+        eng.script = "S.....";
+        eng.exit_limit_ = limit;
+        auto bars = series({kJan27, kJan28, kJan29, kJan30, kFeb02, kFeb03});
+        eng.run(bars.data(), (int)bars.size());
+        expect_single_trade(eng, false, 1, 13.88, 5, 13.74);
+    }
+    {
+        Probe eng;
+        eng.script = "S...";
+        eng.exit_limit_ = 13.3449;
+        auto bars = series({kJan21, kJan22, kJan23, kJan26});
+        eng.run(bars.data(), (int)bars.size());
+        expect_single_trade(eng, false, 1, 13.78, 3, 13.34);
+    }
+}
+
+// --- (d) stop / limit entries ----------------------------------------------
+// bars: 0 Jan30 (placed) 1 Feb02 2 Feb03 3 Feb04 (close_all) 4 Feb05 (exit 13.75)
+void test_stop_entries() {
+    std::printf("-- entry stops: long on the 14.0351 high, short on the 13.745 low (es-*, eo-*) --\n");
+    for (double level : {14.0349, 14.03505, 14.0352}) {
+        for (char kind : {'e', 'o'}) {
+            Probe eng;
+            eng.script = std::string(1, kind) + "..C.";
+            eng.entry_long_ = true;
+            eng.entry_level_ = level;
+            auto bars = series({kJan30, kFeb02, kFeb03, kFeb04, kFeb05});
+            eng.run(bars.data(), (int)bars.size());
+            expect_single_trade(eng, true, 2, 14.04, 4, 13.75);
+        }
+    }
+    for (double level : {13.7451, 13.7449}) {
+        for (char kind : {'e', 'o'}) {
+            Probe eng;
+            eng.script = std::string(1, kind) + "..C.";
+            eng.entry_long_ = false;
+            eng.entry_level_ = level;
+            auto bars = series({kJan30, kFeb02, kFeb03, kFeb04, kFeb05});
+            eng.run(bars.data(), (int)bars.size());
+            // pre-fix: 13.7451 filled on Feb02 (bar 1).
+            expect_single_trade(eng, false, 2, 13.74, 4, 13.75);
+        }
+    }
+}
+
+void test_limit_entries() {
+    std::printf("-- entry limits: long on the 13.745 low, short on the 14.0351 high (el-*) --\n");
+    for (double level : {13.7451, 13.7449}) {
+        Probe eng;
+        eng.script = "m..C.";
+        eng.entry_long_ = true;
+        eng.entry_level_ = level;
+        auto bars = series({kJan30, kFeb02, kFeb03, kFeb04, kFeb05});
+        eng.run(bars.data(), (int)bars.size());
+        expect_single_trade(eng, true, 2, 13.74, 4, 13.75);
+    }
+    for (double level : {14.03505, 14.0352}) {
+        Probe eng;
+        eng.script = "m..C.";
+        eng.entry_long_ = false;
+        eng.entry_level_ = level;
+        auto bars = series({kJan30, kFeb02, kFeb03, kFeb04, kFeb05});
+        eng.run(bars.data(), (int)bars.size());
+        expect_single_trade(eng, false, 2, 14.04, 4, 13.75);
+    }
+}
+
+// --- trail: not quantized (raw extremes, unchanged) -------------------------
+void test_trail_keeps_raw_path() {
+    std::printf("-- trail 20/3 over the 14.035 high: exits at the next open 13.98 (xt-L-trail) --\n");
+    // bars: 0 Feb18 (signal) 1 Feb19 (fill 13.77) 2 Feb20 (high 14.035) 3 Feb23 (open 13.98)
+    Probe eng;
+    eng.script = "L...";
+    eng.trail_points_ = 20.0;
+    eng.trail_offset_ = 3.0;
+    auto bars = series({kFeb18, kFeb19, kFeb20, kFeb23});
+    eng.run(bars.data(), (int)bars.size());
+    // raw best 14.035 - 0.03 = 14.005 > close 14.01 on Feb20: no fill; the
+    // Feb23 open 13.98 gaps through -> 13.98. (A quantized best 14.04 would
+    // have filled Feb20 @14.01, which TradingView does not do.)
+    expect_single_trade(eng, true, 1, 13.77, 3, 13.98);
+}
+
+// --- leg order: the raw bar's, on every path coordinate ---------------------
+void test_leg_order_is_the_raw_bars() {
+    std::printf("-- leg order: quantization flips the O->H / O->L proximity tie, the cursor stays in the raw bar's order --\n");
+    // Raw bar: O 13.7749 H 13.7846 L 13.7649 C 13.775 — |H-O| 0.0097 <
+    // |O-L| 0.0100, so the raw path is O -> H -> L -> C (high first).
+    // Tick twin: O 13.77 H 13.78 L 13.76 C 13.78 — a 0.01 / 0.01 tie, which
+    // bar_path_uses_high_first resolves LOW first. A long stop entry at
+    // 13.7751 fires on the raw first leg (tick high 13.78 >= 13.7751, tick
+    // open 13.77 is no gap) and fills at ceil -> 13.78; its same-bar bracket
+    // stop 13.766 then sits on the H -> L leg (tick 13.78 -> 13.76) and
+    // fills at floor -> 13.76 on the SAME bar. Had the entry's path cursor
+    // been taken in the twin's own (low-first) order it would read 1.755 —
+    // past the H waypoint of the raw walk — and the bracket would miss the
+    // H -> L leg entirely (no exit this bar), a regression the pre-round-6
+    // raw walk never had.
+    const Bar flip = mk_bar(0, 13.7749, 13.7846, 13.7649, 13.775);
+    Probe probe;
+    CHECK(probe.grid(flip.open) == 13.77);
+    CHECK(probe.grid(flip.high) == 13.78);
+    CHECK(probe.grid(flip.low) == 13.76);
+    CHECK(probe.grid(flip.close) == 13.78);
+
+    const Bar placement = mk_bar(0, 13.70, 13.75, 13.65, 13.72);
+    const Bar after = mk_bar(0, 13.80, 13.85, 13.79, 13.84);
+    Probe eng;
+    eng.script = "e..";
+    eng.entry_long_ = true;
+    eng.entry_level_ = 13.7751;
+    eng.exit_stop_ = 13.766;
+    eng.arm_exit_flat_ = true;
+    auto bars = series({placement, flip, after});
+    eng.run(bars.data(), (int)bars.size());
+    expect_single_trade(eng, true, 1, 13.78, 1, 13.76);
+}
+
+// --- control: the quantization is the tick's doing --------------------------
+void test_no_tick_no_quantization() {
+    std::printf("-- control: mintick 0 keeps the raw compare (13.7451 fires on the 13.745 low) --\n");
+    Probe eng;
+    eng.syminfo_mintick_ = 0.0;
+    eng.script = "L.....";
+    eng.exit_stop_ = 13.7451;
+    auto bars = series({kJan27, kJan28, kJan29, kJan30, kFeb02, kFeb03});
+    eng.run(bars.data(), (int)bars.size());
+    // No tick: raw compare AND raw fill (no snap either).
+    expect_single_trade(eng, true, 1, 13.88, 4, 13.7451);
+}
+
+}  // namespace
+
+int main() {
+    std::printf("--- stop_tick_rounding ---\n");
+    test_tick_grid_price();
+    test_long_sell_stop_skips_subtick_low();
+    test_long_sell_stop_fires_on_rounded_down_low();
+    test_long_sell_stop_open_is_quantized();
+    test_short_buy_stop_fires_on_rounded_up_high();
+    test_short_buy_stop_high_rounds_nearest_not_up();
+    test_exit_limits();
+    test_stop_entries();
+    test_limit_entries();
+    test_trail_keeps_raw_path();
+    test_leg_order_is_the_raw_bars();
+    test_no_tick_no_quantization();
+    std::printf("\n=== Results: %d passed, %d failed ===\n",
+                tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_ta_extremes_edge.cpp
+++ b/tests/test_ta_extremes_edge.cpp
@@ -64,14 +64,15 @@ static void test_highest_warmup_evict_na() {
     CHECK(near(hi.compute(1.0), 2.0));  // window {2,1,1} -> 9 evicted, max 2
     CHECK(near(hi.compute(1.0), 1.0));  // window {1,1,1} -> all evicted, max 1
 
-    // A direct ta.highest answers na on an na source (pinned 2026-09-04,
-    // NYSE:F 1D every-bar ta.lowest over a source na on every 4th bar: na on
-    // exactly those bars, 11/11); the slot stays a gap the next bar skips.
-    // The finding-331 "stay live over the non-na members" reading survives
-    // inside the composites (Stoch, WPR, Range), which construct with
-    // na_src_answers_na = false.
+    // An na source answers na AND poisons the window (pinned 2026-09-04,
+    // NYSE:F 1D every-bar ta.lowest/ta.highest over `bar_index % 4 == 0 ?
+    // na : low`: na on the na bars, 11/11, and on the bar after each na bar
+    // lowest == highest == that bar's own low, 20/20 -- the members older
+    // than the na are dead, not skipped). Re-pinned from `{1, na, 0.5} ->
+    // 1.0` (the old "skip the gap" reading) with that tape; see
+    // test_ta_extremes_ring.cpp for the full replay.
     CHECK(is_na(hi.compute(na<double>())));      // window {1,1,na} -> na on the na bar
-    CHECK(near(hi.compute(0.5), 1.0));           // window {1,na,0.5} -> max 1
+    CHECK(near(hi.compute(0.5), 0.5));           // window {1,na,0.5} -> the 1 is poisoned: 0.5
 }
 
 // --- Lowest: warmup na, full-window value, eviction, na-input ---
@@ -92,7 +93,7 @@ static void test_lowest_warmup_evict_na() {
     CHECK(near(lo.compute(6.0), 6.0));   // {8,7,6} -> min 6
 
     CHECK(is_na(lo.compute(na<double>())));      // na source -> na (2026-09-04 pin)
-    CHECK(near(lo.compute(10.0), 6.0));          // {6,na,10} -> min 6
+    CHECK(near(lo.compute(10.0), 10.0));         // {6,na,10} -> the 6 is poisoned: 10 (re-pinned, same tape)
 }
 
 // --- HighestBars: warmup na, offset semantics, eviction ---

--- a/tests/test_ta_extremes_edge.cpp
+++ b/tests/test_ta_extremes_edge.cpp
@@ -64,9 +64,13 @@ static void test_highest_warmup_evict_na() {
     CHECK(near(hi.compute(1.0), 2.0));  // window {2,1,1} -> 9 evicted, max 2
     CHECK(near(hi.compute(1.0), 1.0));  // window {1,1,1} -> all evicted, max 1
 
-    // na input advances the positional window as a gap (TV semantics, pinned
-    // by the finding-331 oracle: extrema stay live over the non-na members).
-    CHECK(near(hi.compute(na<double>()), 1.0));  // window {1,1,na} -> max 1
+    // A direct ta.highest answers na on an na source (pinned 2026-09-04,
+    // NYSE:F 1D every-bar ta.lowest over a source na on every 4th bar: na on
+    // exactly those bars, 11/11); the slot stays a gap the next bar skips.
+    // The finding-331 "stay live over the non-na members" reading survives
+    // inside the composites (Stoch, WPR, Range), which construct with
+    // na_src_answers_na = false.
+    CHECK(is_na(hi.compute(na<double>())));      // window {1,1,na} -> na on the na bar
     CHECK(near(hi.compute(0.5), 1.0));           // window {1,na,0.5} -> max 1
 }
 
@@ -87,7 +91,7 @@ static void test_lowest_warmup_evict_na() {
     CHECK(near(lo.compute(7.0), 7.0));   // {9,8,7} -> 1 evicted, min 7
     CHECK(near(lo.compute(6.0), 6.0));   // {8,7,6} -> min 6
 
-    CHECK(near(lo.compute(na<double>()), 6.0));  // {7,6,na} -> min 6 (gap)
+    CHECK(is_na(lo.compute(na<double>())));      // na source -> na (2026-09-04 pin)
     CHECK(near(lo.compute(10.0), 6.0));          // {6,na,10} -> min 6
 }
 

--- a/tests/test_ta_extremes_ring.cpp
+++ b/tests/test_ta_extremes_ring.cpp
@@ -23,8 +23,11 @@
  * 10.70, 10.70, 10.65, 10.87, 11.85 ... (call 6 = 10.65: a per-call buffer
  * would still hold 10.70 — only the bar-addressed ring drops it).
  *
- * Every-bar callers must stay byte-identical to the previous positional deque
- * in every context; the deque is reproduced here as the reference.
+ * Every-bar callers must stay byte-identical to the positional deque in every
+ * context; the deque is reproduced here as the reference, with one re-pin:
+ * an na source answers na (NYSE:F 1D, every-bar ta.lowest over a source that
+ * is na on every 4th bar answers na on exactly those bars, 11/11), where the
+ * old deque skipped the na and answered the window's other members.
  *
  * NDEBUG-PROOF: self-rolled CHECK with a failure counter; main() returns
  * nonzero on any failure.
@@ -99,6 +102,7 @@ struct RefHighest {
         buffer.push_back(src);
         while ((int)buffer.size() > length) buffer.pop_front();
         if ((int)buffer.size() < length) return na<double>();
+        if (is_na(src)) return na<double>();   // pinned 2026-09-04 (NYSE:F 1D): an na source answers na
         double hi = na<double>();
         for (int i = 0; i < (int)buffer.size(); i++)
             if (!is_na(buffer[i]) && (is_na(hi) || buffer[i] > hi)) hi = buffer[i];
@@ -108,6 +112,7 @@ struct RefHighest {
         if (buffer.empty()) return compute(src);
         buffer.back() = src;
         if ((int)buffer.size() < length) return na<double>();
+        if (is_na(src)) return na<double>();
         double hi = na<double>();
         for (int i = 0; i < (int)buffer.size(); i++)
             if (!is_na(buffer[i]) && (is_na(hi) || buffer[i] > hi)) hi = buffer[i];
@@ -123,6 +128,7 @@ struct RefLowest {
         buffer.push_back(src);
         while ((int)buffer.size() > length) buffer.pop_front();
         if ((int)buffer.size() < length) return na<double>();
+        if (is_na(src)) return na<double>();   // pinned 2026-09-04 (NYSE:F 1D): an na source answers na
         double lo = na<double>();
         for (int i = 0; i < (int)buffer.size(); i++)
             if (!is_na(buffer[i]) && (is_na(lo) || buffer[i] < lo)) lo = buffer[i];
@@ -132,6 +138,7 @@ struct RefLowest {
         if (buffer.empty()) return compute(src);
         buffer.back() = src;
         if ((int)buffer.size() < length) return na<double>();
+        if (is_na(src)) return na<double>();
         double lo = na<double>();
         for (int i = 0; i < (int)buffer.size(); i++)
             if (!is_na(buffer[i]) && (is_na(lo) || buffer[i] < lo)) lo = buffer[i];
@@ -605,6 +612,32 @@ static void test_never_written_slots_read_as_zero() {
     CHECK(call == 16);
 }
 
+
+// --- An na source answers na and leaves the cache alone (pinned 2026-09-04,
+// OANDA:XAUUSD 15: `ta.lowest(bar_index % 13 == 6 ? na : z, 10)` answers na
+// on the na call and the next valid call continues from the previous cache).
+static void test_na_source_answers_na_without_touching_the_cache() {
+    std::printf("test_na_source_answers_na_without_touching_the_cache\n");
+    ta::Lowest lo(10);
+    double last_valid = na<double>();
+    for (int b = 0; b <= 120; ++b) {
+        ta::BarContextScope scope(b, 0);
+        const bool valid_call = b % 13 == 5;
+        const bool na_call = b >= 100 && b % 13 == 6;
+        if (!valid_call && !na_call) continue;
+        if (na_call) {
+            CHECK(is_na(lo.compute(na<double>())));
+            continue;
+        }
+        const double src = 3000.0 - b;                  // falling: every valid call is a new minimum -> cache path
+        const double v = lo.compute(src);
+        if (b >= 9) { CHECK(near(v, src)); }
+        last_valid = v;
+    }
+    CHECK(!is_na(last_valid));
+    CHECK(!ta::bar_context().installed);
+}
+
 int main() {
     test_cadence7_pin();
     test_cadence9_pin();
@@ -616,6 +649,7 @@ int main() {
     test_cached_extremum_keeps_over_aliased_slot_until_expiry();
     test_new_extremum_precedes_expiry_rescan();
     test_never_written_slots_read_as_zero();
+    test_na_source_answers_na_without_touching_the_cache();
     std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
     return g_fail ? 1 : 0;
 }

--- a/tests/test_ta_extremes_ring.cpp
+++ b/tests/test_ta_extremes_ring.cpp
@@ -24,10 +24,15 @@
  * would still hold 10.70 — only the bar-addressed ring drops it).
  *
  * Every-bar callers must stay byte-identical to the positional deque in every
- * context; the deque is reproduced here as the reference, with one re-pin:
- * an na source answers na (NYSE:F 1D, every-bar ta.lowest over a source that
- * is na on every 4th bar answers na on exactly those bars, 11/11), where the
- * old deque skipped the na and answered the window's other members.
+ * context; the deque is reproduced here as the reference, with the na rule
+ * re-pinned (2026-09-04, NYSE:F 1D, every-bar ta.lowest / ta.highest over a
+ * source na on every 4th bar): an na source answers na on its own bar
+ * (11/11) AND poisons the window -- the answer on the bars after it is the
+ * extremum over the members newer than the na (20/20 entries: lowest ==
+ * highest on the bar after each gap), where the old deque skipped the na and
+ * answered the window's other members. The same written-na poison governs
+ * conditional callers' rescans and their cache (log-20260904t112527z-ea13dfcd;
+ * the tape replays at the end of this file).
  *
  * NDEBUG-PROOF: self-rolled CHECK with a failure counter; main() returns
  * nonzero on any failure.
@@ -92,7 +97,21 @@ static int tv_size(double v) {
     return is_na(v) ? 1 : static_cast<int>(std::llround(v * 100.0));
 }
 
-// --- The previous implementation, kept verbatim as the every-bar reference ---
+// --- The previous implementation, kept as the every-bar reference ---
+
+// The positional window's extremum under the written-na poison (pinned
+// 2026-09-04, NYSE:F 1D pin-lowest-na-everybar): an na member resets the
+// running extremum, so the result is the extremum over the members newer than
+// the newest na (na when there is none). The pre-poison deque took the
+// extremum over ALL non-na members.
+static double ref_extremum(const std::deque<double>& buffer, bool want_max) {
+    double best = na<double>();
+    for (double v : buffer) {
+        if (is_na(v)) { best = na<double>(); continue; }
+        if (is_na(best) || (want_max ? v > best : v < best)) best = v;
+    }
+    return best;
+}
 
 struct RefHighest {
     std::deque<double> buffer;
@@ -103,20 +122,14 @@ struct RefHighest {
         while ((int)buffer.size() > length) buffer.pop_front();
         if ((int)buffer.size() < length) return na<double>();
         if (is_na(src)) return na<double>();   // pinned 2026-09-04 (NYSE:F 1D): an na source answers na
-        double hi = na<double>();
-        for (int i = 0; i < (int)buffer.size(); i++)
-            if (!is_na(buffer[i]) && (is_na(hi) || buffer[i] > hi)) hi = buffer[i];
-        return hi;
+        return ref_extremum(buffer, true);
     }
     double recompute(double src) {
         if (buffer.empty()) return compute(src);
         buffer.back() = src;
         if ((int)buffer.size() < length) return na<double>();
         if (is_na(src)) return na<double>();
-        double hi = na<double>();
-        for (int i = 0; i < (int)buffer.size(); i++)
-            if (!is_na(buffer[i]) && (is_na(hi) || buffer[i] > hi)) hi = buffer[i];
-        return hi;
+        return ref_extremum(buffer, true);
     }
 };
 
@@ -129,20 +142,14 @@ struct RefLowest {
         while ((int)buffer.size() > length) buffer.pop_front();
         if ((int)buffer.size() < length) return na<double>();
         if (is_na(src)) return na<double>();   // pinned 2026-09-04 (NYSE:F 1D): an na source answers na
-        double lo = na<double>();
-        for (int i = 0; i < (int)buffer.size(); i++)
-            if (!is_na(buffer[i]) && (is_na(lo) || buffer[i] < lo)) lo = buffer[i];
-        return lo;
+        return ref_extremum(buffer, false);
     }
     double recompute(double src) {
         if (buffer.empty()) return compute(src);
         buffer.back() = src;
         if ((int)buffer.size() < length) return na<double>();
         if (is_na(src)) return na<double>();
-        double lo = na<double>();
-        for (int i = 0; i < (int)buffer.size(); i++)
-            if (!is_na(buffer[i]) && (is_na(lo) || buffer[i] < lo)) lo = buffer[i];
-        return lo;
+        return ref_extremum(buffer, false);
     }
 };
 
@@ -376,9 +383,9 @@ static void test_bars_variants_ring() {
         CHECK(near(v, -2.0));
     }
 
-    // na input: recorded as a positional gap (skipped by the extremum) and
-    // answers na on that bar; the offset then points at the real bar. The
-    // deque skipped na without advancing, so {9, na, 7, 2} at length 3
+    // na input: written as a positional member (it poisons the older ones)
+    // and answers na on that bar; the offset then points at the real bar.
+    // The deque skipped na without advancing, so {9, na, 7, 2} at length 3
     // answered -2 (the 9, actually 3 bars back) — TV's series is positional.
     {
         ta::HighestBars t(3);
@@ -425,8 +432,8 @@ static void test_every_bar_identity() {
     std::printf("test_every_bar_identity\n");
     for (int length : {1, 2, 3, 5, 8, 13, 50}) {
         for (int mode = 0; mode < 3; ++mode) {
-            // Highest / Lowest: positional deque incl. na gaps -> identical
-            // with gaps planted every 7th bar.
+            // Highest / Lowest: positional deque incl. na gaps (under the
+            // written-na poison) -> identical with gaps planted every 7th bar.
             every_bar_identity<ta::Highest, RefHighest>(length, mode, 7, 17u + length);
             every_bar_identity<ta::Lowest, RefLowest>(length, mode, 7, 29u + length);
             every_bar_identity<ta::Highest, RefHighest>(length, mode, 0, 3u + length);
@@ -613,28 +620,294 @@ static void test_never_written_slots_read_as_zero() {
 }
 
 
-// --- An na source answers na and leaves the cache alone (pinned 2026-09-04,
-// OANDA:XAUUSD 15: `ta.lowest(bar_index % 13 == 6 ? na : z, 10)` answers na
-// on the na call and the next valid call continues from the previous cache).
-static void test_na_source_answers_na_without_touching_the_cache() {
-    std::printf("test_na_source_answers_na_without_touching_the_cache\n");
-    ta::Lowest lo(10);
-    double last_valid = na<double>();
-    for (int b = 0; b <= 120; ++b) {
-        ta::BarContextScope scope(b, 0);
-        const bool valid_call = b % 13 == 5;
-        const bool na_call = b >= 100 && b % 13 == 6;
-        if (!valid_call && !na_call) continue;
-        if (na_call) {
-            CHECK(is_na(lo.compute(na<double>())));
-            continue;
+
+// --- A written na POISONS the ring (pinned 2026-09-04, ledger
+// log-20260904t112527z-ea13dfcd; tapes scratchpad/r6/pins/ringkind/{out-1,
+// out-nafirst,out-mlsite} on OANDA:XAUUSD 1D and r6/pins/out-pin-lowest-na-
+// everybar on NYSE:F 1D). In the oldest-first rescan a slot written with na
+// resets the running extremum and the next (newer) slot restarts it, so the
+// answer is the extremum over the slots NEWER than the newest na slot in the
+// window (never-written 0 slots among them included), na when the newest slot
+// is itself na; the na write also poisons the cache to (na, b), so the next
+// valid call restarts from its own src without reading the slots. ----------
+
+// Every-bar, mid-stream gaps: NYSE:F 1D lows, bars 0..41 of the pinned range
+// (bar 0 = 2025-04-01; `lab bars NYSE:F 1D`), `x = bar_index % 4 == 0 ? na :
+// low`, v = ta.lowest(x, 5), h = ta.highest(x, 5), entries on odd bars with
+// qty = na ? 7 : 1 + round(v * 100). TV: v == h on every bar after an na bar
+// (5, 9, 13, ...: the bar's own low, a single live member) -- the old "skip
+// the gap" reading kept the pre-gap extremum (bar 9: 8.44 from bar 6; TV
+// 9.20), and the old "leave the cache alone" na rule would have kept it too
+// (the cache was only 3 bars old). 20/20 entries.
+static const double kFordLows[42] = {
+    9.81, 9.82, 9.53, 9.2, 9.0, 8.55, 8.4406, 8.88, 9.04, 9.2, 9.38, 9.29,
+    9.405, 9.35, 9.53, 9.71, 9.815, 9.97, 9.9701, 9.925, 9.86, 10.02, 10.215,
+    10.095, 10.055, 10.12, 10.26, 10.35, 10.48, 10.42, 10.48, 10.55, 10.64,
+    10.63, 10.66, 10.45, 10.34, 10.29, 10.21, 10.15, 10.11, 10.12};
+// TV "Size (qty)" of the V / H entries signalled on bars 1, 3, ..., 39.
+static const int kFordTapeV[20] = {7, 7, 856, 845, 921, 921, 936, 936, 998, 994,
+                                   1003, 1003, 1013, 1013, 1043, 1043, 1064, 1046, 1030, 1016};
+static const int kFordTapeH[20] = {7, 7, 856, 889, 921, 939, 936, 972, 998, 998,
+                                   1003, 1023, 1013, 1036, 1043, 1056, 1064, 1067, 1030, 1030};
+
+static bool matches_qty(double v, int qty) {
+    if (qty == 7) return is_na(v);
+    if (is_na(v)) return false;
+    return std::fabs(v - (qty - 1) / 100.0) <= 0.0051;   // round(v * 100) resolution
+}
+
+static void test_everybar_na_gap_poisons_the_window() {
+    std::printf("test_everybar_na_gap_poisons_the_window\n");
+    for (int mode = 0; mode < 2; ++mode) {          // 0: standalone cadence, 1: chart context
+        ta::Lowest lo(5);
+        ta::Highest hi(5);
+        int entry = 0;
+        for (int b = 0; b < 42; ++b) {
+            const double x = (b % 4 == 0) ? na<double>() : kFordLows[b];
+            double v, h;
+            if (mode == 0) {
+                v = lo.compute(x);
+                h = hi.compute(x);
+            } else {
+                ta::BarContextScope scope(b, 0);
+                v = lo.compute(x);
+                h = hi.compute(x);
+            }
+            if (b % 4 == 0) { CHECK(is_na(v)); CHECK(is_na(h)); }          // the na bar answers na
+            if (b % 2 == 1 && b <= 39) {   // bar 41's signal has no next bar to fill on
+                CHECK(entry < 20);
+                if (entry < 20) {
+                    CHECK(matches_qty(v, kFordTapeV[entry]));
+                    CHECK(matches_qty(h, kFordTapeH[entry]));
+                }
+                ++entry;
+            }
+            if (b >= 4 && b % 4 == 1) CHECK(same(v, h));   // the bar after a gap: a single live member
+            if (b == 9) { CHECK(near(v, 9.2)); CHECK(near(h, 9.2)); }   // not 8.4406 (bar 6, older than bar 8's na)
+            if (b == 11) { CHECK(near(v, 9.2)); CHECK(near(h, 9.38)); } // bars 9..11 live
         }
-        const double src = 3000.0 - b;                  // falling: every valid call is a new minimum -> cache path
-        const double v = lo.compute(src);
-        if (b >= 9) { CHECK(near(v, src)); }
-        last_valid = v;
+        CHECK(entry == 20);
     }
-    CHECK(!is_na(last_valid));
+    CHECK(!ta::bar_context().installed);
+}
+
+// Conditional, cadence 13 / length 10 (K = 11) on OANDA:XAUUSD 1D
+// (2025-03-01..2025-11-01, bar 0 = 2025-03-03; tape r6/pins/ringkind/out-1):
+// the zero-fill control ta.lowest(low, 10) -- na, 0 x 9 while a never-written
+// slot sits in the window, then the stale minima 2880.3 / 3017.7 / 3210.1 --
+// and the sign-mixed COMPUTED source o = sma(close, 5) - close, where the
+// never-written 0 never wins because every live member is negative: the
+// source kind does not change the rule (13/13 on low, close - 2000,
+// sma(close, 5), low[1], hl2 and o; only C and o are replayed here).
+static const int kXauCallBars[13] = {5, 18, 31, 44, 57, 70, 83, 96, 109, 122, 135, 148, 161};
+static const double kXauLowAtCalls[13] = {
+    2880.310, 3017.655, 3210.065, 3237.790, 3279.235, 3302.015, 3255.850,
+    3319.695, 3345.005, 3325.280, 3626.030, 3734.440, 4140.735};
+static const double kXauTvLowestLow[13] = {NAN, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2880.3, 3017.7, 3210.1};
+static const double kXauOscAtCalls[13] = {
+    19.9530, -30.1400, -42.4510, -50.4460, -28.0200, 14.0790, 51.2330,
+    -8.3920, -47.9130, -4.4120, -35.5470, -8.6510, -117.0400};
+// TV: sign via qty 3/5/9 (neg/pos/zero) and |v| via 11 + round(|v| * 100).
+static const double kXauTvLowestOsc[13] = {
+    NAN, -30.14, -42.45, -50.45, -50.45, -50.45, -50.45, -50.45, -47.91,
+    -50.45, -50.45, -50.45, -117.04};
+
+static void test_cadence13_zero_fill_control_and_computed_source() {
+    std::printf("test_cadence13_zero_fill_control_and_computed_source\n");
+    ta::Lowest lo(10);
+    ta::Lowest lo_osc(10);
+    for (int i = 0; i < 13; ++i) {
+        ta::BarContextScope scope(kXauCallBars[i], 0);
+        const double v = lo.compute(kXauLowAtCalls[i]);
+        const double w = lo_osc.compute(kXauOscAtCalls[i]);
+        if (i == 0) { CHECK(is_na(v)); CHECK(is_na(w)); continue; }
+        CHECK(!is_na(v) && near(v, kXauTvLowestLow[i], 0.051));
+        CHECK(!is_na(w) && near(w, kXauTvLowestOsc[i], 0.006));
+        if (i >= 1 && i <= 9) CHECK(near(v, 0.0));   // a never-written slot in the window reads 0
+        if (i >= 1) CHECK(w < 0.0);                  // the 0 never beats a negative member
+    }
+}
+
+// Leading-na sites at the same cadence (tape out-nafirst): the first 1 / 2 /
+// 5 calls of ta.lowest(sma(close, N), 10) write na. Every zero run ends at
+// bar 83 when the na slot re-enters at k = 1 (src is the only live member),
+// and the stale first valid write returns from bar 109 on, once it is newer
+// than the na slot -- poison 13/13 on all 7 sites (zero-fill 8-10/13, skip
+// 7-10/13). F and G are the sign-mixed sma(close, N) - close twins.
+static const double kNaFirstSrc[5][13] = {
+    {NAN, 2997.9843, 3111.9871, 3316.0614, 3285.6300, 3329.3643, 3357.6014, 3327.4057, 3350.1189, 3355.1350, 3478.2407, 3689.8500, 3964.3786},        // A: sma 14
+    {NAN, NAN, 3086.7670, 3254.7987, 3287.3295, 3303.4298, 3355.1255, 3333.7838, 3343.2762, 3343.9192, 3435.9715, 3649.7668, 3891.3310},              // B: sma 20
+    {NAN, NAN, NAN, NAN, NAN, 3235.7817, 3301.0254, 3322.9830, 3332.4742, 3348.5481, 3376.0111, 3455.1191, 3593.3572},                                // E: sma 59
+    {NAN, NAN, -143.0280, -79.3963, -7.6805, -19.1802, 80.9505, -13.8162, -30.3588, 5.2092, -190.3435, -110.0882, -316.4390},                         // F: sma 20 - close
+    {NAN, NAN, NAN, NAN, -86.4224, -38.3341, 46.4009, -20.1672, -26.5463, 5.3768, -238.9141, -275.7978, -544.8904},                                   // G: sma 46 - close
+};
+static const double kNaFirstTv[5][13] = {
+    {NAN, 2998.00, 0.00, 0.00, 0.00, 0.00, 3357.60, 3327.40, 2998.00, 2998.00, 2998.00, 2998.00, 3112.00},
+    {NAN, NAN, 3086.80, 0.00, 0.00, 0.00, 3355.10, 3333.80, 3086.80, 3086.80, 3086.80, 3086.80, 3086.80},
+    {NAN, NAN, NAN, NAN, NAN, 3235.80, 3301.00, 3323.00, 3332.50, 3348.50, 3376.00, 3235.80, 3235.80},
+    {NAN, NAN, -143.03, -143.03, -143.03, -143.03, 80.95, -13.82, -30.36, -143.03, -190.34, -190.34, -316.44},
+    {NAN, NAN, NAN, NAN, -86.42, -86.42, 46.40, -20.17, -26.55, 5.38, -238.91, -275.80, -544.89},
+};
+static const double kNaFirstTol[5] = {0.051, 0.051, 0.051, 0.0051, 0.0051};   // qty resolution 0.1 / 0.01
+
+static void test_leading_na_site_poison_pin() {
+    std::printf("test_leading_na_site_poison_pin\n");
+    for (int s = 0; s < 5; ++s) {
+        ta::Lowest lo(10);
+        ta::LowestBars lb(10);
+        for (int i = 0; i < 13; ++i) {
+            ta::BarContextScope scope(kXauCallBars[i], 0);
+            const double v = lo.compute(kNaFirstSrc[s][i]);
+            const double k = lb.compute(kNaFirstSrc[s][i]);
+            if (is_na(kNaFirstTv[s][i])) {
+                CHECK(is_na(v));
+                CHECK(is_na(k));
+            } else {
+                CHECK(!is_na(v) && near(v, kNaFirstTv[s][i], kNaFirstTol[s]));
+                CHECK(!is_na(k));
+            }
+            if (s == 0) {
+                // Site A, ta.lowest(sma(close, 14), 10): the bars-since of the
+                // extremum among the non-poisoned slots (derived, no tape).
+                if (i == 1) CHECK(near(k, 0.0));     // bar 18: restart on src (slot 6 behind it never read)
+                if (i == 2) CHECK(near(k, -3.0));    // bar 31: never-written slot 6 = bar 28, the oldest 0 past bar 27's na
+                if (i == 6) CHECK(near(k, 0.0));     // bar 83: the na slot at k = 1, src alone
+                if (i == 8) CHECK(near(k, -3.0));    // bar 109: 2998 lives in slot 7 = bar 106
+                if (i == 12) CHECK(near(k, -9.0));   // bar 161: 3112 in slot 9 = bar 152
+            }
+        }
+    }
+    // Site A, first three calls, spelled out: bar 5 writes na (cache (na, 5)),
+    // bar 18 restarts on 2998 (a rescan would have read the never-written
+    // slot 6 = bar 17 as 0 -- TV says 2998), bar 31 rescans: slots 0..4
+    // (bars 22..26) never written -> 0, bar 27 = slot 5 -> na, poison; bar
+    // 28 = slot 6 never written -> 0 restarts; 2998 (bar 29) and 3112 (bar
+    // 31) do not beat it -> 0.
+    {
+        ta::Lowest lo(10);
+        { ta::BarContextScope scope(5, 0);  CHECK(is_na(lo.compute(na<double>()))); }
+        { ta::BarContextScope scope(18, 0); CHECK(near(lo.compute(2997.9843), 2997.9843)); }
+        { ta::BarContextScope scope(31, 0); CHECK(near(lo.compute(3111.9871), 0.0)); }
+    }
+}
+
+// Replica of the market-logic VFDO-S site (tape out-mlsite, OANDA:XAUUSD 1D
+// 2025-04-01..2026-05-01): osc = resid / stdev(resid, 50) is na for its
+// first ~100 bars; pivot-gated ta.lowest(osc, 11) on pivot-low bars and
+// ta.highest(osc, 11) on pivot-high bars; qty = 100000 + round(v * 1000).
+// 32 calls: 16 na reads (the poisoned cache), one stale aliased read (bar
+// 240 on the highest ring, src 0.7236: the aged cache rescans bars 230..240;
+// bar 227's 1.3252 sits in slot 227 % 12 = 11, which the window addresses as
+// bar 239, k = 1, past the poison of the na written at bar 70 in slot 10) and
+// one true 0 read (bar 273, highest ring: past the na slots the live members
+// are two never-written 0s and src -0.6354, so 0). Poison 32/32; zero-fill
+// 24/32; skip 25/32.
+struct MlCall { int bar; bool low_ring; double osc; double tv; };
+static const MlCall kMlCalls[32] = {
+    {18, false, NAN, NAN},      {25, true, NAN, NAN},       {28, false, NAN, NAN},
+    {35, true, NAN, NAN},       {41, false, NAN, NAN},      {45, true, NAN, NAN},
+    {50, false, NAN, NAN},      {52, true, NAN, NAN},       {57, false, NAN, NAN},
+    {67, true, NAN, NAN},       {70, false, NAN, NAN},      {74, true, NAN, NAN},
+    {80, true, NAN, NAN},       {84, false, NAN, NAN},      {89, true, NAN, NAN},
+    {96, false, NAN, NAN},
+    {104, true, 1.4057, 1.406},  {147, false, 1.5218, 1.522}, {153, true, 1.1918, 1.192},
+    {165, false, 0.9717, 0.972}, {168, true, 1.0785, 1.078},  {177, false, 0.8948, 0.895},
+    {195, false, 4.2483, 4.248}, {198, true, 3.8822, 3.882},  {218, false, 1.1347, 1.135},
+    {220, true, 1.8796, 1.880},  {227, false, 1.3252, 1.325}, {231, true, 1.4513, 1.451},
+    {240, false, 0.7236, 1.325}, {241, true, 0.8939, 0.894},  {255, true, -1.0579, -1.058},
+    {273, false, -0.6354, 0.000},
+};
+
+static void test_market_logic_replica_pin() {
+    std::printf("test_market_logic_replica_pin\n");
+    ta::Lowest lo(11);
+    ta::Highest hi(11);
+    int ok = 0;
+    for (const MlCall& c : kMlCalls) {
+        ta::BarContextScope scope(c.bar, 0);
+        const double v = c.low_ring ? lo.compute(c.osc) : hi.compute(c.osc);
+        const bool hit = is_na(c.tv) ? is_na(v) : (!is_na(v) && near(v, c.tv, 0.0007));
+        CHECK(hit);
+        ok += hit;
+        if (c.bar == 240) CHECK(!is_na(v) && near(v, 1.3252, 1e-6));   // the aliased bar-227 slot, not src 0.7236
+        if (c.bar == 273) CHECK(!is_na(v) && near(v, 0.0));            // a never-written slot beats every negative member
+    }
+    CHECK(ok == 32);
+}
+
+// The *Bars variants under poison (derived from the rule; no tape): the
+// offset is the bars-since of the extremum among the non-poisoned members.
+static void test_bars_variants_under_poison() {
+    std::printf("test_bars_variants_under_poison\n");
+    // Every bar, length 5: {9, 8, na, 7, 2, 1} -> bar 5's live members are
+    // bars 3..5. highest = 7 at bar 3 (-2), lowest = 1 at bar 5 (0). The old
+    // "skip the gap" reading answered 8 at bar 1 (-4) for the highest.
+    {
+        ta::HighestBars hb(5);
+        ta::LowestBars lb(5);
+        const double xs[6] = {9.0, 8.0, na<double>(), 7.0, 2.0, 1.0};
+        double h = na<double>(), l = na<double>();
+        for (int b = 0; b < 6; ++b) {
+            ta::BarContextScope scope(b, 0);
+            h = hb.compute(xs[b]);
+            l = lb.compute(xs[b]);
+            if (b == 2) { CHECK(is_na(h)); CHECK(is_na(l)); }
+        }
+        CHECK(near(h, -2.0));
+        CHECK(near(l, 0.0));
+    }
+    // Same series through a Range (the composites share the ring): bar 5's
+    // range is 7 - 1 = 6 over the live members, not 9 - 1 = 8.
+    {
+        ta::Range r(5);
+        const double xs[6] = {9.0, 8.0, na<double>(), 7.0, 2.0, 1.0};
+        double v = na<double>();
+        for (int b = 0; b < 6; ++b) {
+            ta::BarContextScope scope(b, 0);
+            v = r.compute(xs[b]);
+            if (b == 2) CHECK(is_na(v));
+        }
+        CHECK(near(v, 6.0));
+    }
+    // A leading-na series (the finding-331 stochRSI shape) is unchanged by
+    // the poison: the first live bar is a single-member window.
+    {
+        ta::Stoch st(3);
+        CHECK(is_na(st.compute(na<double>(), na<double>(), na<double>())));
+        CHECK(is_na(st.compute(na<double>(), na<double>(), na<double>())));
+        CHECK(is_na(st.compute(na<double>(), na<double>(), na<double>())));
+        CHECK(is_na(st.compute(50.0, 50.0, 50.0)));            // hi == lo -> division by zero -> na
+        CHECK(near(st.compute(60.0, 60.0, 60.0), 100.0));      // window {50, 60}: (60 - 50) / 10
+    }
+}
+
+// An na source poisons the cache (re-pinned 2026-09-04: the OANDA:XAUUSD 15
+// geometry `ta.lowest(bar_index % 13 == 6 ? na : z, 10)` with the inserted na
+// calls from bar 100 answers na on them, 34/34 -- and every valid call after
+// one answers its own src, which the previous "leave the cache alone" reading
+// only reproduced for a falling series). With a RISING series the old rule
+// rescanned (aged cache) and read the never-written / stale slots; the
+// poisoned cache restarts on src instead.
+static void test_na_source_poisons_the_cache() {
+    std::printf("test_na_source_poisons_the_cache\n");
+    for (int falling = 0; falling < 2; ++falling) {
+        ta::Lowest lo(10);
+        int checked = 0;
+        for (int b = 0; b <= 200; ++b) {
+            ta::BarContextScope scope(b, 0);
+            const bool valid_call = b % 13 == 5;
+            const bool na_call = b >= 100 && b % 13 == 6;
+            if (!valid_call && !na_call) continue;
+            if (na_call) {
+                CHECK(is_na(lo.compute(na<double>())));
+                continue;
+            }
+            const double src = falling ? 3000.0 - b : 3000.0 + b;
+            const double v = lo.compute(src);
+            if (b >= 122) { CHECK(near(v, src)); ++checked; }   // the na call 12 bars earlier poisoned the cache
+        }
+        CHECK(checked == 7);
+    }
     CHECK(!ta::bar_context().installed);
 }
 
@@ -649,7 +922,12 @@ int main() {
     test_cached_extremum_keeps_over_aliased_slot_until_expiry();
     test_new_extremum_precedes_expiry_rescan();
     test_never_written_slots_read_as_zero();
-    test_na_source_answers_na_without_touching_the_cache();
+    test_na_source_poisons_the_cache();
+    test_everybar_na_gap_poisons_the_window();
+    test_cadence13_zero_fill_control_and_computed_source();
+    test_leading_na_site_poison_pin();
+    test_market_logic_replica_pin();
+    test_bars_variants_under_poison();
     std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
     return g_fail ? 1 : 0;
 }

--- a/tests/test_ta_extremes_ring.cpp
+++ b/tests/test_ta_extremes_ring.cpp
@@ -8,7 +8,8 @@
  * call site owns K = length + 1 slots addressed by bar_index % K; a call on
  * bar b writes slot[b % K] = src and returns the extremum over the WRITTEN
  * slots (b - k) % K, k in [0, length). Stale values from earlier executions
- * survive in slots not rewritten, never-written slots are skipped, and the
+ * survive in slots not rewritten, never-written slots read as 0 (pinned
+ * 2026-09-04 on BTCUSDT 1D at cadence 13), and the
  * result is na iff bar_index < length - 1 — NOT until `length` executions.
  *
  *   pin-ring-highest.pine:  if bar_index % 7 == 3
@@ -570,6 +571,40 @@ static void test_new_extremum_precedes_expiry_rescan() {
     CHECK(!ta::bar_context().installed);
 }
 
+
+// --- Never-written slots read as 0 (pinned 2026-09-04, BINANCE:BTCUSDT 1D,
+// `if bar_index % 13 == 5`, K = 11): ta.lowest(low, 10) answers na on the
+// first call (bar 5 < 9), 0 on calls 2..10 while a never-written slot sits
+// in the scanned window, then the stale positive minimum from call 11 on
+// once every residue has been written (TV: 77.3k, 84.5k); ta.highest(-close,
+// 10) mirrors it (0, then negative); ta.highest(high, 10) is unaffected. ----
+static void test_never_written_slots_read_as_zero() {
+    std::printf("test_never_written_slots_read_as_zero\n");
+    ta::Lowest lo(10);
+    ta::Highest hi(10);
+    ta::Highest hneg(10);
+    int call = 0;
+    for (int b = 0; b <= 200; ++b) {
+        ta::BarContextScope scope(b, 0);
+        if (b % 13 != 5) continue;
+        ++call;
+        const double price = 100000.0 + b;         // rising, so every call is a fresh high, never a new low
+        const double l = lo.compute(price);
+        const double h = hi.compute(price);
+        const double n = hneg.compute(-price);
+        if (call == 1) { CHECK(is_na(l)); CHECK(is_na(h)); CHECK(is_na(n)); continue; }
+        CHECK(near(h, price));                     // a rising series: the current high wins
+        if (call <= 10) {                          // residues 5,7,9,0,2,4,6,8,10,1 written so far: a slot in the window is still unwritten
+            CHECK(near(l, 0.0));
+            CHECK(near(n, 0.0));
+        } else {                                   // call 11 writes residue 3: every slot written, stale values return
+            CHECK(!is_na(l) && l > 0.0);
+            CHECK(!is_na(n) && n < 0.0);
+        }
+    }
+    CHECK(call == 16);
+}
+
 int main() {
     test_cadence7_pin();
     test_cadence9_pin();
@@ -580,6 +615,7 @@ int main() {
     test_htf_context_sanity();
     test_cached_extremum_keeps_over_aliased_slot_until_expiry();
     test_new_extremum_precedes_expiry_rescan();
+    test_never_written_slots_read_as_zero();
     std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
     return g_fail ? 1 : 0;
 }

--- a/tests/test_ta_indicators_extras.cpp
+++ b/tests/test_ta_indicators_extras.cpp
@@ -969,7 +969,27 @@ static void test_pivot_point_levels() {
 // Driver
 // ============================================================================
 
+
+// ta.stdev holds its last full-window value on an na input (pinned 2026-09-04,
+// OANDA:XAUUSD 15: stdev(z2, 20) with z2 na on every 5th bar, 310/310 with the
+// hold; the engine used to answer na on those bars).
+static void test_stdev_holds_on_na_input() {
+    std::printf("test_stdev_holds_on_na_input\n");
+    ta::StdDev sd(3);
+    CHECK(is_na(sd.compute(na<double>())));      // before seeding: na
+    CHECK(is_na(sd.compute(1.0)));
+    CHECK(is_na(sd.compute(na<double>())));      // still seeding: na, state untouched
+    CHECK(is_na(sd.compute(2.0)));
+    const double full = sd.compute(3.0);         // window {1,2,3}: population stdev sqrt(2/3)
+    CHECK(!is_na(full) && std::fabs(full - std::sqrt(2.0 / 3.0)) < 1e-12);
+    const double held = sd.compute(na<double>()); // na input: held, window untouched
+    CHECK(!is_na(held) && std::fabs(held - full) < 1e-12);
+    const double next = sd.compute(4.0);         // window {2,3,4}: the na never entered
+    CHECK(!is_na(next) && std::fabs(next - std::sqrt(2.0 / 3.0)) < 1e-12);
+}
+
 int main() {
+    test_stdev_holds_on_na_input();
     test_wma();
     test_hma();
     test_alma();


### PR DESCRIPTION
Round-6 engine candidate `c548e37`, gated PASS against the like-for-like baseline (pr-gate verdict `d71f4d1794ee…`, hard 0 regressions / 0 tolerated, target +24/−0; snapshot `44ef42cb…` vs `de7434f7…`): 98.0% → 98.6% (4132/4190 excellent+strong, +58 tiers, 0 down).

Pinned on TradingView (`lab tv` tapes in the campaign scratchpad, rules in the campaign ledger):
- **Extremes ring** (`ExtremeRing`): never-written slots read 0 for every source kind; a slot written with na poisons the oldest-first rescan and the next newer slot restarts it (answer = extremum over the slots newer than the newest na slot; na iff the newest slot is na); an na write poisons the cache; `na_src_answers_na` retired (contradicted by the every-bar NYSE:F gap tape 20/20).
- **Stop/limit triggers**: the broker tests a resting stop/limit against the bar's OHLC quantized to the tick (nearest) while the level stays raw; fills keep their directional snap; trail legs, stop-limit entries, on-close compares and calc_on_order_fills cursors stay raw; the O→H→L leg order comes from the raw bar.
- **percent_of_equity > 100** goes through the affordability admission like fixed/cash sizing.
- **Native daily security feed** (`strategy_set_native_security_feed`): `request.security(tickerid, "D", …)` on intraday charts serves TradingView's own daily bar when the lane provides it.

Tests: ctest 161/161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dwbd239WT9zfcTLYM5UpUU