### PR TITLE
round 7e: trail fills snap directionally at sub-tick opens, trail_points/offset tick rounding, trail activation on the quantized bar, Pine tolerant compare inside ta.dmi

### DIFF
--- a/include/pineforge/pine_float_compare.hpp
+++ b/include/pineforge/pine_float_compare.hpp
@@ -1,0 +1,67 @@
+#pragma once
+// Pine's relational operators on floats.
+//
+// TradingView compares two finite floats with a fixed ABSOLUTE band: values
+// at most 1e-10 apart are EQUAL (inclusive at exactly 1e-10), independent of
+// magnitude, and strict `<` / `>` are suppressed inside the band. Pinned with
+// `lab tv` on NYSE:F 15m (round 7 family K, 2026-09-05, scratchpad/r7/pins/
+// f15-eps-{abs,rel}, 20 qty-encoded decisions): at m = 11.5, a = m + d vs
+// b = m answers a > b for d = 1e-8 / 1e-9 / 1e-10 (the double diff at 11.5
+// sits one ulp ABOVE 1e-10) and EQUAL for d = 1e-11 .. 1e-14; d = 1e-10 at
+// m = 1, 1000, 100000 answers a > b (diffs 1.0000000827e-10, 1.00044e-10,
+// 1.0186e-10 — all above the band, so it is not relative to |a|); a fixed
+// relative diff 1e-11 is EQUAL at m = 0.01 (1e-13) and 1 (1e-11) but a > b
+// at m = 100 (1e-9), 1e4 and 1e6; 1e-10 vs 0 is EQUAL (inclusive edge),
+// 1.1e-10 vs 0 is a > b, 0.9e-10 vs 0 EQUAL; 11.58-11.565 vs 11.54-11.525
+// (diff 1.78e-15) and 0.1+0.2 vs 0.3 are EQUAL. The codegen lowers every
+// script-level float relational to this predicate (KI-73, visit_expr.py
+// _emit_float_relational); the builtins that decide on two derived doubles
+// (ta.dmi's up > down, ta.percentrank's src[i] <= src) use these helpers so
+// the engine answers the ties TradingView's own builtins answer — the
+// 2025-07-15 19:30Z NYSE:F bar (up = 11.58-11.565, down = 11.54-11.525,
+// both 0.015 in decimal) gives plusDM 0 AND minusDM 0 on TradingView
+// (`lab tv` f15-plusdm-perbar-0714 / f15-dmi-internals-0718), where a strict
+// IEEE compare hands the 0.015 to one side.
+//
+// na (NaN) operands make every relational false, `!=` included, exactly as
+// Pine's na semantics do; infinities compare by value (equal infinities are
+// equal, a finite/infinite pair is ordered).
+#include <cmath>
+
+namespace pineforge {
+
+inline constexpr double kPineFloatEqualityBand = 1e-10;
+
+inline bool pine_float_eq(double a, double b) {
+    if (std::isnan(a) || std::isnan(b)) return false;
+    return a == b
+        || (std::isfinite(a) && std::isfinite(b)
+            && std::fabs(a - b) <= kPineFloatEqualityBand);
+}
+
+inline bool pine_float_ne(double a, double b) {
+    if (std::isnan(a) || std::isnan(b)) return false;
+    return !pine_float_eq(a, b);
+}
+
+inline bool pine_float_gt(double a, double b) {
+    if (std::isnan(a) || std::isnan(b)) return false;
+    return a > b && !pine_float_eq(a, b);
+}
+
+inline bool pine_float_lt(double a, double b) {
+    if (std::isnan(a) || std::isnan(b)) return false;
+    return a < b && !pine_float_eq(a, b);
+}
+
+inline bool pine_float_ge(double a, double b) {
+    if (std::isnan(a) || std::isnan(b)) return false;
+    return a > b || pine_float_eq(a, b);
+}
+
+inline bool pine_float_le(double a, double b) {
+    if (std::isnan(a) || std::isnan(b)) return false;
+    return a < b || pine_float_eq(a, b);
+}
+
+}  // namespace pineforge

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -4356,7 +4356,8 @@ void BacktestEngine::apply_filled_order_to_state(
         // closing trade that no bar-boundary sample ever sees.
         double off = std::isnan(order.trail_offset)
                          ? 0.0
-                         : std::floor(order.trail_offset) * syminfo_mintick_;
+                         : internal::trail_offset_to_ticks(order.trail_offset)
+                               * syminfo_mintick_;
         fold_exit_trail_peak_ = (position_side_ == PositionSide::LONG)
                                     ? fill_price + off
                                     : fill_price - off;
@@ -6239,7 +6240,11 @@ BacktestEngine::FillEvaluation BacktestEngine::evaluate_fill_price(
         if (exit_fill.should_fill) {
             // finding-446: an open-gap fill is the raw bar open; a level
             // fill keeps its directional / limit-or-better snap downstream.
-            fill_price = exit_fill.at_bar_open
+            // A one-shot trail arming AT the open fills at its level
+            // open -/+ 0 (open_is_trail_level): a computed level, snapped
+            // directionally like every other trail fill (AAPL 196.135 ->
+            // 196.13 sell / 193.665 -> 193.67 buy, round 7 family G).
+            fill_price = exit_fill.at_bar_open && !exit_fill.open_is_trail_level
                 ? bar_fill_price(exit_fill.fill_price)
                 : exit_fill.fill_price;
             should_fill = true;

--- a/src/engine_internal.hpp
+++ b/src/engine_internal.hpp
@@ -351,15 +351,21 @@ CrossEventList collect_cross_events(double from_price,
                                                         double trail_level);
 
 // design-stop-tick-rounding: stop and limit crossings are taken on the
-// tick-quantized segment (tick_from -> tick_to), the trail crossing on the raw
-// segment (from -> to); the merged list keeps collect_cross_events's order.
+// tick-quantized segment (tick_from -> tick_to), an ACTIVE trail's level
+// crossing on the raw segment (from -> to); the merged list keeps
+// collect_cross_events's order. design-trail-activation-tick-bar: a dormant
+// exit-at-activation trail's activation level (trail_activation_level, set
+// only when trail_level is NaN) is reached on the tick-quantized segment and
+// reported as the TRAIL event.
 CrossEventList collect_cross_events_split(double from_price,
                                           double to_price,
                                           double tick_from_price,
                                           double tick_to_price,
                                           double stop_level,
                                           double limit_level,
-                                          double trail_level);
+                                          double trail_level,
+                                          double trail_activation_level
+                                              = std::numeric_limits<double>::quiet_NaN());
 
 
 // fill_at_bar_point (optional) reports whether the returned fill price is a

--- a/src/engine_internal.hpp
+++ b/src/engine_internal.hpp
@@ -216,6 +216,16 @@ struct ExitPathFill {
     // level fill keeps its directional snap; price equality cannot tell the
     // two apart when a sub-tick open coincides with a level.
     bool at_bar_open = false;
+    // True when an at_bar_open fill is the trail's LEVEL rather than the raw
+    // print: a one-shot (zero-offset) trail whose activation the open already
+    // sits past arms AT the open with best = open and fills at open -/+ 0 —
+    // a COMPUTED level, so the consumer snaps it directionally (sell floor,
+    // buy ceil) instead of nearest-rounding the bar print. `lab tv`
+    // NASDAQ:AAPL 15m (round 7 family G, scratchpad/r7/pins/scalper-trail-*):
+    // long exit at the 2025-04-22 13:30Z open 196.135 -> TV 196.13 (engine
+    // booked bar_fill_price = 196.14); short exit at the 05-23 13:30Z open
+    // 193.665 -> 193.67.
+    bool open_is_trail_level = false;
     // Where the fill happened on the bar's 4-waypoint synthesized path, in
     // first_touch_position units (0 = open, 1/2 = the extremes, 3 = close;
     // fractional inside a segment). This is the fill's ACTUAL chronology,
@@ -225,6 +235,66 @@ struct ExitPathFill {
     // margin-call slice compares this against the adverse extreme.
     double path_position = std::numeric_limits<double>::quiet_NaN();
 };
+
+
+// ── Trailing-exit tick arithmetic ─────────────────────────────────────
+//
+// TradingView reads strategy.exit's trail_points / trail_offset as TICK
+// COUNTS: trail_points is ceiled WITH a tolerance that swallows floating-
+// point residue — a value computed as close * 0.02 / syminfo.mintick that
+// lands a few ulps past a whole number is that whole number, not the next
+// one — while trail_offset is floored EXACTLY. Pinned with `lab tv` on
+// NYSE:F 15m 2025-04-01..05, short from the 04-02 19:00Z signal (entry
+// 10.11, mintick 0.01; scratchpad/r7/pins/trail-eq-*), each zero-offset
+// exit filling at its activation level:
+//   trail_points 14.00001                -> 14 ticks (9.97)
+//   trail_points 14.0001 / 14.001        -> 15 ticks (9.96)
+//   trail_points 0.14 / syminfo.mintick  (= 14.000000000000002) -> 14 (9.97)
+//   trail_points 14.0000001              -> 14 (9.97)
+//   trail_points 18.2                    -> 19 (9.92)
+//   trail_offset 0.3 / (syminfo.mintick * 10)  (= 2.9999999999999996)
+//     -> 2 ticks (trail_points 18: fills 04-03 14:15Z @9.85 = trough 9.83
+//     + 2t; a tolerant floor would trail 3t and print 9.86)
+// and BINANCE:BTCUSDT 15m short 2025-08-17 23:30Z @117559.99 with
+// trail_points = 117560 * 0.02 / 0.01 = 235120.00000000003: TV exits
+// 08-18 03:30Z @115208.79 (235120 ticks); std::ceil gave 235121 -> .78.
+// The ceil tolerance is bounded in [1e-5, 1e-4) by the 14.00001 / 14.0001
+// pair; 5e-5 sits in the middle. Round 5's sub-tick pins hold: 0.0006 ->
+// 1 tick, offsets 0 / 0.5 / 0.9 -> 0, 1.4 -> 1.
+constexpr double kTrailPointsCeilEps = 5e-5;
+
+inline double trail_points_to_ticks(double trail_points) {
+    return std::ceil(trail_points - kTrailPointsCeilEps);  // NaN stays NaN
+}
+
+inline double trail_offset_to_ticks(double trail_offset) {
+    return std::floor(trail_offset);  // exact; NaN stays NaN
+}
+
+// The broker keeps trailing levels ON the tick grid: an activation level
+// entry -/+ N ticks and a trailing level best -/+ K ticks are tick counts,
+// and a bar extreme landing exactly on the level TOUCHES it. Built in
+// doubles, 10.11 - 21 * 0.01 is 9.899999999999999 — one ulp under the 9.9
+// low — and the inclusive segment test reads it as "not reached" (NYSE:F
+// 15m 2025-04-03 13:45Z, bar O 10.165 H 10.18 L 9.9 C 9.9: TV fills the
+// trail there @9.90, `lab tv` trail-eq-S-off0-tp21; the engine gap-filled
+// the next open @9.89). Materialize a level within a millionth of a tick
+// of the grid as the grid point, spelled the way tick_grid_price
+// (engine.hpp) spells it so it compares EQUAL to a feed print bit for bit;
+// a genuinely sub-tick level (best 196.135 - 1 tick = 196.125) stays raw
+// and takes the directional fill snap downstream.
+inline double snap_trail_level_to_tick_grid(double price, double mintick) {
+    if (std::isnan(price) || !(mintick > 0.0)) return price;
+    const double r = price / mintick;
+    const double k = std::floor(r + 0.5);
+    if (std::abs(r - k) > 1e-6) return price;
+    const double inv = 1.0 / mintick;
+    const double inv_int = std::floor(inv + 0.5);
+    if (inv_int > 0.0 && std::abs(inv - inv_int) <= 1e-6 * inv_int) {
+        return k / inv_int;
+    }
+    return k * mintick;
+}
 
 
 // ── Path-resolution helpers (defined in engine_path_resolve.cpp) ──

--- a/src/engine_path_resolve.cpp
+++ b/src/engine_path_resolve.cpp
@@ -503,11 +503,22 @@ CrossEventList collect_cross_events_split(double from_price,
                                           double tick_to_price,
                                           double stop_level,
                                           double limit_level,
-                                          double trail_level) {
+                                          double trail_level,
+                                          double trail_activation_level) {
     CrossEventList events;
     append_cross_event(&events, tick_from_price, tick_to_price, stop_level, PathCrossKind::STOP);
     append_cross_event(&events, tick_from_price, tick_to_price, limit_level, PathCrossKind::LIMIT);
-    append_cross_event(&events, from_price, to_price, trail_level, PathCrossKind::TRAIL);
+    // An ACTIVE trail's level (running raw best -/+ offset) is crossed on the
+    // raw path; a dormant exit-at-activation trail's ACTIVATION is reached on
+    // the tick-quantized path (design-trail-activation-tick-bar, below). The
+    // two are exclusive per segment (select_exit_segment_levels), so the
+    // list still holds at most one TRAIL event.
+    if (!std::isnan(trail_level)) {
+        append_cross_event(&events, from_price, to_price, trail_level, PathCrossKind::TRAIL);
+    } else {
+        append_cross_event(&events, tick_from_price, tick_to_price,
+                           trail_activation_level, PathCrossKind::TRAIL);
+    }
     sort_cross_events(events);
     return events;
 }
@@ -590,6 +601,38 @@ bool resolve_entry_stop_limit_fill(const Bar& bar,
 
 
 namespace {
+
+// design-trail-activation-tick-bar (round 7 family K): TradingView tests a
+// trailing stop's ACTIVATION against the bar's OHLC quantized to the tick
+// (nearest, floor(p / mintick + 0.5), the round-6 stop / limit trigger rule)
+// while the trail's running best stays the raw print. Pinned with `lab tv`
+// on NYSE:F 15m (scratchpad/r7/pins/f15-trail-0415-{reissue,fixed760,
+// fixed754}, 2025-04-10..18, fixed 100 shares): a short entered 04-15
+// 14:45Z @9.49 with strategy.exit(trail_points = close * 0.008 /
+// syminfo.mintick, trail_offset = 0) re-issued every bar — or a fixed 7.60 /
+// 7.54 ticks, all ceil to 8 -> activation 9.41 — exits on the 15:45Z bar
+// @9.41 in every tape. That bar's raw low is 9.415 (> 9.41: the engine's
+// no-activate, which slid the exit to the 16:45Z low 9.41) and its
+// tick-quantized low is 9.41 (9.415 is 9.41499.. in binary -> floor(941.499
+// + 0.5) = 941), which reaches the activation and, with offset 0, exits
+// one-shot at the level. The boztilkiserhan wma-adx / wma-rsi probes' 1-4
+// bar exit slides (04-15, 06-20, 2026-01-21) and their exitP90 residual are
+// this. The trail's peak / trough path itself stays raw (round 5; the
+// round-6 stopround-xt-L-trail tape: a quantized 14.04 best would have
+// filled 02-20 @14.01 where TradingView exits 02-23 at the open), and so
+// does the open-gap test (unpinned). Same quantizer as
+// BacktestEngine::tick_grid_price, spelled k / (1 / mintick) for decimal
+// ticks so an on-grid level compares equal bit for bit.
+double tick_quantized_price(double price, double mintick) {
+    if (std::isnan(price) || !(mintick > 0.0)) return price;
+    const double k = std::floor(price / mintick + 0.5);
+    const double inv = 1.0 / mintick;
+    const double inv_int = std::floor(inv + 0.5);
+    if (inv_int > 0.0 && std::abs(inv - inv_int) <= 1e-6 * inv_int) {
+        return k / inv_int;
+    }
+    return k * mintick;
+}
 
 // Per-bar trail state used while walking the synthesized OHLC path for an EXIT.
 // activation_level is the absolute price at which the trail arms;
@@ -702,8 +745,12 @@ ExitTrailState compute_exit_trail_state(bool is_long, double trail_points,
     // running after it activates.
     const bool one_shot_zero_offset_trail = zero_tick_offset;
     if (!one_shot_zero_offset_trail && !std::isnan(s.best_price)) {
-        s.trail_active = is_long ? (s.best_price >= s.activation_level)
-                                 : (s.best_price <= s.activation_level);
+        // The carried best is the raw running extreme; the activation test
+        // reads it tick-quantized (design-trail-activation-tick-bar), as the
+        // broker read the bars that produced it.
+        const double tick_best = tick_quantized_price(s.best_price, syminfo_mintick);
+        s.trail_active = is_long ? (tick_best >= s.activation_level)
+                                 : (tick_best <= s.activation_level);
     }
     return s;
 }
@@ -756,16 +803,20 @@ bool try_exit_open_gap_fill(const Bar& bar, double tick_open, bool is_long,
 // Trigger levels for one OHLC-path segment. Stops fire on against-direction
 // segments (long stops on falling, short stops on rising); limits fire on
 // with-direction segments. The trail level is the active one on stop-firing
-// segments; on limit-firing segments it can still arm if the segment crosses
-// up/down through the activation level for an exit-at-activation trail.
+// segments (crossed on the raw path); on limit-firing segments a dormant
+// exit-at-activation trail can still fire if the segment reaches its
+// activation level, which is reported separately because it is tested on
+// the tick-quantized path (design-trail-activation-tick-bar).
 void select_exit_segment_levels(bool is_long, bool rising, bool falling,
                                 double stop_price, double limit_price,
                                 const ExitTrailState& trail,
                                 double* stop_level, double* limit_level,
-                                double* trail_level) {
+                                double* trail_level,
+                                double* trail_activation_level) {
     *stop_level = std::numeric_limits<double>::quiet_NaN();
     *limit_level = std::numeric_limits<double>::quiet_NaN();
     *trail_level = std::numeric_limits<double>::quiet_NaN();
+    *trail_activation_level = std::numeric_limits<double>::quiet_NaN();
     const bool stop_seg = is_long ? falling : rising;
     const bool limit_seg = is_long ? rising : falling;
     if (stop_seg) {
@@ -774,28 +825,31 @@ void select_exit_segment_levels(bool is_long, bool rising, bool falling,
     } else if (limit_seg) {
         *limit_level = limit_price;
         if (trail.exits_at_activation && !trail.trail_active) {
-            *trail_level = trail.activation_level;
+            *trail_activation_level = trail.activation_level;
         }
     }
 }
 
 // After a segment is walked without a fill, advance trail's best price (only
-// on with-direction segments) and arm the trail once best crosses activation.
+// on with-direction segments, the RAW segment end) and arm the trail once the
+// tick-quantized segment end reaches the activation
+// (design-trail-activation-tick-bar).
 void update_exit_trail_state(bool is_long, bool rising, bool falling,
-                             double to_price, ExitTrailState* trail) {
+                             double to_price, double tick_to_price,
+                             ExitTrailState* trail) {
     if (!trail->has_trail) return;
     if (is_long && rising) {
         if (std::isnan(trail->best_price) || to_price > trail->best_price) {
             trail->best_price = to_price;
         }
-        if (!trail->trail_active && trail->best_price >= trail->activation_level) {
+        if (!trail->trail_active && tick_to_price >= trail->activation_level) {
             trail->trail_active = true;
         }
     } else if (!is_long && falling) {
         if (std::isnan(trail->best_price) || to_price < trail->best_price) {
             trail->best_price = to_price;
         }
-        if (!trail->trail_active && trail->best_price <= trail->activation_level) {
+        if (!trail->trail_active && tick_to_price <= trail->activation_level) {
             trail->trail_active = true;
         }
     }
@@ -1101,13 +1155,15 @@ ExitPathFill resolve_exit_path_fill(const Bar& bar,
         double stop_level;
         double limit_level;
         double trail_level;
+        double trail_activation_level;
         select_exit_segment_levels(is_long, rising, falling,
                                    stop_price, limit_price, trail,
-                                   &stop_level, &limit_level, &trail_level);
+                                   &stop_level, &limit_level, &trail_level,
+                                   &trail_activation_level);
 
         CrossEventList events = collect_cross_events_split(
             from_price, to_price, tick_from_price, tick_to_price,
-            stop_level, limit_level, trail_level);
+            stop_level, limit_level, trail_level, trail_activation_level);
         if (events.n != 0) {
             fill.should_fill = true;
             fill.fill_price = events.ev[0].price;
@@ -1117,8 +1173,10 @@ ExitPathFill resolve_exit_path_fill(const Bar& bar,
             // Interpolate against the FULL segment (path[seg_idx-1] ->
             // path[seg_idx]) even when a mid-path cursor truncated it, so
             // the scale matches first_touch_position's exactly. A stop /
-            // limit crossing is placed on the tick path it was found on.
-            const bool on_tick_path = !fill.is_trail;
+            // limit crossing — and a dormant trail's activation reach — is
+            // placed on the tick path it was found on; an active trail's
+            // level crossing on the raw path.
+            const bool on_tick_path = !fill.is_trail || std::isnan(trail_level);
             const double seg_origin = on_tick_path ? tick_path[seg_idx - 1]
                                                    : path[seg_idx - 1];
             const double seg_end = on_tick_path ? tick_to_price : to_price;
@@ -1131,7 +1189,8 @@ ExitPathFill resolve_exit_path_fill(const Bar& bar,
             return fill;
         }
 
-        update_exit_trail_state(is_long, rising, falling, to_price, &trail);
+        update_exit_trail_state(is_long, rising, falling, to_price,
+                                tick_to_price, &trail);
     }
 
     return fill;

--- a/src/engine_path_resolve.cpp
+++ b/src/engine_path_resolve.cpp
@@ -601,6 +601,7 @@ struct ExitTrailState {
     double activation_level = std::numeric_limits<double>::quiet_NaN();
     double trail_offset_price = std::numeric_limits<double>::quiet_NaN();
     double best_price = std::numeric_limits<double>::quiet_NaN();
+    double mintick = std::numeric_limits<double>::quiet_NaN();
     bool has_trail = false;
     bool trail_active = false;
     bool exits_at_activation = false;
@@ -608,10 +609,13 @@ struct ExitTrailState {
 
 // Initialize per-bar trail state from the strategy.exit parameters.
 // trail_points is interpreted as ticks (TV ceils to next whole tick before
-// applying), so the activation level lands on a mintick boundary AWAY from
-// entry. The engine previously kept the raw float and rounded the activation
-// level to nearest mintick at fill time, which produced a 1-tick-toward-entry
-// bias on roughly 40% of community/scalping-strategy trades.
+// applying — with the kTrailPointsCeilEps tolerance, see engine_internal.hpp),
+// so the activation level lands on a mintick boundary AWAY from entry. The
+// engine previously kept the raw float and rounded the activation level to
+// nearest mintick at fill time, which produced a 1-tick-toward-entry bias
+// on roughly 40% of community/scalping-strategy trades. The level itself
+// is materialized on the tick grid (snap_trail_level_to_tick_grid) so a bar
+// extreme sitting exactly on it counts as reached.
 ExitTrailState compute_exit_trail_state(bool is_long, double trail_points,
                                         double trail_price,
                                         double trail_offset, double entry_price,
@@ -624,14 +628,16 @@ ExitTrailState compute_exit_trail_state(bool is_long, double trail_points,
     // level two different ways. trail_points takes precedence if both are set.
     s.has_trail = !std::isnan(trail_points) || !std::isnan(trail_price);
     s.best_price = trail_best_start;
+    s.mintick = syminfo_mintick;
     if (!s.has_trail) {
         return s;
     }
     if (!std::isnan(trail_points)) {
-        const double trail_ticks = std::ceil(trail_points);
-        s.activation_level = is_long
-            ? (entry_price + trail_ticks * syminfo_mintick)
-            : (entry_price - trail_ticks * syminfo_mintick);
+        const double trail_ticks = trail_points_to_ticks(trail_points);
+        s.activation_level = snap_trail_level_to_tick_grid(
+            is_long ? (entry_price + trail_ticks * syminfo_mintick)
+                    : (entry_price - trail_ticks * syminfo_mintick),
+            syminfo_mintick);
     } else {
         // Absolute activation price level (no entry-relative tick rounding).
         s.activation_level = trail_price;
@@ -664,7 +670,7 @@ ExitTrailState compute_exit_trail_state(bool is_long, double trail_points,
     // 2025-03-31 03:45Z @1.08330, atr*2 ~ 0.0006 "ticks" -> activation
     // ceil -> 1 tick = 1.08329, offset floor -> 0; exit bar O 1.08330
     // L 1.08314: TV 1.08329 (the activation), engine 1.08314 (the low).
-    const double trail_offset_ticks = std::floor(trail_offset);  // NaN stays NaN
+    const double trail_offset_ticks = trail_offset_to_ticks(trail_offset);  // NaN stays NaN
     const bool zero_tick_offset = (trail_offset_ticks == 0.0);   // explicit [0, 1)
     if (!std::isnan(trail_offset_ticks) && !zero_tick_offset) {
         s.trail_offset_price = trail_offset_ticks * syminfo_mintick;
@@ -716,8 +722,13 @@ double active_exit_trail_level(const ExitTrailState& s, bool is_long) {
     if (std::isnan(s.trail_offset_price)) {
         return s.activation_level;
     }
-    return is_long ? (s.best_price - s.trail_offset_price)
-                   : (s.best_price + s.trail_offset_price);
+    // best -/+ K ticks is a tick count too: 9.89 + 1 tick must equal the
+    // 9.90 high that touches it (NYSE:F 15m 2025-04-03 14:00Z, `lab tv`
+    // trail-eq-S-off1: TV fills @9.90 on that bar).
+    return snap_trail_level_to_tick_grid(
+        is_long ? (s.best_price - s.trail_offset_price)
+                : (s.best_price + s.trail_offset_price),
+        s.mintick);
 }
 
 // Open-bar gap shortcut for non-entry bars: if bar.open already breaches an
@@ -732,21 +743,33 @@ bool try_exit_open_gap_fill(const Bar& bar, double tick_open, bool is_long,
                             const ExitTrailState& trail,
                             ExitPathFill* out_fill) {
     const double trail_level = active_exit_trail_level(trail, is_long);
-    auto fill_at_open = [&](bool is_limit) {
+    auto fill_at_open = [&](bool is_limit, bool trail_level_at_open = false) {
         out_fill->should_fill = true;
         out_fill->fill_price = bar.open;
         out_fill->is_limit = is_limit;
         out_fill->at_bar_open = true;
+        out_fill->open_is_trail_level = trail_level_at_open;
         return true;
     };
+    // An exit-at-activation trail whose activation the open already sits
+    // past (in the favourable direction) ARMS at the open with best = open
+    // and fires at open -/+ 0: that price is the trail's LEVEL, not a print
+    // the order gapped through, so it is flagged for the directional level
+    // snap (sub-tick open 196.135 -> 196.13 for a long exit; the raw-print
+    // nearest rounding printed 196.14). A trail the open gaps through in the
+    // ADVERSE direction (first test) keeps the raw-print booking.
     if (is_long) {
         if (!std::isnan(trail_level) && bar.open <= trail_level) return fill_at_open(false);
-        if (trail.exits_at_activation && bar.open >= trail.activation_level) return fill_at_open(false);
+        if (trail.exits_at_activation && bar.open >= trail.activation_level) {
+            return fill_at_open(false, /*trail_level_at_open=*/true);
+        }
         if (has_stop && tick_open <= stop_price) return fill_at_open(false);
         if (has_limit && tick_open >= limit_price) return fill_at_open(true);
     } else {
         if (!std::isnan(trail_level) && bar.open >= trail_level) return fill_at_open(false);
-        if (trail.exits_at_activation && bar.open <= trail.activation_level) return fill_at_open(false);
+        if (trail.exits_at_activation && bar.open <= trail.activation_level) {
+            return fill_at_open(false, /*trail_level_at_open=*/true);
+        }
         if (has_stop && tick_open >= stop_price) return fill_at_open(false);
         if (has_limit && tick_open <= limit_price) return fill_at_open(true);
     }

--- a/src/ta_misc.cpp
+++ b/src/ta_misc.cpp
@@ -9,6 +9,7 @@
 
 #include <pineforge/ta.hpp>
 #include <pineforge/na.hpp>
+#include <pineforge/pine_float_compare.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -21,15 +22,10 @@ namespace ta {
 
 namespace {
 
-constexpr double kPineFloatEqualityBand = 1e-10;
-
+// Pine's tolerant `<=` (pine_float_compare.hpp): the band that used to live
+// here is the engine-wide constant now that ta.dmi decides on it too.
 bool percentrank_less_equal(double lhs, double rhs) {
-    if (is_na(lhs) || is_na(rhs)) return false;
-    const bool equal =
-        lhs == rhs ||
-        (std::isfinite(lhs) && std::isfinite(rhs) &&
-         std::fabs(lhs - rhs) <= kPineFloatEqualityBand);
-    return lhs < rhs || equal;
+    return pine_float_le(lhs, rhs);
 }
 
 }  // namespace

--- a/src/ta_volatility_trend.cpp
+++ b/src/ta_volatility_trend.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <pineforge/ta.hpp>
+#include <pineforge/pine_float_compare.hpp>
 #include <pineforge/na.hpp>
 
 #include <algorithm>
@@ -282,8 +283,20 @@ DMIResult DMI::compute(double high, double low, double close) {
     double up_move = high - prev_high_;
     double down_move = prev_low_ - low;
 
-    double plus_dm = (up_move > down_move && up_move > 0.0) ? up_move : 0.0;
-    double minus_dm = (down_move > up_move && down_move > 0.0) ? down_move : 0.0;
+    // Pine's `up > down and up > 0` — the TOLERANT relational (|a - b| <=
+    // 1e-10 is equal, pine_float_compare.hpp), not IEEE strict: on the
+    // NYSE:F 15m 2025-07-15 19:30Z bar up = 11.58 - 11.565 and down = 11.54
+    // - 11.525 are both 0.015 in decimal, 1.78e-15 apart in doubles, and
+    // TradingView's ta.dmi books plusDM = minusDM = 0 (`lab tv`
+    // f15-plusdm-perbar-0714 / f15-dmi-internals-0718: TV rma(plusDM)
+    // 0.006907 vs the strict model's 0.006939, +DI 16.92562 vs 17.00417,
+    // ADX 24.22 vs 23.57 at the 07-18 14:15Z signal — round 7 family K,
+    // boztilkiserhan wma-adx-trailing). One bar's plusDM moves +DI for
+    // weeks, so the strict compare fired a whole ADX > 24 short late.
+    double plus_dm = (pine_float_gt(up_move, down_move)
+                      && pine_float_gt(up_move, 0.0)) ? up_move : 0.0;
+    double minus_dm = (pine_float_gt(down_move, up_move)
+                       && pine_float_gt(down_move, 0.0)) ? down_move : 0.0;
 
     // True range (Pine / ta.tr: max(high-low, |high-prev_close|, |low-prev_close|))
     double tr = std::max({high - low,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -157,6 +157,7 @@ set(TEST_SOURCES
     test_range_end_close
     test_close_id_retires_ledger
     test_trail_open_arm_subtick_offset
+    test_trail_fill_snap
     test_session_predicates_daily_chart
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -157,6 +157,7 @@ set(TEST_SOURCES
     test_range_end_close
     test_close_id_retires_ledger
     test_trail_open_arm_subtick_offset
+    test_trail_activation_tick_bar
     test_session_predicates_daily_chart
 )
 

--- a/tests/test_dmi_parity.cpp
+++ b/tests/test_dmi_parity.cpp
@@ -1,7 +1,9 @@
 #include <cmath>
 #include <cstdio>
+#include <limits>
 #include <pineforge/ta.hpp>
 #include <pineforge/na.hpp>
+#include <pineforge/pine_float_compare.hpp>
 
 using namespace pineforge;
 
@@ -59,10 +61,125 @@ static void test_dmi_recompute_prev_close_consistent() {
     CHECK(near(r1.adx, r2.adx));
 }
 
+// --- Pine's tolerant relational inside ta.dmi (round 7 family K) ----------
+//
+// TradingView's `up > down` / `down > up` / `up > 0` inside ta.dmi are Pine
+// float relationals: |a - b| <= 1e-10 is EQUAL (inclusive, absolute), so an
+// exact-decimal tie books NEITHER directional movement. Pinned on NYSE:F 15m
+// (`lab tv` f15-plusdm-perbar-0714, one qty-encoded lot per bar over
+// 2025-07-14..18; f15-dmi-internals-0718 / f15-wma-adx-sense-0718 for the
+// smoothed terms): the 07-15 19:30Z bar (prev 19:15Z h 11.565 l 11.54;
+// 19:30Z h 11.58 l 11.525) has up = 11.58 - 11.565 and down = 11.54 - 11.525,
+// both 0.015 in decimal and 1.78e-15 apart as doubles; TV's plusDM is 0
+// (qty 1 = round(0 * 1e6) + 1) where the strict compare booked 0.015, and
+// TV's rma(plusDM, 18) at 07-18 14:15Z is 0.006907 (strict model 0.006939),
+// +DI 16.92562 (17.00417), ADX 24.22236 (23.571) — the bar that fires the
+// boztilkiserhan ADX > 24 short on TV only.
+static void test_dmi_exact_decimal_tie_books_neither_dm() {
+    std::printf("test_dmi_exact_decimal_tie_books_neither_dm\n");
+    // di_length 1: rma(1) is the value itself, so +DI / -DI read the bar's
+    // own plusDM / minusDM over its true range.
+    ta::DMI dmi(1, 1);
+    dmi.compute(11.565, 11.54, 11.545);            // 2025-07-15 19:15Z
+    ta::DMIResult r = dmi.compute(11.58, 11.525, 11.575);  // 19:30Z
+    // The strict compare hands 0.015 to one side (here up > down in IEEE:
+    // 11.58 - 11.565 = 0.015000000000000568 > 11.54 - 11.525 =
+    // 0.014999999999998792); Pine's tolerant compare books a tie.
+    CHECK((11.58 - 11.565) != (11.54 - 11.525));
+    CHECK((r.diplus == 0.0));
+    CHECK((r.diminus == 0.0));
+    CHECK((r.adx == 0.0));
+}
+
+static void test_dmi_clear_difference_is_unchanged() {
+    std::printf("test_dmi_clear_difference_is_unchanged\n");
+    // Control: up = 0.025, down = 0.015 -> plusDM 0.025, minusDM 0; TR =
+    // max(11.59 - 11.525, |11.59 - 11.545|, |11.525 - 11.545|) = 0.065.
+    ta::DMI dmi(1, 1);
+    dmi.compute(11.565, 11.54, 11.545);
+    ta::DMIResult r = dmi.compute(11.59, 11.525, 11.575);
+    CHECK(near(r.diplus, 100.0 * (11.59 - 11.565) / (11.59 - 11.525), 1e-9));
+    CHECK((r.diminus == 0.0));
+    CHECK(near(r.adx, 100.0, 1e-9));
+    // And the mirror: down clearly larger -> minusDM only.
+    ta::DMI dmi2(1, 1);
+    dmi2.compute(11.565, 11.54, 11.545);
+    ta::DMIResult r2 = dmi2.compute(11.575, 11.51, 11.52);
+    CHECK((r2.diplus == 0.0));
+    CHECK(near(r2.diminus, 100.0 * (11.54 - 11.51) / (11.575 - 11.51), 1e-9));
+}
+
+static void test_dmi_up_within_band_of_zero_is_not_up() {
+    std::printf("test_dmi_up_within_band_of_zero_is_not_up\n");
+    // `up > 0` is tolerant too: a 5e-11 up-move (sub-band) is no movement,
+    // and with down = 0 the up/down pair is a tie as well -> both 0.
+    ta::DMI dmi(1, 1);
+    dmi.compute(10.0, 9.0, 9.5);
+    ta::DMIResult r = dmi.compute(10.0 + 5e-11, 9.0, 9.5);
+    CHECK((10.0 + 5e-11) - 10.0 > 0.0);   // strictly positive in IEEE
+    CHECK((r.diplus == 0.0));
+    CHECK((r.diminus == 0.0));
+    // 1.5e-10 is outside the band: booked.
+    ta::DMI dmi2(1, 1);
+    dmi2.compute(10.0, 9.0, 9.5);
+    ta::DMIResult r2 = dmi2.compute(10.0 + 1.5e-10, 9.0, 9.5);
+    CHECK(r2.diplus > 0.0);
+    CHECK((r2.diminus == 0.0));
+}
+
+// The band itself, replayed from the two `lab tv` sensor tapes on NYSE:F 15m
+// 2025-07-10..18 (scratchpad/r7/pins/f15-eps-abs / f15-eps-rel, qty = 1000 +
+// 100*(a>b) + 10*(a==b) + (a<b) + 10000*k): 20/20 decisions.
+static void test_pine_float_compare_band_replays_the_sensor_tapes() {
+    std::printf("test_pine_float_compare_band_replays_the_sensor_tapes\n");
+    auto code = [](double a, double b) {
+        return 100 * (pine_float_gt(a, b) ? 1 : 0)
+             + 10 * (pine_float_eq(a, b) ? 1 : 0)
+             + (pine_float_lt(a, b) ? 1 : 0);
+    };
+    // abs: a = m + d, b = m.
+    const double m = 11.5;
+    CHECK(code(m + 1e-8, m) == 100);     // k0
+    CHECK(code(m + 1e-9, m) == 100);     // k1
+    CHECK(code(m + 1e-10, m) == 100);    // k2: the double diff is 1e-10 + 1 ulp
+    CHECK(code(m + 1e-11, m) == 10);     // k3
+    CHECK(code(m + 1e-12, m) == 10);     // k4
+    CHECK(code(m + 1e-13, m) == 10);     // k5
+    CHECK(code(m + 1e-14, m) == 10);     // k6
+    CHECK(code(1.0 + 1e-10, 1.0) == 100);        // k7 (diff 1.0000000827e-10)
+    CHECK(code(1000.0 + 1e-10, 1000.0) == 100);  // k8 (1.00044e-10)
+    CHECK(code(100000.0 + 1e-10, 100000.0) == 100);  // k9 (1.0186e-10)
+    // rel: a fixed relative diff 1e-11 is absolute-banded, not relative.
+    CHECK(code(0.01 * (1 + 1e-11), 0.01) == 10);         // k0 diff 1e-13
+    CHECK(code(1.0 * (1 + 1e-11), 1.0) == 10);           // k1 diff 1e-11
+    CHECK(code(100.0 * (1 + 1e-11), 100.0) == 100);      // k2 diff 1e-9
+    CHECK(code(10000.0 * (1 + 1e-11), 10000.0) == 100);  // k3
+    CHECK(code(1000000.0 * (1 + 1e-11), 1000000.0) == 100);  // k4
+    CHECK(code(11.58 - 11.565, 11.54 - 11.525) == 10);   // k5: the DMI tie
+    CHECK(code(0.1 + 0.2, 0.3) == 10);                   // k6
+    CHECK(code(1e-10, 0.0) == 10);                       // k7: inclusive edge
+    CHECK(code(1.1e-10, 0.0) == 100);                    // k8
+    CHECK(code(0.9e-10, 0.0) == 10);                     // k9
+    // na makes every relational false, != included.
+    CHECK(!pine_float_gt(na<double>(), 1.0));
+    CHECK(!pine_float_lt(1.0, na<double>()));
+    CHECK(!pine_float_eq(na<double>(), na<double>()));
+    CHECK(!pine_float_ne(na<double>(), 1.0));
+    CHECK(pine_float_ge(1.0 + 1e-11, 1.0) && pine_float_le(1.0 + 1e-11, 1.0));
+    CHECK(pine_float_ne(1.0 + 1.1e-10, 1.0));
+    // Infinities compare by value.
+    const double inf = std::numeric_limits<double>::infinity();
+    CHECK(pine_float_eq(inf, inf) && pine_float_gt(inf, 1.0) && pine_float_lt(-inf, inf));
+}
+
 int main() {
     test_dmi_first_bar_returns_na();
     test_dmi_true_range_uses_prev_close();
     test_dmi_recompute_prev_close_consistent();
+    test_dmi_exact_decimal_tie_books_neither_dm();
+    test_dmi_clear_difference_is_unchanged();
+    test_dmi_up_within_band_of_zero_is_not_up();
+    test_pine_float_compare_band_replays_the_sensor_tapes();
     std::printf("dmi_parity: %d passed, %d failed\n", tests_passed, tests_failed);
     return tests_failed > 0 ? 1 : 0;
 }

--- a/tests/test_native_security_feed.cpp
+++ b/tests/test_native_security_feed.cpp
@@ -319,6 +319,174 @@ void test_overnight_cme_session_labels_by_session_day() {
 
 }  // namespace
 
+// ── the tuple form: [o, h, l, c, v] = request.security(tickerid, tf, [open,
+// high, low, close, volume]) reads the same native row ────────────────────
+//
+// Round 7 family K (mukhlisilahi universal-backtest-pro NYSE:F@15, campaign
+// note log-20260905t084530z-66c3f27e): the probe's chart EMAs run on the
+// CLOSE element of a five-field tuple request whose timeframe is an
+// input.timeframe("D") variable. The codegen lowers the tuple body to one
+// evaluator that assigns every element from the completed bucket
+// (`_req_sec_0_3 = bar.close`), so the substitution the scalar path gets in
+// feed_security_input applies to it unchanged — pinned here on the registry
+// NYSE:F 15m bars of 2025-04-22 / 04-23 (feed 80f404ae85ef) against the
+// exchange's own 1D rows (feed e3dd3a88e85b): 04-22 closes 9.65 where the
+// last 15m print is 9.655; 04-23 is 9.835 / 10.0054 / 9.71 / 9.78 /
+// 158,691,527 where the aggregate reads 9.83 / 10.00 / 9.715 / 9.765.
+// (The probe's own runs never had the feed: the harness routes the native
+// daily candidate only for a LITERAL "D"/"1D" timeframe argument —
+// pineforge-lab verify_routing.py executable_uses_daily_security — so an
+// input-bound timeframe kept the aggregate. That is the harness's fix.)
+namespace {
+
+constexpr int64_t kApr22_1330Z = 1745328600000LL;  // 2025-04-22 13:30Z
+constexpr int64_t kApr23_1330Z = 1745415000000LL;  // 2025-04-23 13:30Z
+
+Bar f15(double o, double h, double l, double c, double v) {
+    return Bar{o, h, l, c, v, 0};
+}
+
+// NYSE:F 15m, the two full sessions (26 bars each), registry prints.
+std::vector<Bar> f15_apr22_apr23() {
+    std::vector<Bar> d1 = {
+        f15(9.55, 9.635, 9.53, 9.605, 427205), f15(9.605, 9.63, 9.59, 9.59, 219496),
+        f15(9.59, 9.595, 9.55, 9.56, 218153), f15(9.56, 9.595, 9.54, 9.57, 306707),
+        f15(9.56, 9.62, 9.56, 9.615, 155463), f15(9.61, 9.615, 9.58, 9.605, 174014),
+        f15(9.61, 9.67, 9.61, 9.665, 283781), f15(9.67, 9.67, 9.625, 9.63, 119196),
+        f15(9.635, 9.66, 9.61, 9.615, 109087), f15(9.615, 9.66, 9.61, 9.66, 186877),
+        f15(9.655, 9.7, 9.655, 9.675, 333614), f15(9.67, 9.71, 9.65, 9.695, 239144),
+        f15(9.69, 9.72, 9.69, 9.705, 168025), f15(9.705, 9.705, 9.68, 9.7, 220522),
+        f15(9.69, 9.695, 9.63, 9.63, 287554), f15(9.635, 9.64, 9.535, 9.545, 414666),
+        f15(9.55, 9.6, 9.53, 9.6, 175623), f15(9.605, 9.605, 9.565, 9.565, 75129),
+        f15(9.56, 9.62, 9.56, 9.615, 112723), f15(9.61, 9.64, 9.61, 9.63, 158776),
+        f15(9.625, 9.64, 9.62, 9.62, 86466), f15(9.62, 9.65, 9.62, 9.65, 122109),
+        f15(9.64, 9.65, 9.63, 9.63, 64055), f15(9.64, 9.64, 9.605, 9.615, 166832),
+        f15(9.61, 9.665, 9.61, 9.66, 220974), f15(9.65, 9.67, 9.62, 9.655, 672067),
+    };
+    std::vector<Bar> d2 = {
+        f15(9.83, 9.93, 9.81, 9.9, 914063), f15(9.895, 10, 9.86, 9.895, 1019468),
+        f15(9.9, 9.955, 9.85, 9.895, 704662), f15(9.9, 9.92, 9.85, 9.9, 185224),
+        f15(9.9, 9.92, 9.86, 9.89, 235711), f15(9.89, 9.895, 9.86, 9.88, 153999),
+        f15(9.875, 9.9, 9.825, 9.9, 417687), f15(9.895, 9.895, 9.81, 9.83, 485316),
+        f15(9.835, 9.87, 9.77, 9.835, 363176), f15(9.84, 9.845, 9.75, 9.785, 412994),
+        f15(9.785, 9.8, 9.755, 9.77, 218683), f15(9.775, 9.775, 9.715, 9.765, 164273),
+        f15(9.77, 9.835, 9.765, 9.83, 307265), f15(9.82, 9.835, 9.8, 9.835, 257656),
+        f15(9.83, 9.87, 9.77, 9.865, 357318), f15(9.865, 9.885, 9.855, 9.86, 193816),
+        f15(9.86, 9.865, 9.81, 9.84, 155121), f15(9.845, 9.89, 9.835, 9.88, 280372),
+        f15(9.875, 9.9, 9.85, 9.88, 248374), f15(9.88, 9.895, 9.83, 9.835, 146731),
+        f15(9.84, 9.87, 9.83, 9.83, 91255), f15(9.835, 9.84, 9.81, 9.81, 53131),
+        f15(9.815, 9.835, 9.8, 9.81, 116294), f15(9.81, 9.81, 9.75, 9.755, 165863),
+        f15(9.76, 9.785, 9.755, 9.77, 222441), f15(9.77, 9.795, 9.755, 9.765, 536554),
+    };
+    std::vector<Bar> chart;
+    for (std::size_t i = 0; i < d1.size(); ++i) {
+        d1[i].timestamp = kApr22_1330Z + static_cast<int64_t>(i) * kQuarter;
+        chart.push_back(d1[i]);
+    }
+    for (std::size_t i = 0; i < d2.size(); ++i) {
+        d2[i].timestamp = kApr23_1330Z + static_cast<int64_t>(i) * kQuarter;
+        chart.push_back(d2[i]);
+    }
+    return chart;
+}
+
+// TradingView's own NYSE:F daily rows for the two sessions.
+const Bar kNativeApr22{9.55, 9.72, 9.53, 9.65, 121387081.0, kApr22_1330Z};
+const Bar kNativeApr23{9.835, 10.0054, 9.71, 9.78, 158691527.0, kApr23_1330Z};
+
+// The generated strategy's shape for `[o, h, l, c, v] = request.security(
+// syminfo.tickerid, tf_input, [open, high, low, close, volume])`: one
+// evaluator assigning the five members from the bucket it is handed, the
+// timeframe string an input value ("D" is input.timeframe's default; "1D"
+// is what an exported inputs.json spells).
+class TupleProbe final : public BacktestEngine {
+public:
+    explicit TupleProbe(std::string tf) : tf_(std::move(tf)) {}
+    struct Row { double o, h, l, c, v; };
+    double o_ = na<double>(), h_ = na<double>(), l_ = na<double>(),
+           c_ = na<double>(), v_ = na<double>();
+    std::vector<Row> at_chart_close;
+
+    void configure_security_evaluators() override {
+        security_eval_states_.clear();
+        register_security_eval(0, tf_, input_tf_, false, false);
+    }
+    void evaluate_security(int sec_id, const Bar& bar, bool) override {
+        if (sec_id != 0) return;
+        o_ = bar.open; h_ = bar.high; l_ = bar.low; c_ = bar.close; v_ = bar.volume;
+    }
+    void on_bar(const Bar&) override {
+        at_chart_close.push_back({o_, h_, l_, c_, v_});
+    }
+
+private:
+    std::string tf_;
+};
+
+bool row_is(const TupleProbe::Row& r, const Bar& b) {
+    return r.o == b.open && r.h == b.high && r.l == b.low && r.c == b.close
+        && r.v == b.volume;
+}
+
+}  // namespace
+
+void test_tuple_request_reads_the_native_daily_row() {
+    for (const char* tf : {"D", "1D"}) {
+        std::vector<Bar> chart = f15_apr22_apr23();
+        const Bar daily[] = {kNativeApr22, kNativeApr23};
+        TupleProbe probe(tf);
+        strategy_set_syminfo_timezone(
+            static_cast<pf_strategy_t>(&probe), "America/New_York");
+        strategy_set_syminfo_session(
+            static_cast<pf_strategy_t>(&probe), "0930-1600");
+        assert(strategy_set_native_security_feed(
+            static_cast<pf_strategy_t>(&probe), "D",
+            reinterpret_cast<const pf_bar_t*>(daily), 2) == 0);
+        probe.run(chart.data(), static_cast<int>(chart.size()), "15", "15",
+                  false, 4, MagnifierDistribution::ENDPOINTS);
+        assert(probe.last_error().empty());
+        assert(probe.at_chart_close.size() == 52);
+        // na until the first daily completion (the 04-22 19:45Z bar).
+        assert(std::isnan(probe.at_chart_close[24].c));
+        // Every element of the tuple is the native row, verbatim: the
+        // sub-penny close 9.65 (aggregate 9.655), and on 04-23 the
+        // 10.0054 high / 9.835 open / 9.71 low / 9.78 close / the exchange
+        // volume (aggregate 9.83 / 10.0 / 9.715 / 9.765).
+        assert(row_is(probe.at_chart_close[25], kNativeApr22));
+        assert(row_is(probe.at_chart_close[26], kNativeApr22));   // held
+        assert(row_is(probe.at_chart_close[50], kNativeApr22));
+        assert(row_is(probe.at_chart_close[51], kNativeApr23));
+        assert(probe.at_chart_close[51].h == 10.0054);
+        assert(probe.at_chart_close[51].c == 9.78);
+        assert(probe.native_security_substitutions() == 2);
+        assert(probe.native_security_misses() == 0);
+    }
+}
+
+void test_tuple_request_without_the_feed_is_the_aggregate() {
+    // The same run with no native feed — the shape the mukhlisilahi F@15
+    // case actually ran under — reads the 15m aggregate: 04-22 close 9.655,
+    // 04-23 9.83 / 10.0 / 9.715 / 9.765 and the summed volume.
+    std::vector<Bar> chart = f15_apr22_apr23();
+    TupleProbe probe("D");
+    strategy_set_syminfo_timezone(
+        static_cast<pf_strategy_t>(&probe), "America/New_York");
+    strategy_set_syminfo_session(
+        static_cast<pf_strategy_t>(&probe), "0930-1600");
+    probe.run(chart.data(), static_cast<int>(chart.size()), "15", "15",
+              false, 4, MagnifierDistribution::ENDPOINTS);
+    assert(probe.last_error().empty());
+    assert(probe.at_chart_close.size() == 52);
+    const TupleProbe::Row& d1 = probe.at_chart_close[25];
+    assert(d1.o == 9.55 && d1.h == 9.72 && d1.l == 9.53 && d1.c == 9.655);
+    const TupleProbe::Row& d2 = probe.at_chart_close[51];
+    assert(d2.o == 9.83 && d2.h == 10.0 && d2.l == 9.715 && d2.c == 9.765);
+    double vol = 0.0;
+    for (std::size_t i = 26; i < 52; ++i) vol += chart[i].volume;
+    assert(d2.v == vol);
+    assert(probe.native_security_substitutions() == 0);
+}
+
 int main() {
     test_completed_daily_bucket_carries_the_native_bar();
     test_a_bucket_without_a_native_bar_keeps_its_aggregate();
@@ -326,5 +494,7 @@ int main() {
     test_feed_validation_fails_closed();
     test_split_aux_feed_path_substitutes_the_same_native_bar();
     test_overnight_cme_session_labels_by_session_day();
+    test_tuple_request_reads_the_native_daily_row();
+    test_tuple_request_without_the_feed_is_the_aggregate();
     return 0;
 }

--- a/tests/test_trail_activation_tick_bar.cpp
+++ b/tests/test_trail_activation_tick_bar.cpp
@@ -1,0 +1,327 @@
+/*
+ * test_trail_activation_tick_bar.cpp — round 7 family K,
+ * design-trail-activation-tick-bar: TradingView tests a trailing stop's
+ * ACTIVATION (trail_points / trail_price) against the bar's OHLC QUANTIZED
+ * to the tick — the round-6 stop / limit trigger rule (test_stop_tick_
+ * rounding.cpp) extended to the trail's arming — while the trail's running
+ * best (peak / trough) stays the raw print (round 5; stopround-xt-L-trail).
+ *
+ * Pinned with three `lab tv` tapes on NYSE:F 15m, 2025-04-10..18, fixed 100
+ * shares (scratchpad/r7/pins/f15-trail-0415-{reissue,fixed760,fixed754};
+ * campaign note log-20260905t084531z-57cedc55): a short entered at the
+ * 04-15 14:45Z open (9.495 -> 9.49) with
+ *   strategy.exit("XS", "S", trail_points = close * 0.008 / syminfo.mintick,
+ *                 trail_offset = 0)            re-issued every bar, or
+ *   trail_points = 7.60 / 7.54 fixed           (all ceil to 8 ticks),
+ * exits on the 15:45Z bar @9.41 in EVERY tape. Activation = 9.49 - 0.08 =
+ * 9.41; the 15:45Z bar (O 9.43 H 9.45 L 9.415 C 9.445) has a raw low of
+ * 9.415 — above the level, the engine's no-activate, which slid the exit to
+ * the 16:45Z bar (low 9.41) — and a tick-quantized low of 9.41 (9.415 is
+ * 9.41499.. in binary: floor(941.499 + 0.5) = 941), which reaches it; with
+ * offset 0 the trail exits one-shot at the level. Re-issuing trail_points
+ * from the current close is irrelevant (the fixed tapes are identical).
+ *
+ * The bars are the registry feed's (lab bars NYSE:F 15, feed 80f404ae85ef),
+ * UTC-stamped; tape times are UTC+8 evenings of the same day.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "../src/engine_internal.hpp"
+
+using namespace pineforge;
+using namespace pineforge::internal;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_NEAR(a, b, tol)                                                  \
+    do {                                                                       \
+        double _a = (a), _b = (b);                                             \
+        if (!(std::fabs(_a - _b) <= (tol))) {                                  \
+            std::printf("  FAIL  %s:%d  %s == %.10f, expected %.10f\n",        \
+                        __FILE__, __LINE__, #a, _a, _b);                       \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+namespace {
+
+constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+constexpr int64_t kQuarter = 15 * 60 * 1000;
+// 2025-04-15 14:30:00Z
+constexpr int64_t k0415_1430Z = 1744727400000LL;
+
+Bar mk(double o, double h, double l, double c, int64_t ts = 0) {
+    Bar b{};
+    b.open = o; b.high = h; b.low = l; b.close = c;
+    b.volume = 100000.0; b.timestamp = ts;
+    return b;
+}
+
+// NYSE:F 15m, 2025-04-15 14:30Z .. 16:45Z (10 bars), registry feed prints.
+std::vector<Bar> f15_0415() {
+    std::vector<Bar> bars = {
+        mk(9.51, 9.525, 9.46, 9.5),        // 14:30  signal bar
+        mk(9.495, 9.5, 9.44, 9.465),       // 14:45  entry @ open 9.495 -> 9.49
+        mk(9.465, 9.485, 9.42, 9.425),     // 15:00
+        mk(9.425, 9.455, 9.425, 9.435),    // 15:15
+        mk(9.435, 9.46, 9.42, 9.425),      // 15:30
+        mk(9.43, 9.45, 9.415, 9.445),      // 15:45  low 9.415 -> tick 9.41: TV exits @9.41
+        mk(9.445, 9.46, 9.43, 9.445),      // 16:00
+        mk(9.445, 9.46, 9.43, 9.435),      // 16:15
+        mk(9.44, 9.45, 9.42, 9.435),       // 16:30
+        mk(9.435, 9.44, 9.41, 9.415),      // 16:45  low 9.41: the engine's old exit
+    };
+    for (std::size_t i = 0; i < bars.size(); ++i) {
+        bars[i].timestamp = k0415_1430Z + static_cast<int64_t>(i) * kQuarter;
+    }
+    return bars;
+}
+
+// NYSE:F strategy() of the pins: 100 shares fixed, no commission / slippage,
+// one position, orders processed at the next bar's open. Bar 0 enters short;
+// while short, strategy.exit("X", "E", trail_points = <mode>, trail_offset =
+// 0) is re-issued every bar — trail_points either fixed (fixed_points_) or
+// close * 0.008 / mintick (the probe's form).
+class Probe : public BacktestEngine {
+public:
+    Probe() {
+        initial_capital_ = 10000.0;
+        syminfo_.pointvalue = 1.0;
+        syminfo_mintick_ = 0.01;
+        qty_step_ = 1.0;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 100.0;
+        commission_type_ = CommissionType::PERCENT;
+        commission_value_ = 0.0;
+        margin_long_ = 100.0;
+        margin_short_ = 100.0;
+        pyramiding_ = 0;
+        slippage_ = 0;
+        process_orders_on_close_ = false;
+        margin_call_enabled_ = false;
+    }
+    double fixed_points_ = kNaN;   // NaN -> close * 0.008 / mintick
+    double trail_offset_ = 0.0;
+
+    void on_bar(const Bar& bar) override {
+        if (bar_index_ == 0) strategy_entry("E", false);
+        if (position_side_ != PositionSide::FLAT) {
+            const double points = std::isnan(fixed_points_)
+                ? bar.close * 0.008 / syminfo_mintick_
+                : fixed_points_;
+            strategy_exit("X", "E", kNaN, kNaN, points, trail_offset_);
+        }
+    }
+    using BacktestEngine::position_side_;
+};
+
+void expect_short_exit(const Probe& eng, int exit_bar, double exit_px) {
+    CHECK(eng.position_side_ == PositionSide::FLAT);
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() != 1) return;
+    const Trade& t = eng.get_trade(0);
+    CHECK(t.is_long == false);
+    CHECK(t.entry_time == k0415_1430Z + 1 * kQuarter);
+    CHECK_NEAR(t.entry_price, 9.49, 1e-9);
+    CHECK(t.exit_time == k0415_1430Z + exit_bar * kQuarter);
+    CHECK_NEAR(t.exit_price, exit_px, 1e-9);
+    CHECK_NEAR(t.qty, 100.0, 1e-9);
+    if (t.exit_time != k0415_1430Z + exit_bar * kQuarter) {
+        std::printf("        got exit bar %lld @%.5f (expected bar %d @%.5f)\n",
+                    (long long)((t.exit_time - k0415_1430Z) / kQuarter),
+                    t.exit_price, exit_bar, exit_px);
+    }
+}
+
+// ── engine: the three tapes ───────────────────────────────────────────
+
+void test_reissued_trail_points_exits_on_the_quantized_low() {
+    std::printf("-- f15-trail-0415-reissue: trail_points = close*0.008/mintick, offset 0 -> 15:45Z @9.41 --\n");
+    Probe eng;
+    auto bars = f15_0415();
+    eng.run(bars.data(), (int)bars.size());
+    // 9.465 * 0.8 = 7.572 -> 8 ticks -> 9.41; 9.425 * 0.8 = 7.54 -> 8 -> 9.41.
+    // Bar 5 (15:45Z): raw low 9.415 > 9.41, tick low 9.41 <= 9.41 -> exit.
+    expect_short_exit(eng, 5, 9.41);
+}
+
+void test_fixed_760_exits_on_the_quantized_low() {
+    std::printf("-- f15-trail-0415-fixed760: trail_points 7.60 -> 8 ticks -> 15:45Z @9.41 --\n");
+    Probe eng;
+    eng.fixed_points_ = 7.60;
+    auto bars = f15_0415();
+    eng.run(bars.data(), (int)bars.size());
+    expect_short_exit(eng, 5, 9.41);
+}
+
+void test_fixed_754_exits_on_the_quantized_low() {
+    std::printf("-- f15-trail-0415-fixed754: trail_points 7.54 -> 8 ticks -> 15:45Z @9.41 --\n");
+    Probe eng;
+    eng.fixed_points_ = 7.54;
+    auto bars = f15_0415();
+    eng.run(bars.data(), (int)bars.size());
+    expect_short_exit(eng, 5, 9.41);
+}
+
+// Control: an activation one tick FURTHER (9 ticks -> 9.40) is reached by
+// neither the quantized 15:45Z low (9.41) nor the 16:45Z low (9.41): the
+// quantized compare does not over-fire, the position is still open at the
+// end of the window.
+void test_activation_below_the_quantized_low_does_not_fire() {
+    std::printf("-- control: trail_points 9 -> 9.40 is below every quantized low -> no exit --\n");
+    Probe eng;
+    eng.fixed_points_ = 9.0;
+    auto bars = f15_0415();
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.position_side_ == PositionSide::SHORT);
+    CHECK(eng.trade_count() == 0);
+}
+
+// ── resolver: where the quantization lives ────────────────────────────
+
+Bar tick_twin(const Bar& b, double mintick) {
+    auto q = [&](double p) {
+        const double k = std::floor(p / mintick + 0.5);
+        return k / std::floor(1.0 / mintick + 0.5);
+    };
+    Bar t = b;
+    t.open = q(b.open); t.high = q(b.high); t.low = q(b.low); t.close = q(b.close);
+    return t;
+}
+
+void test_resolver_activation_is_reached_on_the_tick_path() {
+    std::printf("-- resolver: the 15:45Z bar's tick twin reaches 9.41 on the O->L leg, the raw bar does not --\n");
+    const Bar bar = mk(9.43, 9.45, 9.415, 9.445);
+    const Bar tick = tick_twin(bar, 0.01);
+    CHECK(tick.low == 9.41);
+    CHECK(tick.close == 9.45);   // 9.445 -> 944.5000000000001 + 0.5 -> 945
+    // Short @9.49, trail_points 8 (activation 9.41), offset 0, carried best
+    // = the raw trough so far (9.42), not the entry bar.
+    ExitPathFill f = resolve_exit_path_fill(
+        bar, tick, PositionSide::SHORT, /*stop=*/kNaN, /*limit=*/kNaN,
+        /*trail_points=*/8.0, /*trail_price=*/kNaN, /*trail_offset=*/0.0,
+        /*entry=*/9.49, /*best_start=*/9.42, /*is_entry_bar=*/false,
+        /*magnifier=*/false, /*mintick=*/0.01);
+    CHECK(f.should_fill == true);
+    CHECK(f.is_trail == true);
+    CHECK(f.is_limit == false);
+    CHECK(f.at_bar_open == false);
+    CHECK_NEAR(f.fill_price, 9.41, 1e-12);
+    // |H-O| 0.02 > |O-L| 0.015 -> low first: O -> L is segment 0 and the
+    // tick leg 9.43 -> 9.41 ends exactly on the level: path position 1.0.
+    CHECK_NEAR(f.path_position, 1.0, 1e-9);
+
+    // The raw-only form (tick twin == bar) walks the raw 9.415 low: no fill.
+    ExitPathFill raw = resolve_exit_path_fill(
+        bar, PositionSide::SHORT, kNaN, kNaN, 8.0, kNaN, 0.0,
+        9.49, 9.42, false, false, 0.01);
+    CHECK(raw.should_fill == false);
+}
+
+// A trail WITH an offset arms on the quantized extreme too, then trails the
+// RAW best: long @9.90, activation 10.00 (10 ticks), offset 2 ticks; bar
+// O 9.98 H 9.996 L 9.97 C 9.975 (|O-L| 0.01 < |H-O| 0.016 -> low first).
+// Raw high 9.996 never reaches 10.00 (dormant, no fill — the old engine);
+// tick high 10.00 (999.6 + 0.5 -> 1000) arms it at the end of the L->H leg
+// with best = 9.996 raw, so the H->C leg crosses 9.996 - 0.02 = 9.976 and
+// fills there. (The consequence of the pinned rule for offset trails; the
+// round-6 stopround-xt-L-trail tape fixes the best itself as RAW — a
+// quantized best 10.00 would have printed 9.98.)
+void test_resolver_offset_trail_arms_on_the_quantized_extreme() {
+    std::printf("-- resolver: offset trail arms on the tick high 10.00, trails the raw best 9.996 --\n");
+    const Bar bar = mk(9.98, 9.996, 9.97, 9.975);
+    const Bar tick = tick_twin(bar, 0.01);
+    CHECK(tick.high == 10.0);
+    ExitPathFill f = resolve_exit_path_fill(
+        bar, tick, PositionSide::LONG, kNaN, kNaN,
+        /*trail_points=*/10.0, kNaN, /*trail_offset=*/2.0,
+        /*entry=*/9.90, /*best_start=*/9.90, false, false, 0.01);
+    CHECK(f.should_fill == true);
+    CHECK(f.is_trail == true);
+    CHECK_NEAR(f.fill_price, 9.976, 1e-9);
+    // Segment 2 (H -> C, 9.996 -> 9.975) is crossed 0.02 / 0.021 of the way.
+    CHECK_NEAR(f.path_position, 2.0 + 0.02 / 0.021, 1e-6);
+    ExitPathFill raw = resolve_exit_path_fill(
+        bar, PositionSide::LONG, kNaN, kNaN, 10.0, kNaN, 2.0,
+        9.90, 9.90, false, false, 0.01);
+    CHECK(raw.should_fill == false);
+}
+
+// The carried best (previous bars' raw extreme) is read quantized for the
+// arming test as well: best_start 9.996 with activation 10.00 arrives ARMED
+// (tick 10.00), so a bar that only falls (O 9.99 H 9.99 L 9.96 C 9.97)
+// crosses 9.996 - 0.02 = 9.976 on its O -> L leg; the old raw compare never
+// armed it (no rising leg on this bar) and produced no fill.
+void test_resolver_carried_best_arms_quantized() {
+    std::printf("-- resolver: carried raw best 9.996 arms (tick 10.00) the 10.00 activation --\n");
+    const Bar bar = mk(9.99, 9.99, 9.96, 9.97);
+    const Bar tick = tick_twin(bar, 0.01);
+    ExitPathFill f = resolve_exit_path_fill(
+        bar, tick, PositionSide::LONG, kNaN, kNaN,
+        /*trail_points=*/10.0, kNaN, /*trail_offset=*/2.0,
+        /*entry=*/9.90, /*best_start=*/9.996, false, false, 0.01);
+    CHECK(f.should_fill == true);
+    CHECK(f.is_trail == true);
+    CHECK_NEAR(f.fill_price, 9.976, 1e-9);
+    // A best that quantizes BELOW the activation (9.994 -> 9.99, and 9.995
+    // -> 9.99 too: 9.995 is 9.99499.. in binary) stays dormant, as before.
+    for (double best : {9.994, 9.995}) {
+        ExitPathFill dormant = resolve_exit_path_fill(
+            bar, tick, PositionSide::LONG, kNaN, kNaN, 10.0, kNaN, 2.0,
+            9.90, best, false, false, 0.01);
+        CHECK(dormant.should_fill == false);
+    }
+}
+
+// The one-shot trail's activation on a segment whose RAW end already passes
+// the level is unchanged: fill at the level, found on the tick path with
+// the same chronology (a regression guard for the shared TRAIL slot).
+void test_resolver_raw_reach_is_unchanged() {
+    std::printf("-- resolver: a raw low through the activation still fills at the level --\n");
+    const Bar bar = mk(9.435, 9.44, 9.405, 9.415);   // 16:45Z-like, low 9.405
+    const Bar tick = tick_twin(bar, 0.01);
+    ExitPathFill f = resolve_exit_path_fill(
+        bar, tick, PositionSide::SHORT, kNaN, kNaN, 8.0, kNaN, 0.0,
+        9.49, 9.42, false, false, 0.01);
+    CHECK(f.should_fill == true);
+    CHECK(f.is_trail == true);
+    CHECK_NEAR(f.fill_price, 9.41, 1e-12);
+    // |O-L| 0.03 > |H-O| 0.005 -> high first, so O -> H is segment 0 and
+    // H -> L segment 1; the tick leg is 9.44 -> 9.40 (9.405 is 9.40499.. in
+    // binary and quantizes DOWN), crossed 0.03 / 0.04 of the way -> 1.75.
+    CHECK_NEAR(f.path_position, 1.75, 1e-9);
+}
+
+}  // namespace
+
+int main() {
+    test_reissued_trail_points_exits_on_the_quantized_low();
+    test_fixed_760_exits_on_the_quantized_low();
+    test_fixed_754_exits_on_the_quantized_low();
+    test_activation_below_the_quantized_low_does_not_fire();
+    test_resolver_activation_is_reached_on_the_tick_path();
+    test_resolver_offset_trail_arms_on_the_quantized_extreme();
+    test_resolver_carried_best_arms_quantized();
+    test_resolver_raw_reach_is_unchanged();
+    std::printf("trail_activation_tick_bar: %d passed, %d failed\n",
+                tests_passed, tests_failed);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/tests/test_trail_fill_snap.cpp
+++ b/tests/test_trail_fill_snap.cpp
@@ -1,0 +1,708 @@
+/*
+ * test_trail_fill_snap.cpp — trailing-exit fill rules pinned from TradingView
+ * tapes in round 7 (family G, stevenygabbyperez-fast-scalper-with-stops:
+ * strategy.exit(stop=close*0.99|1.01, trail_points=close*0.02/syminfo.mintick,
+ * NO trail_offset); `lab tv` tapes scratchpad/r7/pins/scalper-trail-* and
+ * trail-eq-*, record scratchpad/r7/pins/scalper-PINS.md). TV is ground truth.
+ *
+ * (1) A one-shot (omitted / zero-offset) trail whose activation the bar's
+ *     OPEN already sits past fills at open -/+ 0 as a LEVEL: snapped
+ *     directionally (sell floor, buy ceil), not nearest-rounded like a raw
+ *     print the order gapped through.
+ *       NASDAQ:AAPL 15m long 2025-04-21 19:45Z @191.91 (trail_points 383.82
+ *         -> 384t, activation 195.75); 04-22 13:30Z opens 196.135: TV 196.13
+ *         with the offset omitted AND with trail_offset=0; 196.12 with
+ *         trail_offset=1 (196.135 - 1t = 196.125, floored). Engine booked
+ *         bar_fill_price(196.135) = 196.14.
+ *       NASDAQ:AAPL 15m short 05-22 17:30Z @201.9 (403.8 -> 404t, 197.86);
+ *         05-23 13:30Z opens 193.665: TV 193.67 (ceil == nearest here).
+ *
+ * (2) trail_points is a tick count with a TOLERANT ceil (kTrailPointsCeilEps
+ *     = 5e-5), trail_offset an EXACT floor: NYSE:F 15m short from the 04-02
+ *     19:00Z signal (entry 10.11, mintick 0.01), zero-offset trails filling
+ *     at the activation: trail_points 14.00001 -> 14t (9.97), 14.0001 /
+ *     14.001 -> 15t (9.96), 0.14/syminfo.mintick = 14.000000000000002 -> 14t,
+ *     14.0000001 -> 14t, 18.2 -> 19t (9.92); trail_offset
+ *     0.3/(syminfo.mintick*10) = 2.9999999999999996 -> 2t (04-03 14:15Z
+ *     @9.85 = trough 9.83 + 2t; 3t would print 9.86).
+ *       BINANCE:BTCUSDT 15m short 2025-08-17 23:30Z @117559.99,
+ *         trail_points = 117560 * 0.02 / 0.01 = 235120.00000000003: TV exits
+ *         08-18 03:30Z @115208.79 (235120t); std::ceil gave 235121t -> .78.
+ *
+ * (3) The activation level and the trailing level are ON the tick grid: a bar
+ *     extreme landing exactly on the level touches it. 10.11 - 21 * 0.01 is
+ *     9.899999999999999 in doubles, one ulp UNDER the 9.9 low of NYSE:F
+ *     2025-04-03 13:45Z (O 10.165 H 10.18 L 9.9 C 9.9): TV fills the
+ *     zero-offset trail there @9.90 (trail-eq-S-off0-tp21; the probe's own
+ *     20.22 -> 21t case); the engine read the leg as "not reached" and
+ *     gap-filled the next open @9.89. The "stop == trough == close equality"
+ *     reading of that row is REFUTED: trail_points 18 fills the same bar at
+ *     its activation 9.93, not at the 9.90 extreme/close (trail-eq-S-off0,
+ *     and trail-eq-S-omit with the offset omitted); the long twin (entry
+ *     04-01 19:15Z @9.88, trail_points 8) fills 04-02 13:30Z @9.96 = the
+ *     activation on a close == high bar (trail-eq-L-off0). A whole-tick
+ *     offset trails durably and its level is touched inclusively: with
+ *     trail_offset=1 the short fills 04-03 14:00Z @9.90 (trough 9.89 at the
+ *     open + 1t == the bar's 9.90 high; trail-eq-S-off1), the long fills
+ *     04-02 13:45Z @9.97 (peak 9.985 - 1t = 9.975, floored; trail-eq-L-off1).
+ *
+ * Resolver-level pins go straight through resolve_exit_path_fill (as
+ * test_trail_open_arm_subtick_offset.cpp does); engine-level pins run
+ * BacktestEngine end to end over the registry feed bars (`lab bars`).
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "../src/engine_internal.hpp"
+
+using namespace pineforge;
+using namespace pineforge::internal;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+namespace {
+
+constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+bool near(double a, double b, double tol = 1e-9) {
+    return std::fabs(a - b) <= tol;
+}
+
+Bar mk(double o, double h, double l, double c, int64_t ts = 0) {
+    Bar b{};
+    b.open = o; b.high = h; b.low = l; b.close = c;
+    b.volume = 1000.0; b.timestamp = ts;
+    return b;
+}
+
+// Resolver call for a lone trailing exit (no stop / limit legs) resting on
+// a NON-entry bar from the open, in the plain (non-magnifier) path.
+ExitPathFill trail_fill(const Bar& bar, PositionSide side,
+                        double trail_points, double trail_offset,
+                        double entry, double best_start, double mintick) {
+    return resolve_exit_path_fill(
+        bar, side, /*stop=*/kNaN, /*limit=*/kNaN,
+        trail_points, /*trail_price=*/kNaN, trail_offset, entry,
+        best_start, /*is_entry_bar=*/false, /*magnifier_active=*/false,
+        mintick);
+}
+
+// ── registry feed bars (UTC labels; lab bars) ─────────────────────────
+
+// NASDAQ:AAPL 15m, feed ae2b03d3736f.
+const Bar kAaplSignal0421_1930 = mk(191.13, 192.09, 191.06, 191.92, 1745263800000);
+const Bar kAaplEntry0421_1945  = mk(191.91, 193.43, 191.61, 193.03, 1745264700000);
+const Bar kAapl0422_1330       = mk(196.135, 197.5, 195.96, 197.25, 1745328600000);
+const Bar kAapl0422_1345       = mk(197.28, 197.855, 197.14, 197.81, 1745329500000);
+
+const Bar kAaplSignal0522_1715 = mk(201.3, 201.94, 201.28, 201.88, 1747934100000);
+const Bar kAaplEntry0522_1730  = mk(201.9, 202.08, 201.67, 202.06, 1747935000000);
+const Bar kAapl0522_1745 = mk(202.09, 202.18, 201.78, 201.89, 1747935900000);
+const Bar kAapl0522_1800 = mk(201.89, 202.11, 201.69, 202.07, 1747936800000);
+const Bar kAapl0522_1815 = mk(202.07, 202.22, 201.91, 201.97, 1747937700000);
+const Bar kAapl0522_1830 = mk(201.96, 201.96, 201.64, 201.72, 1747938600000);
+const Bar kAapl0522_1845 = mk(201.71, 202.25, 201.69, 202.13, 1747939500000);
+const Bar kAapl0522_1900 = mk(202.13, 202.68, 202.12, 202.52, 1747940400000);
+const Bar kAapl0522_1915 = mk(202.51, 202.75, 202.11, 202.61, 1747941300000);
+const Bar kAapl0522_1930 = mk(202.62, 202.65, 201.78, 201.82, 1747942200000);
+const Bar kAapl0522_1945 = mk(201.82, 202.17, 201.0, 201.34, 1747943100000);
+const Bar kAapl0523_1330 = mk(193.665, 197.095, 193.47, 196.0, 1748007000000);
+const Bar kAapl0523_1345 = mk(195.97, 196.8, 195.32, 196.38, 1748007900000);
+
+// NYSE:F 15m, feed 80f404ae85ef.
+const Bar kFSignal0402_1900 = mk(10.13, 10.145, 10.105, 10.105, 1743620400000);
+const Bar kFEntry0402_1915  = mk(10.105, 10.125, 10.085, 10.095, 1743621300000);
+const Bar kF0402_1930 = mk(10.09, 10.125, 10.075, 10.115, 1743622200000);
+const Bar kF0402_1945 = mk(10.115, 10.145, 10.1, 10.14, 1743623100000);
+const Bar kF0403_1330 = mk(10.01, 10.2, 9.95, 10.17, 1743687000000);
+const Bar kF0403_1345 = mk(10.165, 10.18, 9.9, 9.9, 1743687900000);
+const Bar kF0403_1400 = mk(9.89, 9.9, 9.83, 9.835, 1743688800000);
+const Bar kF0403_1415 = mk(9.835, 9.865, 9.8, 9.805, 1743689700000);
+
+const Bar kFSignal0401_1900 = mk(9.84, 9.88, 9.84, 9.88, 1743534000000);
+const Bar kFEntry0401_1915  = mk(9.88, 9.905, 9.87, 9.885, 1743534900000);
+const Bar kF0401_1930 = mk(9.88, 9.9, 9.87, 9.9, 1743535800000);
+const Bar kF0401_1945 = mk(9.9, 9.93, 9.87, 9.92, 1743536700000);
+const Bar kF0402_1330 = mk(9.835, 9.985, 9.83, 9.985, 1743600600000);
+const Bar kF0402_1345 = mk(9.98, 10.02, 9.945, 9.985, 1743601500000);
+const Bar kF0402_1400 = mk(9.98, 10.08, 9.97, 10.06, 1743602400000);
+
+// BINANCE:BTCUSDT 15m, feed 6b54c44ac6de.
+const Bar kBtcSignal0817_2315 = mk(117779.55, 117837.2, 117481.99, 117560, 1755472500000);
+const Bar kBtcEntry0817_2330  = mk(117559.99, 117603.13, 117482.31, 117569.57, 1755473400000);
+const Bar kBtc0817_2345 = mk(117569.56, 117569.57, 117371.65, 117405.01, 1755474300000);
+const Bar kBtc0818_0000 = mk(117405.01, 117543.75, 117336.04, 117512.99, 1755475200000);
+const Bar kBtc0818_0015 = mk(117512.98, 117512.98, 117088.29, 117142.44, 1755476100000);
+const Bar kBtc0818_0030 = mk(117142.44, 117364, 117020, 117258.5, 1755477000000);
+const Bar kBtc0818_0045 = mk(117258.5, 117347.46, 117167.63, 117290.19, 1755477900000);
+const Bar kBtc0818_0100 = mk(117290.2, 117400, 117264.91, 117304.29, 1755478800000);
+const Bar kBtc0818_0115 = mk(117304.29, 117409.87, 116670.03, 116670.05, 1755479700000);
+const Bar kBtc0818_0130 = mk(116670.04, 116935.12, 116366, 116427.6, 1755480600000);
+const Bar kBtc0818_0145 = mk(116427.59, 116478.82, 116166.03, 116269.54, 1755481500000);
+const Bar kBtc0818_0200 = mk(116269.53, 116339.61, 115910.99, 115995.2, 1755482400000);
+const Bar kBtc0818_0215 = mk(115995.2, 116030, 115730.03, 115791.95, 1755483300000);
+const Bar kBtc0818_0230 = mk(115791.94, 116070.75, 115678.02, 115896.15, 1755484200000);
+const Bar kBtc0818_0245 = mk(115896.15, 115924.36, 115292.67, 115453.24, 1755485100000);
+const Bar kBtc0818_0300 = mk(115452, 115636.89, 115433.69, 115480.01, 1755486000000);
+const Bar kBtc0818_0315 = mk(115480, 115550.53, 115332, 115359.34, 1755486900000);
+const Bar kBtc0818_0330 = mk(115359.33, 115417.13, 115115, 115166, 1755487800000);
+const Bar kBtc0818_0345 = mk(115166, 115380, 115000, 115319, 1755488700000);
+
+// The family's trail_points expression, evaluated the way the codegen'd
+// strategy evaluates it: close * 0.02 / syminfo.mintick in doubles.
+double scalper_trail_points(double signal_close, double mintick) {
+    return signal_close * 0.02 / mintick;
+}
+
+// ── (2) tick arithmetic ───────────────────────────────────────────────
+
+void test_trail_points_ceil_is_tolerant() {
+    std::printf("test_trail_points_ceil_is_tolerant\n");
+    // NYSE:F tapes: 14.00001 -> 14 (9.97), 14.0001 / 14.001 -> 15 (9.96).
+    CHECK(trail_points_to_ticks(14.00001) == 14.0);
+    CHECK(trail_points_to_ticks(14.0001) == 15.0);
+    CHECK(trail_points_to_ticks(14.001) == 15.0);
+    CHECK(trail_points_to_ticks(14.0000001) == 14.0);
+    // 0.14 / syminfo.mintick evaluates to 14.000000000000002.
+    CHECK(0.14 / 0.01 > 14.0);
+    CHECK(trail_points_to_ticks(0.14 / 0.01) == 14.0);
+    CHECK(trail_points_to_ticks(18.2) == 19.0);
+    // The probes' own values.
+    CHECK(trail_points_to_ticks(scalper_trail_points(10.11, 0.01)) == 21.0);
+    CHECK(trail_points_to_ticks(scalper_trail_points(10.105, 0.01)) == 21.0);
+    CHECK(trail_points_to_ticks(scalper_trail_points(191.92, 0.01)) == 384.0);
+    CHECK(trail_points_to_ticks(scalper_trail_points(201.88, 0.01)) == 404.0);
+    // BTC: 117560 * 0.02 / 0.01 = 235120.00000000003 -> 235120, not 235121.
+    CHECK(scalper_trail_points(117560.0, 0.01) > 235120.0);
+    CHECK(std::ceil(scalper_trail_points(117560.0, 0.01)) == 235121.0);
+    CHECK(trail_points_to_ticks(scalper_trail_points(117560.0, 0.01)) == 235120.0);
+    // Round-5 pins hold: a sub-tick trail_points still ceils to 1 tick.
+    CHECK(trail_points_to_ticks(0.0006) == 1.0);
+    CHECK(trail_points_to_ticks(0.6) == 1.0);
+    CHECK(trail_points_to_ticks(3.0) == 3.0);
+    CHECK(trail_points_to_ticks(0.0) == 0.0);
+    CHECK(std::isnan(trail_points_to_ticks(kNaN)));
+}
+
+void test_trail_offset_floor_is_exact() {
+    std::printf("test_trail_offset_floor_is_exact\n");
+    // 0.3 / (syminfo.mintick * 10) evaluates to 2.9999999999999996 -> 2
+    // ticks (trail-eq-S-off3fp2: 04-03 14:15Z @9.85 = 9.83 + 2t, not 9.86):
+    // no tolerance on the floor, unlike the ceil.
+    CHECK(0.3 / (0.01 * 10.0) < 3.0);
+    CHECK(trail_offset_to_ticks(0.3 / (0.01 * 10.0)) == 2.0);
+    CHECK(trail_offset_to_ticks(2.99999) == 2.0);
+    CHECK(trail_offset_to_ticks(3.0) == 3.0);
+    // Round-5 pins hold: [0, 1) is the zero-tick one-shot, 1.4 trails 1t.
+    CHECK(trail_offset_to_ticks(0.0) == 0.0);
+    CHECK(trail_offset_to_ticks(0.5) == 0.0);
+    CHECK(trail_offset_to_ticks(0.9) == 0.0);
+    CHECK(trail_offset_to_ticks(1.0) == 1.0);
+    CHECK(trail_offset_to_ticks(1.4) == 1.0);
+    CHECK(trail_offset_to_ticks(15.0) == 15.0);
+    CHECK(std::isnan(trail_offset_to_ticks(kNaN)));
+}
+
+void test_trail_level_tick_grid_snap() {
+    std::printf("test_trail_level_tick_grid_snap\n");
+    // The F knife-edge: 10.11 - 21 * 0.01 sits one ulp under 9.9.
+    const double raw = 10.11 - 21.0 * 0.01;
+    CHECK(raw < 9.9);
+    CHECK(snap_trail_level_to_tick_grid(raw, 0.01) == 9.9);
+    // A genuinely sub-tick level stays raw (it takes the directional fill
+    // snap downstream, 196.125 -> 196.12 for a sell).
+    CHECK(snap_trail_level_to_tick_grid(196.135 - 0.01, 0.01) == 196.135 - 0.01);
+    CHECK(near(196.135 - 0.01, 196.125));
+    // XAUUSD round-5 shape on mintick 0.001: open - 15t materializes as the
+    // grid point 3110.385.
+    CHECK(near(snap_trail_level_to_tick_grid(3110.40 - 0.015, 0.001), 3110.385));
+    CHECK(snap_trail_level_to_tick_grid(3110.40 - 0.015, 0.001) == 3110385.0 / 1000.0);
+    CHECK(std::isnan(snap_trail_level_to_tick_grid(kNaN, 0.01)));
+    CHECK(snap_trail_level_to_tick_grid(9.9, 0.0) == 9.9);
+}
+
+// ── (1) resolver: the one-shot trail arming at a sub-tick open ───────
+
+void test_resolver_aapl_long_arms_at_subtick_open() {
+    std::printf("test_resolver_aapl_long_arms_at_subtick_open\n");
+    // activation 191.91 + 384t = 195.75 < open 196.135: fires at the open as
+    // the trail's LEVEL (open_is_trail_level) — omitted offset and explicit 0
+    // alike. The raw open is reported; the consumer snaps it directionally.
+    const double tp = scalper_trail_points(191.92, 0.01);
+    const double offsets[] = {kNaN, 0.0};
+    for (double off : offsets) {
+        ExitPathFill f = trail_fill(kAapl0422_1330, PositionSide::LONG, tp, off,
+                                    /*entry=*/191.91, /*best_start=*/193.43,
+                                    /*mintick=*/0.01);
+        CHECK(f.should_fill == true);
+        CHECK(f.fill_price == 196.135);
+        CHECK(f.at_bar_open == true);
+        CHECK(f.open_is_trail_level == true);
+        CHECK(f.is_limit == false);
+        CHECK(near(f.path_position, 0.0));
+    }
+    // trail_offset=1: arms at the open with best = open, the adverse-first
+    // leg (|O-L| = 0.175 < |H-O| = 1.365) crosses 196.135 - 1t = 196.125 —
+    // a level fill (TV prints the floored 196.12).
+    ExitPathFill f1 = trail_fill(kAapl0422_1330, PositionSide::LONG, tp, 1.0,
+                                 191.91, 193.43, 0.01);
+    CHECK(f1.should_fill == true);
+    CHECK(near(f1.fill_price, 196.125));
+    CHECK(f1.is_trail == true);
+    CHECK(f1.at_bar_open == false);
+    CHECK(f1.open_is_trail_level == false);
+}
+
+void test_resolver_aapl_short_arms_at_subtick_open() {
+    std::printf("test_resolver_aapl_short_arms_at_subtick_open\n");
+    // activation 201.9 - 404t = 197.86 > open 193.665.
+    const double tp = scalper_trail_points(201.88, 0.01);
+    ExitPathFill f = trail_fill(kAapl0523_1330, PositionSide::SHORT, tp, kNaN,
+                                /*entry=*/201.9, /*best_start=*/201.0,
+                                /*mintick=*/0.01);
+    CHECK(f.should_fill == true);
+    CHECK(f.fill_price == 193.665);
+    CHECK(f.at_bar_open == true);
+    CHECK(f.open_is_trail_level == true);
+}
+
+void test_resolver_adverse_gap_through_armed_level_is_a_raw_print() {
+    std::printf("test_resolver_adverse_gap_through_armed_level_is_a_raw_print\n");
+    // Control: a trail ARMED from the carried best (omitted offset, best 99.5
+    // past the 99.97 activation) that the open gaps through in the adverse
+    // direction is a resting level the print went through — raw open, no
+    // level flag (the #148 / corpus discriminator booking, unchanged).
+    Bar gap_up = mk(100.20, 100.30, 100.05, 100.10);
+    ExitPathFill f = trail_fill(gap_up, PositionSide::SHORT,
+                                /*trail_points=*/3.0, /*trail_offset=*/kNaN,
+                                /*entry=*/100.0, /*best_start=*/99.5,
+                                /*mintick=*/0.01);
+    CHECK(f.should_fill == true);
+    CHECK(near(f.fill_price, 100.20));
+    CHECK(f.at_bar_open == true);
+    CHECK(f.open_is_trail_level == false);
+}
+
+// ── (3) resolver: the activation is a tick-grid level ────────────────
+
+void test_resolver_ford_short_activation_touched_by_the_low() {
+    std::printf("test_resolver_ford_short_activation_touched_by_the_low\n");
+    // 21t from 10.11 -> 9.90 == the bar's low (high-first path O->H->L->C,
+    // the H->L leg ends ON the level): TV fills @9.90 on this bar. The
+    // probe's own trail_points (20.22) and a literal 21 agree.
+    const double tps[] = {scalper_trail_points(10.11, 0.01), 21.0};
+    for (double tp : tps) {
+        ExitPathFill f = trail_fill(kF0403_1345, PositionSide::SHORT, tp, kNaN,
+                                    /*entry=*/10.11, /*best_start=*/9.95,
+                                    /*mintick=*/0.01);
+        CHECK(f.should_fill == true);
+        CHECK(f.fill_price == 9.9);
+        CHECK(f.is_trail == true);
+        CHECK(f.at_bar_open == false);
+        // End of the H->L leg (segment 2 of the O->H->L->C path).
+        CHECK(near(f.path_position, 2.0, 1e-9));
+    }
+    // Explicit 0 is the same one-shot.
+    ExitPathFill f0 = trail_fill(kF0403_1345, PositionSide::SHORT, 21.0, 0.0,
+                                 10.11, 9.95, 0.01);
+    CHECK(f0.should_fill == true);
+    CHECK(f0.fill_price == 9.9);
+}
+
+void test_resolver_ford_short_fills_at_activation_not_at_the_extreme() {
+    std::printf("test_resolver_ford_short_fills_at_activation_not_at_the_extreme\n");
+    // trail_points 18 -> activation 9.93, crossed on the H->L leg: the fill
+    // is the activation (TV 9.93, trail-eq-S-off0 / trail-eq-S-omit), NOT
+    // the 9.90 trough / close. Refutes the "stop == trough == close"
+    // equality reading of the probe row.
+    const double offsets[] = {kNaN, 0.0};
+    for (double off : offsets) {
+        ExitPathFill f = trail_fill(kF0403_1345, PositionSide::SHORT, 18.0, off,
+                                    10.11, 9.95, 0.01);
+        CHECK(f.should_fill == true);
+        CHECK(near(f.fill_price, 9.93));
+        CHECK(f.is_trail == true);
+        CHECK(near(f.path_position, 1.0 + (9.93 - 10.18) / (9.9 - 10.18), 1e-9));
+    }
+    // Tolerant ceil at the resolver: 14.00001 -> 14t = 9.97 on the 13:30Z
+    // bar (low-first path, the O->L leg 10.01 -> 9.95 crosses it);
+    // 14.0001 -> 15t = 9.96. 0.14 / syminfo.mintick -> 9.97.
+    ExitPathFill a = trail_fill(kF0403_1330, PositionSide::SHORT, 14.00001, 0.0,
+                                10.11, 10.075, 0.01);
+    CHECK(a.should_fill == true);
+    CHECK(near(a.fill_price, 9.97));
+    ExitPathFill b = trail_fill(kF0403_1330, PositionSide::SHORT, 14.0001, 0.0,
+                                10.11, 10.075, 0.01);
+    CHECK(b.should_fill == true);
+    CHECK(near(b.fill_price, 9.96));
+    ExitPathFill c = trail_fill(kF0403_1330, PositionSide::SHORT, 0.14 / 0.01, 0.0,
+                                10.11, 10.075, 0.01);
+    CHECK(c.should_fill == true);
+    CHECK(near(c.fill_price, 9.97));
+}
+
+void test_resolver_ford_short_whole_tick_offset_level_touched_by_the_high() {
+    std::printf("test_resolver_ford_short_whole_tick_offset_level_touched_by_the_high\n");
+    // trail_offset=1: the 13:45Z bar arms at 9.93 and trails to 9.90 + 1t =
+    // 9.91 (close 9.90: no fill). 14:00Z opens 9.89 (new trough, level
+    // 9.90), the O->H leg ends ON 9.90 -> fill @9.90 (TV trail-eq-S-off1).
+    ExitPathFill hold = trail_fill(kF0403_1345, PositionSide::SHORT, 18.0, 1.0,
+                                   10.11, 9.95, 0.01);
+    CHECK(hold.should_fill == false);
+    ExitPathFill f = trail_fill(kF0403_1400, PositionSide::SHORT, 18.0, 1.0,
+                                10.11, /*best_start=*/9.9, 0.01);
+    CHECK(f.should_fill == true);
+    CHECK(f.fill_price == 9.9);
+    CHECK(f.is_trail == true);
+    CHECK(near(f.path_position, 1.0));
+    // trail_offset = 0.3 / (syminfo.mintick * 10) (2.9999999999999996 ->
+    // 2t, exact floor): 14:00Z trails 9.89 + 2t = 9.91 (high 9.90: hold),
+    // trough 9.83 -> 9.85 (close 9.835: hold); 14:15Z opens 9.835, the
+    // O->H leg (high-first: |H-O| = 0.03 < |O-L| = 0.035) reaches 9.85 ->
+    // fill @9.85 (TV trail-eq-S-off3fp2; a tolerant 3t floor would print
+    // 9.86).
+    const double off3 = 0.3 / (0.01 * 10.0);
+    ExitPathFill h1 = trail_fill(kF0403_1345, PositionSide::SHORT, 18.0, off3,
+                                 10.11, 9.95, 0.01);
+    CHECK(h1.should_fill == false);
+    ExitPathFill h2 = trail_fill(kF0403_1400, PositionSide::SHORT, 18.0, off3,
+                                 10.11, 9.9, 0.01);
+    CHECK(h2.should_fill == false);
+    ExitPathFill g = trail_fill(kF0403_1415, PositionSide::SHORT, 18.0, off3,
+                                10.11, 9.83, 0.01);
+    CHECK(g.should_fill == true);
+    CHECK(g.fill_price == 9.85);
+}
+
+void test_resolver_ford_long_twin() {
+    std::printf("test_resolver_ford_long_twin\n");
+    // Long @9.88, trail_points 8 -> 9.96. 04-02 13:30Z (O 9.835 H 9.985
+    // L 9.83 C 9.985, low-first) crosses it on the L->H leg: fill @9.96
+    // (TV trail-eq-L-off0), not the 9.985 peak == close.
+    ExitPathFill f = trail_fill(kF0402_1330, PositionSide::LONG, 8.0, 0.0,
+                                /*entry=*/9.88, /*best_start=*/9.93, 0.01);
+    CHECK(f.should_fill == true);
+    CHECK(f.fill_price == 9.96);
+    CHECK(f.is_trail == true);
+    CHECK(near(f.path_position, 1.0 + (9.96 - 9.83) / (9.985 - 9.83), 1e-9));
+    // trail_offset=1: arms at 9.96, trails the 9.985 peak - 1t = 9.975
+    // (close 9.985: hold); 13:45Z (O 9.98, low-first) crosses 9.975 on the
+    // O->L leg — a sub-tick level, floored to 9.97 by the consumer (TV
+    // trail-eq-L-off1 @9.97).
+    ExitPathFill hold = trail_fill(kF0402_1330, PositionSide::LONG, 8.0, 1.0,
+                                   9.88, 9.93, 0.01);
+    CHECK(hold.should_fill == false);
+    ExitPathFill g = trail_fill(kF0402_1345, PositionSide::LONG, 8.0, 1.0,
+                                9.88, /*best_start=*/9.985, 0.01);
+    CHECK(g.should_fill == true);
+    CHECK(near(g.fill_price, 9.975));
+    CHECK(g.is_trail == true);
+}
+
+void test_resolver_btc_short_activation_after_tolerant_ceil() {
+    std::printf("test_resolver_btc_short_activation_after_tolerant_ceil\n");
+    // 235120t from 117559.99 -> 115208.79, crossed on the O->H->L->C path's
+    // H->L leg of 08-18 03:30Z. std::ceil's 235121t would put it at .78.
+    const double tp = scalper_trail_points(117560.0, 0.01);
+    ExitPathFill f = trail_fill(kBtc0818_0330, PositionSide::SHORT, tp, kNaN,
+                                /*entry=*/117559.99, /*best_start=*/115292.67,
+                                /*mintick=*/0.01);
+    CHECK(f.should_fill == true);
+    CHECK(near(f.fill_price, 115208.79));
+    CHECK(f.is_trail == true);
+    ExitPathFill g = trail_fill(kBtc0818_0330, PositionSide::SHORT, 235121.0, kNaN,
+                                117559.99, 115292.67, 0.01);
+    CHECK(g.should_fill == true);
+    CHECK(near(g.fill_price, 115208.78));
+}
+
+// ── engine-level fixtures ─────────────────────────────────────────────
+
+class TrailEngine : public BacktestEngine {
+public:
+    double exit_price(int i) const { return closed_trade_exit_price(i); }
+    double entry_price(int i) const { return closed_trade_entry_price(i); }
+    int exit_bar(int i) const { return closed_trade_exit_bar_index(i); }
+    double position_size() const { return signed_position_size(); }
+};
+
+// The family's shape: a market entry on the signal bar (fills at the next
+// open) with strategy.exit(stop=close*0.99|1.01, trail_points=..., [offset])
+// issued alongside it; the exit rests until it fills.
+class ScalperTrailProbe : public TrailEngine {
+public:
+    ScalperTrailProbe(bool is_long, double trail_points, double trail_offset,
+                      double mintick, bool with_stop = true)
+        : is_long_(is_long), trail_points_(trail_points),
+          trail_offset_(trail_offset), with_stop_(with_stop) {
+        initial_capital_ = 1'000'000.0;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        process_orders_on_close_ = false;
+        syminfo_mintick_ = mintick;
+    }
+
+    void on_bar(const Bar& bar) override {
+        if (bar_index_ == 0) {
+            strategy_entry("E", is_long_, kNaN, kNaN, /*qty=*/1.0);
+            const double stop = with_stop_
+                ? (is_long_ ? bar.close * 0.99 : bar.close * 1.01)
+                : kNaN;
+            strategy_exit("x", "E", /*limit=*/kNaN, stop,
+                          trail_points_, trail_offset_, /*trail_price=*/kNaN);
+        }
+    }
+
+private:
+    bool is_long_;
+    double trail_points_;
+    double trail_offset_;
+    bool with_stop_;
+};
+
+struct Outcome {
+    int trades;
+    double entry_price;
+    double exit_price;
+    int exit_bar;
+    double position;
+    std::string error;
+};
+
+Outcome run_probe(bool is_long, double trail_points, double trail_offset,
+                  double mintick, const std::vector<Bar>& bars,
+                  bool with_stop = true) {
+    ScalperTrailProbe eng(is_long, trail_points, trail_offset, mintick, with_stop);
+    eng.run(bars.data(), (int)bars.size());
+    Outcome o{eng.trade_count(), kNaN, kNaN, -1, eng.position_size(),
+              eng.last_error()};
+    if (eng.trade_count() >= 1) {
+        o.entry_price = eng.entry_price(0);
+        o.exit_price = eng.exit_price(0);
+        o.exit_bar = eng.exit_bar(0);
+    }
+    return o;
+}
+
+void test_engine_aapl_long_exit_floors_at_subtick_open() {
+    std::printf("test_engine_aapl_long_exit_floors_at_subtick_open\n");
+    const std::vector<Bar> bars = {
+        kAaplSignal0421_1930, kAaplEntry0421_1945, kAapl0422_1330, kAapl0422_1345,
+    };
+    const double tp = scalper_trail_points(191.92, 0.01);
+    // Omitted offset and explicit 0: TV 196.13 (was 196.14).
+    const double one_shot[] = {kNaN, 0.0};
+    for (double off : one_shot) {
+        Outcome o = run_probe(true, tp, off, 0.01, bars);
+        CHECK(o.error.empty());
+        CHECK(o.trades == 1);
+        CHECK(near(o.entry_price, 191.91));
+        CHECK(near(o.exit_price, 196.13));
+        CHECK(o.exit_bar == 2);
+        CHECK(near(o.position, 0.0));
+    }
+    // trail_offset=1: 196.135 - 1t = 196.125 floored -> 196.12 (TV).
+    Outcome o1 = run_probe(true, tp, 1.0, 0.01, bars);
+    CHECK(o1.error.empty());
+    CHECK(o1.trades == 1);
+    CHECK(near(o1.exit_price, 196.12));
+    CHECK(o1.exit_bar == 2);
+}
+
+void test_engine_aapl_short_exit_ceils_at_subtick_open() {
+    std::printf("test_engine_aapl_short_exit_ceils_at_subtick_open\n");
+    const std::vector<Bar> bars = {
+        kAaplSignal0522_1715, kAaplEntry0522_1730, kAapl0522_1745, kAapl0522_1800,
+        kAapl0522_1815, kAapl0522_1830, kAapl0522_1845, kAapl0522_1900,
+        kAapl0522_1915, kAapl0522_1930, kAapl0522_1945, kAapl0523_1330,
+        kAapl0523_1345,
+    };
+    const double tp = scalper_trail_points(201.88, 0.01);
+    Outcome o = run_probe(false, tp, kNaN, 0.01, bars);
+    CHECK(o.error.empty());
+    CHECK(o.trades == 1);
+    CHECK(near(o.entry_price, 201.9));
+    CHECK(near(o.exit_price, 193.67));   // TV (ceil == nearest for 193.665)
+    CHECK(o.exit_bar == 11);
+    CHECK(near(o.position, 0.0));
+}
+
+void test_engine_ford_short_activation_touch_and_tolerant_ticks() {
+    std::printf("test_engine_ford_short_activation_touch_and_tolerant_ticks\n");
+    const std::vector<Bar> bars = {
+        kFSignal0402_1900, kFEntry0402_1915, kF0402_1930, kF0402_1945,
+        kF0403_1330, kF0403_1345, kF0403_1400, kF0403_1415,
+    };
+    // The probe's row: entry 10.105 -> 10.11 (nearest), 20.21 -> 21t ->
+    // activation 9.90 touched by the 13:45Z low -> exit @9.90 on bar 5
+    // (was the 14:00Z open 9.89 on bar 6).
+    Outcome probe = run_probe(false, scalper_trail_points(10.105, 0.01), kNaN,
+                              0.01, bars);
+    CHECK(probe.error.empty());
+    CHECK(probe.trades == 1);
+    CHECK(near(probe.entry_price, 10.11));
+    CHECK(near(probe.exit_price, 9.90));
+    CHECK(probe.exit_bar == 5);
+    CHECK(near(probe.position, 0.0));
+    // The synthetic pins (trail-eq-*), same bars, offsets NaN / 0 / 1 / fp3.
+    struct Pin { double tp; double off; double price; int bar; };
+    const Pin pins[] = {
+        {18.0, kNaN, 9.93, 5},          // trail-eq-S-omit
+        {18.0, 0.0, 9.93, 5},           // trail-eq-S-off0
+        {21.0, 0.0, 9.90, 5},           // trail-eq-S-off0-tp21
+        {18.2, 0.0, 9.92, 5},           // trail-eq-S-off0-tp18p2
+        {18.0, 1.0, 9.90, 6},           // trail-eq-S-off1 (14:00Z high 9.90)
+        {18.0, 0.3 / (0.01 * 10.0), 9.85, 7},  // trail-eq-S-off3fp2 (14:15Z)
+        {14.00001, 0.0, 9.97, 4},       // trail-eq-S-off0-tp1400001 (13:30Z)
+        {14.0001, 0.0, 9.96, 4},        // trail-eq-S-off0-tp140001
+        {14.001, 0.0, 9.96, 4},         // trail-eq-S-off0-tp14001
+        {0.14 / 0.01, 0.0, 9.97, 4},    // trail-eq-S-off0-fpceil
+        {14.0000001, 0.0, 9.97, 4},     // trail-eq-S-off0-fpceil2
+    };
+    for (const Pin& p : pins) {
+        Outcome o = run_probe(false, p.tp, p.off, 0.01, bars, /*with_stop=*/false);
+        CHECK(o.error.empty());
+        CHECK(o.trades == 1);
+        CHECK(near(o.entry_price, 10.11));
+        CHECK(near(o.exit_price, p.price));
+        CHECK(o.exit_bar == p.bar);
+        CHECK(near(o.position, 0.0));
+    }
+}
+
+void test_engine_ford_long_twin() {
+    std::printf("test_engine_ford_long_twin\n");
+    const std::vector<Bar> bars = {
+        kFSignal0401_1900, kFEntry0401_1915, kF0401_1930, kF0401_1945,
+        kF0402_1330, kF0402_1345, kF0402_1400,
+    };
+    Outcome o0 = run_probe(true, 8.0, 0.0, 0.01, bars, /*with_stop=*/false);
+    CHECK(o0.error.empty());
+    CHECK(o0.trades == 1);
+    CHECK(near(o0.entry_price, 9.88));
+    CHECK(near(o0.exit_price, 9.96));     // trail-eq-L-off0
+    CHECK(o0.exit_bar == 4);
+    Outcome o1 = run_probe(true, 8.0, 1.0, 0.01, bars, /*with_stop=*/false);
+    CHECK(o1.error.empty());
+    CHECK(o1.trades == 1);
+    CHECK(near(o1.exit_price, 9.97));     // trail-eq-L-off1 (9.975 floored)
+    CHECK(o1.exit_bar == 5);
+}
+
+void test_engine_btc_short_exit_at_the_tolerant_activation() {
+    std::printf("test_engine_btc_short_exit_at_the_tolerant_activation\n");
+    const std::vector<Bar> bars = {
+        kBtcSignal0817_2315, kBtcEntry0817_2330, kBtc0817_2345, kBtc0818_0000,
+        kBtc0818_0015, kBtc0818_0030, kBtc0818_0045, kBtc0818_0100,
+        kBtc0818_0115, kBtc0818_0130, kBtc0818_0145, kBtc0818_0200,
+        kBtc0818_0215, kBtc0818_0230, kBtc0818_0245, kBtc0818_0300,
+        kBtc0818_0315, kBtc0818_0330, kBtc0818_0345,
+    };
+    Outcome o = run_probe(false, scalper_trail_points(117560.0, 0.01), kNaN,
+                          0.01, bars);
+    CHECK(o.error.empty());
+    CHECK(o.trades == 1);
+    CHECK(near(o.entry_price, 117559.99));
+    CHECK(near(o.exit_price, 115208.79));   // TV; was 115208.78
+    CHECK(o.exit_bar == 17);
+    CHECK(near(o.position, 0.0));
+}
+
+void test_engine_on_tick_open_and_resting_stop_gap_unchanged() {
+    std::printf("test_engine_on_tick_open_and_resting_stop_gap_unchanged\n");
+    // Control 1: a one-shot trail arming at an ON-TICK open books that open
+    // (floor == nearest there): long @100.00, activation 100.30, bar 2 opens
+    // 100.50.
+    const std::vector<Bar> on_tick = {
+        mk(100.00, 100.10, 99.90, 100.00, 1000),
+        mk(100.00, 100.20, 99.95, 100.10, 2000),
+        mk(100.50, 100.80, 100.40, 100.70, 3000),
+        mk(100.70, 100.90, 100.60, 100.80, 4000),
+    };
+    Outcome a = run_probe(true, 30.0, kNaN, 0.01, on_tick, /*with_stop=*/false);
+    CHECK(a.error.empty());
+    CHECK(a.trades == 1);
+    CHECK(near(a.exit_price, 100.50));
+    CHECK(a.exit_bar == 2);
+    // Control 2: a resting STOP the open gaps through is still a raw print,
+    // nearest-rounded (finding-446): long @191.91 with a sell stop 196.50
+    // resting above the entry and the 04-22 13:30Z open 196.135 below it ->
+    // 196.14, not the trail's 196.13.
+    class StopGapProbe : public TrailEngine {
+    public:
+        StopGapProbe() {
+            initial_capital_ = 1'000'000.0;
+            default_qty_type_ = QtyType::FIXED;
+            default_qty_value_ = 1.0;
+            commission_value_ = 0.0;
+            slippage_ = 0;
+            process_orders_on_close_ = false;
+            syminfo_mintick_ = 0.01;
+        }
+        void on_bar(const Bar&) override {
+            if (bar_index_ == 0) {
+                strategy_entry("E", true, kNaN, kNaN, /*qty=*/1.0);
+            } else if (bar_index_ == 1) {
+                strategy_exit("x", "E", /*limit=*/kNaN, /*stop=*/196.50);
+            }
+        }
+    };
+    StopGapProbe eng;
+    const std::vector<Bar> bars = {
+        kAaplSignal0421_1930, kAaplEntry0421_1945, kAapl0422_1330, kAapl0422_1345,
+    };
+    eng.run(bars.data(), (int)bars.size());
+    CHECK(eng.last_error().empty());
+    CHECK(eng.trade_count() == 1);
+    if (eng.trade_count() == 1) {
+        CHECK(near(eng.exit_price(0), 196.14));
+        CHECK(eng.exit_bar(0) == 2);
+    }
+}
+
+}  // namespace
+
+int main() {
+    std::printf("=== test_trail_fill_snap ===\n");
+
+    test_trail_points_ceil_is_tolerant();
+    test_trail_offset_floor_is_exact();
+    test_trail_level_tick_grid_snap();
+
+    test_resolver_aapl_long_arms_at_subtick_open();
+    test_resolver_aapl_short_arms_at_subtick_open();
+    test_resolver_adverse_gap_through_armed_level_is_a_raw_print();
+
+    test_resolver_ford_short_activation_touched_by_the_low();
+    test_resolver_ford_short_fills_at_activation_not_at_the_extreme();
+    test_resolver_ford_short_whole_tick_offset_level_touched_by_the_high();
+    test_resolver_ford_long_twin();
+    test_resolver_btc_short_activation_after_tolerant_ceil();
+
+    test_engine_aapl_long_exit_floors_at_subtick_open();
+    test_engine_aapl_short_exit_ceils_at_subtick_open();
+    test_engine_ford_short_activation_touch_and_tolerant_ticks();
+    test_engine_ford_long_twin();
+    test_engine_btc_short_exit_at_the_tolerant_activation();
+    test_engine_on_tick_open_and_resting_stop_gap_unchanged();
+
+    std::printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    return (tests_failed > 0) ? 1 : 0;
+}


### PR DESCRIPTION
Round-7e engine candidate (on the round-7c head d9e15ab; codegen unchanged at 65e7fd0), gated PASS against baseline `pineforge-parity-baseline-20260905-engine-d9e15abd` (fast pr-gate, hard 0 regressions): 4161 → 4162 excellent+strong, +9 tiers, 0 down.

Pinned on TradingView (`lab tv` tapes; rules in the campaign ledger):
- A one-shot trailing exit filled at a sub-tick bar open snaps directionally (sell floors, buy ceils); `trail_points` ceils with an FP tolerance (14.00001 → 14 ticks) and `trail_offset` floors exactly; activation and trailing levels within 1e-6 tick of the grid sit on the grid, so a touch counts.
- Trail activation is tested on the tick-quantized bar, like stop/limit triggers.
- Pine's tolerant relational compare (|a − b| ≤ 1e-10, inclusive) applies inside `ta.dmi` (`up > down`), shared via `pine_float_compare.hpp`.
- The native-1D tuple `request.security` path is pinned by test (already correct).

Tests: ctest 174/174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pyos7rr4EChCzh3H6S3Vob