### PR TITLE
round 7f: default percent-of-equity stop entries are sized at the tick-snapped level, placement-checked at tick(close), and filled with that quantity

### DIFF
--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -427,17 +427,47 @@ struct PendingOrder {
     // flips every one of them. Keep ``qty`` NaN; read this field only where a
     // quantity is actually computed.
     double frozen_default_qty = std::numeric_limits<double>::quiet_NaN();
-    // Placement snapshot for one narrowly scoped default-sized pure STOP. A
-    // next-bar open-marketable fill uses this already-quantized quantity for
-    // both margin admission and dispatch. Intrabar touches and every other
-    // priced-entry shape remain fill-time-sized. Keeping it separate from
-    // frozen_default_qty prevents generic MARKET consumers from widening the
-    // rule. NaN means ordinary stop sizing/admission.
-    double stop_placement_open_qty =
+    // Placement snapshot of a DEFAULT percent_of_equity <= 100 pure STOP
+    // entry (round 7, family K default-percent stop-entry sizing; ledger note
+    // log-20260905t084529z-c7b22df1, lab tv tapes scratchpad/r7/pins/
+    // f15-stopsize-{pct100,pct50,short-only,short-m50}, NYSE:F 15
+    // 2025-08-11..23). TradingView sizes the order when strategy.entry is
+    // called, at the TICK-SNAPPED STOP LEVEL (buy stop ceil, sell stop floor):
+    //
+    //   qty = floor_step(equity(B) * pct/100 / (tick(level) + slippage))
+    //
+    // (pct100: 858 = floor(10,000 / 11.65) on the 08-19 13:30Z touch, 854 =
+    // floor(10,000 / 11.70) on 08-22; 873 / 869 at the 11.45 / 11.50 closes
+    // would be wrong; pct50: 450 / 444 / 441 = floor(0.5 eq / L) on the short
+    // touches; margin 50: 901 / 886 / 880 = floor(eq / L)), then runs the
+    // family-E placement check on that quantity at the tick-rounded CLOSE of
+    // the call bar (qty * tick(close) * pv * fx * margin%/100 <= equity), so
+    // an all-in sell stop BELOW the close is never placed (floor(eq/L) * C >
+    // eq: 0 short fills over 3 touches in pct100, 0 fills in short-only —
+    // not an opposite-order effect) while a buy stop above the close always
+    // is. A stop whose level is already at or beyond the close is TV's
+    // market-at-next-open order and is sized like one, at tick(close) +
+    // slippage (frozen_sizing_price; ahtisham F@15 2025-04-04: the 13:30Z
+    // close 9.335 -> 9.34 sizes 1,043 = 88 + 955 filled 13:45Z @9.34).
+    // The quantity is fixed here — a resting order is never re-sized, only
+    // the script's next call re-issues it — and is consumed by the fill-time
+    // admission (stop_entry_margin_admission_declines: qty * tick(fill) <=
+    // realized equity, the level on a touch, the rounded open on a
+    // gap-through) and by dispatch. Explicit-qty / FIXED / CASH / >100%
+    // stops carry no snapshot (family E). NaN means no snapshot: ordinary
+    // fill-time sizing. Kept separate from frozen_default_qty so generic
+    // MARKET consumers never see it.
+    double default_stop_placement_qty =
         std::numeric_limits<double>::quiet_NaN();
-    double stop_placement_open_equity =
+    // strategy.equity as the script read it on the call bar (the placement
+    // check's right-hand side), the tick-rounded call-bar close (its price
+    // basis) and the sizing basis the quantity was divided at — tick(level)
+    // (+/- slippage) or, for a beyond-level stop, tick(close) (+/- slippage).
+    double default_stop_placement_equity =
         std::numeric_limits<double>::quiet_NaN();
-    double stop_placement_signal_close =
+    double default_stop_placement_signal_close =
+        std::numeric_limits<double>::quiet_NaN();
+    double default_stop_sizing_price =
         std::numeric_limits<double>::quiet_NaN();
     // TV margin-admission snapshot for a FROZEN default-sized market order
     // (KI-54). Captured at the same placement point as frozen_default_qty:
@@ -2018,6 +2048,25 @@ protected:
             o.affordability_placement_equity =
                 current_equity() + open_profit(current_bar_.close);
         }
+        // round 7 (family K): a default percent_of_equity <= 100 STOP placed
+        // by this bar's on_bar was sized on pre-liquidation equity too.
+        // Re-size it at its sizing basis on the post-liquidation state, the
+        // same re-freeze the market orders above get. The placement verdict
+        // is not revisited (this runs inside process_pending_orders on the
+        // finding-308 path, where the book must not be mutated); the
+        // fill-time admission still costs the re-sized quantity at the fill.
+        for (auto& o : pending_orders_) {
+            if (o.type != OrderType::ENTRY) continue;
+            if (o.created_bar != bar_index_) continue;
+            if (!std::isfinite(o.default_stop_placement_qty)) continue;
+            if (!std::isfinite(o.default_stop_sizing_price)) continue;
+            o.default_stop_placement_qty =
+                calc_qty(o.default_stop_sizing_price);
+            o.default_stop_placement_equity =
+                current_equity() + open_profit(current_bar_.close);
+            o.default_stop_placement_signal_close =
+                round_to_mintick(current_bar_.close);
+        }
     }
 
     // --- Strategy variable accessors ---
@@ -3057,8 +3106,13 @@ private:
                                      std::vector<size_t>& filled_indices);
     bool stop_entry_margin_admission_declines(
         const PendingOrder& order, double fill_price, const Bar& bar) const;
-    bool use_stop_placement_open_qty(
-        const PendingOrder& order, double fill_price, const Bar& bar) const;
+    // True iff `order` is a default percent_of_equity <= 100 pure STOP that
+    // carries its placement snapshot (PendingOrder::default_stop_placement_qty)
+    // and the fill price is a usable positive print: the fill-time admission
+    // and dispatch then consume the placement quantity instead of re-sizing
+    // at the fill.
+    bool use_default_stop_placement_qty(
+        const PendingOrder& order, double fill_price) const;
     // design-declined-reversal-close-leg: called at the KI-54 reversal-decline
     // site with the just-declined MARKET reversal entry. Flags every pending
     // FULL close that was co-queued after it on the same bar against the held

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -3361,57 +3361,40 @@ void BacktestEngine::compact_filled_pending_orders(
 }
 
 
-bool BacktestEngine::use_stop_placement_open_qty(
-        const PendingOrder& order, double fill_price, const Bar& bar) const {
+// round 7 (family K default-percent stop-entry sizing; rule, tapes and
+// numbers on PendingOrder::default_stop_placement_qty): the DEFAULT
+// percent_of_equity <= 100 pure STOP was sized when strategy.entry was
+// called — at the tick-snapped level, or at tick(close) for a beyond-level
+// stop — and that quantity is the order's quantity for the rest of its life:
+// the fill-time admission costs it and dispatch opens it, on an intrabar
+// touch (the level), on a gap-through (the rounded open) and on the
+// next-open fill of a beyond-level stop alike; a resting order is never
+// re-sized (only the script's next call re-issues it). Scope of the
+// consumption: a true-flat placement (created FLAT, not after a same-bar
+// close) filling from FLAT — the shape every tape and the ahtisham decode
+// pin. A stop placed while a position is held (a same-direction add, a
+// reversal, a deferred-flip carry) keeps the established fill-time sizing
+// of its kernel, and a fill against a live opposite position keeps the
+// reversal kernel's own sizing; both still passed the family-E placement
+// check at the call. A non-positive fill print (a zero open) falls back too,
+// so the zero-lot decline stays byte-identical.
+bool BacktestEngine::use_default_stop_placement_qty(
+        const PendingOrder& order, double fill_price) const {
     if (order.type != OrderType::ENTRY
         || std::isnan(order.stop_price)
         || !std::isnan(order.limit_price)
-        || !std::isfinite(bar.open)
-        || bar.open <= 0.0) {
+        || !std::isnan(order.qty)
+        || order.affordability_close_only) {
         return false;
     }
-    const double margin_pct = order.is_long ? margin_long_ : margin_short_;
-    // A candidate snapshot is usable only on the immediately following bar
-    // when the pure STOP is already marketable at O and therefore fills exactly
-    // at O. Re-prove the ordinary scheduler and unchanged true-flat equity at
-    // consumption time; any intervening fill, delayed resting order, intrabar
-    // touch, OCA link, commission/slippage, or non-default sizing falls back to
-    // established fill-time sizing. This covers favorable and adverse gaps:
-    // both carry the placement qty, while only an adverse notional overshoot is
-    // declined by the caller's margin comparison.
-    // design-stop-tick-rounding: the same tick-quantized open test
-    // evaluate_fill_price's gap fill uses.
-    const double tick_open = broker_trigger_bar(bar).open;
-    const bool gap_open_marketable =
-        order.is_long ? tick_open >= order.stop_price
-                      : tick_open <= order.stop_price;
-    const double placement_equity =
-        order.stop_placement_open_equity;
-    const double equity_guard = std::isfinite(placement_equity)
-        ? std::max(1e-9, std::abs(placement_equity) * 1e-12)
-        : 0.0;
-    return std::isfinite(order.stop_placement_open_qty)
-        && order.stop_placement_open_qty > 0.0
-        && std::isfinite(placement_equity) && placement_equity > 0.0
-        && std::isfinite(order.stop_placement_signal_close)
+    return default_qty_type_ == QtyType::PERCENT_OF_EQUITY
+        && default_qty_value_ <= 100.0
+        && std::isfinite(order.default_stop_placement_qty)
+        && order.default_stop_placement_qty > 0.0
+        && std::isfinite(fill_price) && fill_price > 0.0
         && order.created_position_side == PositionSide::FLAT
         && !order.created_after_position_close_in_bar
-        && position_side_ == PositionSide::FLAT
-        && order.created_bar == bar_index_ - 1
-        && !process_orders_on_close_
-        && !calc_on_order_fills_
-        && !bar_magnifier_enabled_
-        && !order.created_during_coof_recalc
-        && order.oca_name.empty() && order.oca_type == 0
-        && default_qty_type_ == QtyType::PERCENT_OF_EQUITY
-        && std::abs(default_qty_value_ - 100.0) < 1e-12
-        && std::abs(margin_pct - 100.0) < 1e-12
-        && slippage_ == 0
-        && gap_open_marketable
-        && fill_price == bar_fill_price(bar.open)
-        && std::abs(current_equity() - placement_equity) <= equity_guard
-        && calc_commission(
-               fill_price, order.stop_placement_open_qty) == 0.0;
+        && position_side_ == PositionSide::FLAT;
 }
 
 
@@ -3421,25 +3404,32 @@ bool BacktestEngine::use_stop_placement_open_qty(
 //   decline iff floored_qty * cost_basis * pv * fx * margin%/100
 //               > realized equity at the fill
 //
-// The cost basis partitions on the same default-sizing test as the
-// placement half (strategy_entry's affordability_scope): an explicit-qty,
-// default FIXED / CASH or default percent_of_equity > 100 stop is costed
-// at the price the fill BOOKS — the stop level on an intrabar touch, the
-// tick-rounded open on a gap-through (the round-7 pin below). The DEFAULT
-// percent_of_equity <= 100 stop keeps KI-62's bar-OPEN basis: nothing
-// pinned it (all 22 tapes pass an explicit qty), and costing it at the
-// level is a structural no-op for an all-in default (qty = equity / level
-// -> qty * level == equity always admits) that broke the ahtisham
-// volatility-expansion probe on every lane (cand-round7-engine-a-20260905
-// vs base-round7-harness-20260905, BINANCE:ETHUSDT.P 15: 591 -> 1,177
-// trades, 394 extra SHORT entries, every one an intrabar touch whose open
-// is above the level — 2025-04-02 05:15Z o 1866.16 > level 1859.63 >= l
-// 1853.57, 5.3133 * 1866.16 = 9,915 > 9,880.86 declines at the open where
-// 5.3133 * 1859.63 = 9,880.8 admits at the level; TV has no trade there).
-// Under the open basis a default-sized LONG touch (open < level) admits on
-// both bases and a gap-through books the open on both, so the partition
-// changes exactly the default short touch the base engine matched TV on
-// (tests/test_stop_entry_admission.cpp, test_ahtisham_default_pct_stop).
+// The cost basis is the price the fill BOOKS in every sizing partition —
+// the stop level on an intrabar touch, the tick-rounded open on a
+// gap-through (the round-7 family-E pin below). The quantity is the
+// order's: the explicit-qty / default FIXED / CASH / >100% stop re-sizes
+// at the fill (calc_qty_for_type); the DEFAULT percent_of_equity <= 100
+// stop carries the quantity it was sized with at the call (family K,
+// PendingOrder::default_stop_placement_qty — floor(equity * pct /
+// tick(level))), the same quantity dispatch opens.
+//
+// KI-62's bar-OPEN basis for the default partition is RETIRED here: it was
+// the family-K placement rule seen from the fill side. The ahtisham
+// volatility-expansion decode (NYSE:F 15, 121/126 TV entries reproduced
+// with qty and price, every non-fill) shows the open basis coincided with
+// TV on all 178 intrabar touches only because an all-in sell stop below
+// the close is never PLACED (floor(eq/L) * tick(close) > eq — 0 short
+// fills over 3 touches on the pct100 tape, 0 on short-only; the ETH
+// 2025-04-02 05:15Z short touch the open basis declined is that same
+// never-placed order: 5.3133 * 1866.16 = 9,915.5 > 9,880.86 at the 05:00Z
+// close) — and diverged on every session-open gap: 18/18 first-bar SHORT
+// gap-throughs the engine filled at the open TV never placed (2025-04-04
+// 13:30Z 1,020 @9.32; TV re-issues at the 13:30Z close and fills the
+// beyond-level order 13:45Z @9.34 x 1,043), and 6 first-bar LONG
+// gap-throughs TV fills that the close-sized quantity over-costed
+// (2025-08-19 13:30Z: 817 = floor(9,414.16 / 11.51) x 11.52 = 9,411.84
+// <= 9,414.16 admits; 822 sized at the 11.45 close x 11.52 = 9,469 does
+// not).
 //
 // For the explicit partition, KI-62's premise that TV costs the bar OPEN
 // even on a touch is refuted by the tapes —
@@ -3467,12 +3457,12 @@ bool BacktestEngine::use_stop_placement_open_qty(
 // reversal that already lost its entry leg at placement (close-only
 // orders open nothing). The available equity is realized-only
 // (current_equity()), unchanged from KI-62. The qty is exactly the fill
-// kernel's: normally calc_qty_for_type at the fill price; for the narrowly
-// scoped next-open default-percent-100 STOP rule, the same placement
-// snapshot that dispatch consumes. Admission therefore never approves one
-// quantity and executes another.
+// kernel's: the default percent <= 100 stop's placement quantity when
+// use_default_stop_placement_qty says dispatch consumes it, otherwise
+// calc_qty_for_type at the fill price. Admission therefore never approves
+// one quantity and executes another.
 bool BacktestEngine::stop_entry_margin_admission_declines(
-        const PendingOrder& order, double fill_price, const Bar& bar) const {
+        const PendingOrder& order, double fill_price, const Bar& /*bar*/) const {
     if (order.type != OrderType::ENTRY
         || std::isnan(order.stop_price)
         || !std::isnan(order.limit_price)
@@ -3480,37 +3470,21 @@ bool BacktestEngine::stop_entry_margin_admission_declines(
         return false;
     }
     const double margin_pct = order.is_long ? margin_long_ : margin_short_;
-    // The same sizing partition as strategy_entry's affordability_scope:
-    // order.qty is the call's explicit qty (NaN for a default-sized entry)
-    // and default_qty_type_/default_qty_value_ the declaration's sizing.
-    const bool placement_partition =
-        !std::isnan(order.qty)
-        || default_qty_type_ == QtyType::FIXED
-        || default_qty_type_ == QtyType::CASH
-        || (default_qty_type_ == QtyType::PERCENT_OF_EQUITY
-            && default_qty_value_ > 100.0);
     // design-stop-tick-rounding / finding-446: the level is already
     // directionally snapped and a gap open already nearest-rounded when it
     // reaches here, so round_to_mintick is an identity to within one ulp.
-    // The default percent_of_equity <= 100 partition costs the bar OPEN
-    // (KI-62, unchanged — see above).
-    const double cost_basis = placement_partition
-        ? round_to_mintick(fill_price) : bar.open;
+    const double cost_basis = round_to_mintick(fill_price);
     if (!(margin_pct > 0.0) || !std::isfinite(cost_basis)
         || cost_basis <= 0.0) {
         return false;
     }
-    const bool use_placement_open_qty =
-        use_stop_placement_open_qty(order, fill_price, bar);
-    const double fill_qty = use_placement_open_qty
-        ? std::abs(order.stop_placement_open_qty)
+    const double fill_qty = use_default_stop_placement_qty(order, fill_price)
+        ? std::abs(order.default_stop_placement_qty)
         : std::abs(calc_qty_for_type(fill_price, order.qty, order.qty_type));
     const double required = fill_qty * cost_basis * syminfo_.pointvalue
                             * active_account_currency_fx()
                             * (margin_pct / 100.0);
-    const double available = use_placement_open_qty
-        ? order.stop_placement_open_equity
-        : current_equity();
+    const double available = current_equity();
     const double eps = std::max(1e-9, std::abs(available) * 1e-12);
     return fill_qty > 0.0 && required > available + eps;
 }
@@ -3582,11 +3556,12 @@ void BacktestEngine::apply_filled_order_to_state(
     }
 
     // Fill-time margin admission for STOP-ENTRY fills (KI-62 stage 3,
-    // re-based in round 7 for the explicit-qty / FIXED / CASH / >100%
-    // partition): the same floored quantity costed at the tick-rounded FILL
-    // price — the level on a touch, the rounded open on a gap-through —
-    // against realized equity; the default percent_of_equity <= 100 stop
-    // keeps the bar-OPEN basis. Rule, tapes and scope on
+    // re-based in round 7): the order's quantity — re-sized at the fill for
+    // the explicit-qty / FIXED / CASH / >100% partition, the placement
+    // quantity for a default percent_of_equity <= 100 stop (family K) —
+    // costed at the tick-rounded FILL price — the level on a touch, the
+    // rounded open on a gap-through — against realized equity. KI-62's
+    // bar-OPEN basis is retired. Rule, tapes and scope on
     // stop_entry_margin_admission_declines above. A declined stop is
     // CANCELLED (consumed here, removed by compaction). Does NOT touch the
     // :443 created_bar eligibility, the signal-time MARKET gate, or any
@@ -3814,8 +3789,8 @@ void BacktestEngine::apply_filled_order_to_state(
             if (!std::isnan(order.frozen_default_qty)) {
                 opening_qty = order.frozen_default_qty;
             } else if (order.type == OrderType::ENTRY
-                       && use_stop_placement_open_qty(order, fill_price, bar)) {
-                opening_qty = order.stop_placement_open_qty;
+                       && use_default_stop_placement_qty(order, fill_price)) {
+                opening_qty = order.default_stop_placement_qty;
             } else {
                 opening_qty = calc_qty_for_type(
                     apply_fill_slippage(fill_price, order.is_long),
@@ -5196,12 +5171,15 @@ void BacktestEngine::apply_entry_order_fill(PendingOrder& order, double fill_pri
     }
     const bool close_only_opposite =
         prior_cycle_close_only || same_cycle_frozen_tx_exact_flat;
-    const bool use_placement_open_qty =
-        use_stop_placement_open_qty(order, fill_price, bar);
-    const double dispatch_qty = use_placement_open_qty
-        ? order.stop_placement_open_qty
+    // round 7 (family K): a default percent <= 100 stop dispatches the
+    // quantity it was sized with at placement (see
+    // use_default_stop_placement_qty); every other stop sizes at the fill.
+    const bool use_placement_qty =
+        use_default_stop_placement_qty(order, fill_price);
+    const double dispatch_qty = use_placement_qty
+        ? order.default_stop_placement_qty
         : order.qty;
-    const int dispatch_qty_type = use_placement_open_qty ? -1 : order.qty_type;
+    const int dispatch_qty_type = use_placement_qty ? -1 : order.qty_type;
     execute_market_entry(order.id, order.is_long, fill_price,
                          dispatch_qty, dispatch_qty_type,
                          order.created_position_side, close_only_opposite,
@@ -5211,7 +5189,7 @@ void BacktestEngine::apply_entry_order_fill(PendingOrder& order, double fill_pri
                          /*later_same_tick_entry=*/false,
                          /*paired_flat_market_transaction=*/false,
                          /*explicit_qty_prequantized=*/
-                             use_placement_open_qty,
+                             use_placement_qty,
                          order.incarnation);
 
     bool did_execute =

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -294,13 +294,14 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
     // (qty * sizing_price <= sizing_equity) makes this placement check a
     // structural no-op there anyway. The two scopes partition on the same
     // default_qty_value_ <= 100 test the KI-54 gate uses, so exactly 100%
-    // is byte-identical. The same sizing partition applies to pure STOP
-    // entries (round 7): a default percent_of_equity stop at or below 100%
-    // keeps the stop_placement_open_* snapshot below and its fill-time
-    // admission; explicit-qty, FIXED / CASH default and >100% stops take
-    // this placement half. Stop-limit and limit entries carry their own
-    // price and are untouched. margin_pct == 0 disables the check, as it
-    // does in TradingView.
+    // is byte-identical. Pure STOP entries take the same placement half in
+    // every sizing partition (round 7): explicit-qty, FIXED / CASH default
+    // and >100% stops with the family-E quantity; a DEFAULT percent_of_equity
+    // stop at or below 100% with its family-K quantity — sized at the
+    // tick-snapped STOP LEVEL, not the close (default_stop_scope below;
+    // rule, tapes and numbers on PendingOrder::default_stop_placement_qty).
+    // Stop-limit and limit entries carry their own price and are untouched.
+    // margin_pct == 0 disables the check, as it does in TradingView.
     const bool pure_stop_entry =
         std::isnan(limit_price) && std::isfinite(stop_price);
     const bool affordability_scope =
@@ -311,13 +312,59 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
             || default_qty_type_ == QtyType::CASH
             || (default_qty_type_ == QtyType::PERCENT_OF_EQUITY
                 && default_qty_value_ > 100.0));
+    // round 7 (family K, ledger note log-20260905t084529z-c7b22df1; lab tv
+    // tapes scratchpad/r7/pins/f15-stopsize-{pct100,pct50,short-only,
+    // short-m50}): TradingView sizes a DEFAULT percent_of_equity <= 100 pure
+    // STOP entry when the call is made, at the tick-snapped stop level (buy
+    // stop ceil, sell stop floor) plus the slippage ticks the fill will
+    // carry — qty = floor_step(equity * pct / tick(level)) — and then runs
+    // the placement check above on THAT quantity at tick(close). A level
+    // already at or beyond the close is a market-at-next-open order and is
+    // sized like one, at tick(close) + slippage (frozen_sizing_price, the
+    // family-H basis: ahtisham F@15 2025-04-04 13:30Z close 9.335 -> 9.34,
+    // 1,043 = floor(9,742.34 / 9.34) filled 13:45Z @9.34 as TV's 88 + 955).
+    // The quantity is frozen on the order (default_stop_placement_qty) for
+    // the fill-time admission and dispatch; a resting stop is never re-sized.
+    // The snapshot is taken whenever the close and the level are usable,
+    // the check itself only under margin simulation.
+    const bool default_stop_scope =
+        pure_stop_entry && std::isnan(qty)
+        && default_qty_type_ == QtyType::PERCENT_OF_EQUITY
+        && default_qty_value_ <= 100.0;
+    double default_stop_qty = std::numeric_limits<double>::quiet_NaN();
+    double default_stop_sizing_price =
+        std::numeric_limits<double>::quiet_NaN();
+    if (default_stop_scope && std::isfinite(current_bar_.close)
+        && current_bar_.close > 0.0 && stop_price > 0.0) {
+        const double signal_price = round_to_mintick(current_bar_.close);
+        const double snapped_level =
+            round_to_mintick_directional(stop_price, /*is_long_stop=*/is_long);
+        const bool beyond_level = is_long ? snapped_level <= signal_price
+                                          : snapped_level >= signal_price;
+        double sizing_price = frozen_sizing_price(/*is_buy=*/is_long);
+        if (!beyond_level && std::isfinite(snapped_level)
+            && snapped_level > 0.0) {
+            sizing_price = snapped_level;
+            if (slippage_ != 0 && syminfo_mintick_ > 0.0) {
+                sizing_price +=
+                    (is_long ? 1.0 : -1.0) * slippage_ * syminfo_mintick_;
+            }
+        }
+        const double sized = calc_qty(sizing_price);
+        if (std::isfinite(sized) && sized > kQtyEpsilon
+            && std::isfinite(sizing_price) && sizing_price > 0.0) {
+            default_stop_qty = sized;
+            default_stop_sizing_price = sizing_price;
+        }
+    }
     bool affordability_close_only = false;
     double affordability_placement_equity =
         std::numeric_limits<double>::quiet_NaN();
     double affordability_signal_price =
         std::numeric_limits<double>::quiet_NaN();
     double affordability_held_qty = 0.0;
-    if (affordability_scope) {
+    if (affordability_scope
+        || (default_stop_scope && std::isfinite(default_stop_qty))) {
         const double margin_pct = is_long ? margin_long_ : margin_short_;
         if (margin_pct > 0.0 && std::isfinite(current_bar_.close)
             && current_bar_.close > 0.0) {
@@ -329,14 +376,17 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
             // The on-tick signal close is the price the rule is stated on
             // (slippage ticks are in neither basis). The quantity is exactly
             // the one the fill kernel dispatches: the lot-floored explicit
-            // contracts, the FIXED default, or the CASH / >100%
+            // contracts, the FIXED default, the CASH / >100%
             // percent_of_equity default frozen at its slipped sizing basis
             // (frozen_default_market_qty — the same call that fills
-            // order.frozen_default_qty below).
+            // order.frozen_default_qty below), or the default percent <= 100
+            // STOP quantity sized at the level above.
             const double signal_price = round_to_mintick(current_bar_.close);
-            const double own_qty = std::isnan(qty)
-                ? frozen_default_market_qty(/*is_buy=*/is_long)
-                : calc_qty_for_type(signal_price, std::abs(qty), qty_type);
+            const double own_qty = default_stop_scope
+                ? default_stop_qty
+                : std::isnan(qty)
+                    ? frozen_default_market_qty(/*is_buy=*/is_long)
+                    : calc_qty_for_type(signal_price, std::abs(qty), qty_type);
             // A same-direction add is costed as the RESULTING position. Calls
             // are evaluated in source order, so a strategy.close issued
             // earlier in this on_bar has already released its quantity
@@ -632,44 +682,26 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
         // round 7: a pure STOP reversal whose entry leg was rejected at
         // placement rests as the reversal's closing leg only (consumed by
         // apply_entry_order_fill; its fill-time admission is skipped since
-        // nothing opens). No placement snapshot is stored on a stop: its
-        // fill-time half is stop_entry_margin_admission_declines.
+        // nothing opens). The explicit / FIXED / CASH / >100% partition
+        // stores no placement snapshot on a stop: its fill-time half is
+        // stop_entry_margin_admission_declines re-sizing at the fill.
         order.affordability_close_only = affordability_close_only;
 
-        // Snapshot one narrowly scoped pure STOP at placement. A next-bar
-        // open-marketable fill carries the already lot-quantized signal-close
-        // quantity into both admission and dispatch; fill-time logic re-proves
-        // every scope condition before consuming it.
-        const double stop_margin_pct =
-            is_long ? margin_long_ : margin_short_;
-        if (std::isnan(qty)
-            && std::isfinite(stop_price)
-            && std::isnan(limit_price)
-            && oca_name.empty() && oca_type == 0
-            && order.created_position_side == PositionSide::FLAT
-            && !order.created_after_position_close_in_bar
-            && default_qty_type_ == QtyType::PERCENT_OF_EQUITY
-            && std::abs(default_qty_value_ - 100.0) < 1e-12
-            && std::isfinite(stop_margin_pct)
-            && std::abs(stop_margin_pct - 100.0) < 1e-12
-            && !process_orders_on_close_
-            && !calc_on_order_fills_
-            && !bar_magnifier_enabled_
-            && !order.created_during_coof_recalc
-            && slippage_ == 0
-            && std::isfinite(current_bar_.close)
-            && current_bar_.close > 0.0) {
-            const double placement_equity = current_equity();
-            const double placement_qty = calc_qty(current_bar_.close);
-            if (std::isfinite(placement_equity) && placement_equity > 0.0
-                && std::isfinite(placement_qty)
-                && placement_qty > kQtyEpsilon
-                && calc_commission(current_bar_.close, placement_qty) == 0.0) {
-                order.stop_placement_open_qty = placement_qty;
-                order.stop_placement_open_equity = placement_equity;
-                order.stop_placement_signal_close =
-                    current_bar_.close;
-            }
+        // round 7 (family K): the DEFAULT percent_of_equity <= 100 pure STOP
+        // carries the quantity it was sized and placement-checked with (see
+        // default_stop_scope above and PendingOrder::default_stop_placement_
+        // qty). Both the fill-time admission and dispatch consume it — on an
+        // intrabar touch, on a gap-through and on the next-open fill of a
+        // beyond-level stop alike. order.qty stays NaN (default-sized
+        // semantics elsewhere are keyed on it).
+        if (default_stop_scope && std::isfinite(default_stop_qty)
+            && !affordability_close_only) {
+            order.default_stop_placement_qty = default_stop_qty;
+            order.default_stop_sizing_price = default_stop_sizing_price;
+            order.default_stop_placement_signal_close =
+                round_to_mintick(current_bar_.close);
+            order.default_stop_placement_equity =
+                current_equity() + open_profit(current_bar_.close);
         }
         // KI-65 placement-time pending-market awareness (probe pf-probe-ki65-
         // dual-entry-precedence): a priced entry placed from FLAT that will

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,6 +103,7 @@ set(TEST_SOURCES
     test_margin_stop_admission
     test_stop_entry_admission
     test_stop_entry_placement_open_qty
+    test_default_pct_stop_sizing
     test_stop_decline_continue_path
     test_frozen_flat_gap_reject
     test_market_admission_commission

--- a/tests/test_default_pct_stop_sizing.cpp
+++ b/tests/test_default_pct_stop_sizing.cpp
@@ -1,0 +1,866 @@
+/*
+ * test_default_pct_stop_sizing.cpp — round 7, family K: TradingView's sizing
+ * and admission of a DEFAULT percent_of_equity (<= 100) strategy.entry(stop=)
+ * under margin simulation, pinned by four `lab tv` tapes on NYSE:F 15
+ * 2025-08-11..23 (2026-09-05, ledger note log-20260905t084529z-c7b22df1;
+ * tapes scratchpad/r7/pins/f15-stopsize-{pct100,pct50,short-only,short-m50},
+ * decoder scratchpad/r7/k/aht_rule.py: 121/126 ahtisham F@15 TV entries
+ * reproduced with qty and price, every non-fill) and by the ahtisham
+ * volatility-expansion F@15 first-divergence rows (scratchpad/r7/k/).
+ *
+ * The pinned rule (default_qty_type = percent_of_equity, pct <= 100,
+ * margin_long/short > 0, default process_orders_on_close):
+ *
+ *   1. SIZING at the call: qty = floor(equity * pct/100 / tick(level)) with
+ *      the level snapped to the tick directionally (buy stop ceil, sell stop
+ *      floor) — NOT at the close: pct100 fills 858 = floor(10,000 / 11.65)
+ *      and 854 = floor(10,000 / 11.70) (873 / 869 at the closes); pct50
+ *      shorts 450 / 444 / 441 = floor(0.5 eq / L); margin 50 shorts
+ *      901 / 886 / 880 = floor(eq / L).
+ *   2. PLACEMENT (family E) on that quantity: accepted iff
+ *      qty * tick(close) * margin%/100 <= strategy.equity, so an all-in sell
+ *      stop BELOW the close is never placed (floor(eq/L) * C > eq: 0 short
+ *      fills over the 3 touches of pct100, 0 fills on short-only — no
+ *      opposite-order/OCA effect) while a buy stop above the close always
+ *      is; a rejected placement is dropped and only the script's next call
+ *      re-issues it; a rejected same-id re-issue cancels the resting order.
+ *   3. FILL: the same quantity at the level on a touch, at the tick-rounded
+ *      open on a gap-through, admitted iff qty * tick(fill) <= equity
+ *      (08-19 13:30Z: 817 = floor(9,414.16 / 11.51) x 11.52 = 9,411.84 <=
+ *      9,414.16 fills where the close-sized 822 x 11.52 = 9,469 would not;
+ *      a first-bar short gap-through is never filled because the order was
+ *      never placed).
+ *   4. A level already at/beyond the close is a market-at-next-open order
+ *      sized at tick(close): ahtisham 2025-04-04 13:30Z close 9.335 -> 9.34,
+ *      1,043 = floor(9,742.34 / 9.34) filled 13:45Z @9.34 (TV: 88 margin-
+ *      called @9.44 + 955 stopped 15:00Z @9.52).
+ *
+ * Engine before this change (d9e15ab): KI-62 sized the stop at the FILL
+ * price and costed it at the bar OPEN (engine_fills.cpp
+ * stop_entry_margin_admission_declines), a next-open-only snapshot sized it
+ * at the CLOSE. That coincided with TV on every intrabar touch and diverged
+ * on every session-open gap: 18/18 first-bar SHORT gap-throughs filled that
+ * TV never placed (04-04 13:30Z 1,020 @9.32), 0/19 first-bar LONG
+ * gap-throughs filled of which TV fills 6.
+ *
+ * Feed bars are the registry's NYSE:F 15 (feed 80f404ae85ef, mintick 0.01,
+ * whole shares), UTC, `lab bars`. Tape times are UTC+8 in the CSVs; quoted
+ * here in UTC.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <functional>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <pineforge/bar.hpp>
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::printf("  FAIL  %s:%d  %s\n", __FILE__, __LINE__, #expr);     \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_NEAR(a, b, tol)                                                  \
+    do {                                                                       \
+        double _a = (a), _b = (b);                                             \
+        if (!(std::fabs(_a - _b) <= (tol))) {                                  \
+            std::printf("  FAIL  %s:%d  %s == %.10f, expected %.10f\n",        \
+                        __FILE__, __LINE__, #a, _a, _b);                       \
+            ++tests_failed;                                                    \
+        } else {                                                               \
+            ++tests_passed;                                                    \
+        }                                                                      \
+    } while (0)
+
+static constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+static Bar mk(int64_t ts, double o, double h, double l, double c) {
+    Bar b;
+    b.open = o; b.high = h; b.low = l; b.close = c;
+    b.volume = 1.0; b.timestamp = ts;
+    return b;
+}
+
+namespace {
+
+constexpr int64_t kMin15 = 15LL * 60LL * 1000LL;
+
+struct Row { int64_t ts; double o, h, l, c; };
+
+// NYSE:F 15, 2025-08-11 13:30Z .. 2025-08-22 19:45Z, 260 bars (10 sessions
+// of 26). Index map (first bar of each session): 08-11 = 0, 08-12 = 26,
+// 08-13 = 52, 08-14 = 78, 08-15 = 104, 08-18 = 130, 08-19 = 156,
+// 08-20 = 182, 08-21 = 208, 08-22 = 234.
+enum ABar {
+    A0811_1415 = 3, A0811_1430 = 4, A0811_1445 = 5,
+    A0813_1945 = 77, A0814_1330 = 78, A0814_1345 = 79,
+    A0818_1945 = 155, A0819_1330 = 156, A0819_1345 = 157,
+    A0820_1945 = 207, A0821_1330 = 208, A0821_1345 = 209,
+    A0822_1400 = 236, A0822_1415 = 237,
+};
+
+const Row kF0811[] = {
+    {1754919000000LL, 11.32, 11.57, 11.31, 11.535},   // 08-11 13:30Z
+    {1754919900000LL, 11.535, 11.54, 11.35, 11.4},   // 08-11 13:45Z
+    {1754920800000LL, 11.4, 11.405, 11.29, 11.295},   // 08-11 14:00Z
+    {1754921700000LL, 11.3, 11.315, 11.275, 11.295},   // 08-11 14:15Z
+    {1754922600000LL, 11.295, 11.38, 11.06, 11.16},   // 08-11 14:30Z
+    {1754923500000LL, 11.15, 11.18, 11.14, 11.165},   // 08-11 14:45Z
+    {1754924400000LL, 11.16, 11.21, 11.12, 11.13},   // 08-11 15:00Z
+    {1754925300000LL, 11.13, 11.15, 11.11, 11.125},   // 08-11 15:15Z
+    {1754926200000LL, 11.12, 11.125, 11.09, 11.12},   // 08-11 15:30Z
+    {1754927100000LL, 11.12, 11.17, 11.11, 11.17},   // 08-11 15:45Z
+    {1754928000000LL, 11.17, 11.21, 11.17, 11.195},   // 08-11 16:00Z
+    {1754928900000LL, 11.195, 11.21, 11.18, 11.18},   // 08-11 16:15Z
+    {1754929800000LL, 11.18, 11.19, 11.15, 11.155},   // 08-11 16:30Z
+    {1754930700000LL, 11.155, 11.17, 11.13, 11.135},   // 08-11 16:45Z
+    {1754931600000LL, 11.135, 11.15, 11.13, 11.13},   // 08-11 17:00Z
+    {1754932500000LL, 11.13, 11.15, 11.09, 11.095},   // 08-11 17:15Z
+    {1754933400000LL, 11.1, 11.14, 11.085, 11.12},   // 08-11 17:30Z
+    {1754934300000LL, 11.12, 11.14, 11.115, 11.135},   // 08-11 17:45Z
+    {1754935200000LL, 11.135, 11.14, 11.105, 11.115},   // 08-11 18:00Z
+    {1754936100000LL, 11.115, 11.165, 11.115, 11.15},   // 08-11 18:15Z
+    {1754937000000LL, 11.155, 11.165, 11.13, 11.13},   // 08-11 18:30Z
+    {1754937900000LL, 11.13, 11.14, 11.13, 11.14},   // 08-11 18:45Z
+    {1754938800000LL, 11.14, 11.14, 11.12, 11.135},   // 08-11 19:00Z
+    {1754939700000LL, 11.14, 11.15, 11.125, 11.145},   // 08-11 19:15Z
+    {1754940600000LL, 11.15, 11.16, 11.145, 11.155},   // 08-11 19:30Z
+    {1754941500000LL, 11.155, 11.16, 11.125, 11.16},   // 08-11 19:45Z
+    {1755005400000LL, 11.17, 11.2, 11.13, 11.135},   // 08-12 13:30Z
+    {1755006300000LL, 11.135, 11.2, 11.135, 11.195},   // 08-12 13:45Z
+    {1755007200000LL, 11.19, 11.28, 11.19, 11.275},   // 08-12 14:00Z
+    {1755008100000LL, 11.27, 11.315, 11.265, 11.295},   // 08-12 14:15Z
+    {1755009000000LL, 11.29, 11.29, 11.225, 11.265},   // 08-12 14:30Z
+    {1755009900000LL, 11.265, 11.305, 11.26, 11.29},   // 08-12 14:45Z
+    {1755010800000LL, 11.29, 11.31, 11.275, 11.285},   // 08-12 15:00Z
+    {1755011700000LL, 11.29, 11.295, 11.26, 11.265},   // 08-12 15:15Z
+    {1755012600000LL, 11.27, 11.28, 11.26, 11.265},   // 08-12 15:30Z
+    {1755013500000LL, 11.265, 11.3, 11.265, 11.29},   // 08-12 15:45Z
+    {1755014400000LL, 11.285, 11.295, 11.255, 11.265},   // 08-12 16:00Z
+    {1755015300000LL, 11.265, 11.28, 11.255, 11.265},   // 08-12 16:15Z
+    {1755016200000LL, 11.27, 11.28, 11.25, 11.275},   // 08-12 16:30Z
+    {1755017100000LL, 11.28, 11.28, 11.27, 11.275},   // 08-12 16:45Z
+    {1755018000000LL, 11.275, 11.275, 11.24, 11.245},   // 08-12 17:00Z
+    {1755018900000LL, 11.245, 11.255, 11.24, 11.255},   // 08-12 17:15Z
+    {1755019800000LL, 11.255, 11.285, 11.25, 11.285},   // 08-12 17:30Z
+    {1755020700000LL, 11.285, 11.285, 11.265, 11.285},   // 08-12 17:45Z
+    {1755021600000LL, 11.285, 11.29, 11.255, 11.255},   // 08-12 18:00Z
+    {1755022500000LL, 11.255, 11.26, 11.25, 11.255},   // 08-12 18:15Z
+    {1755023400000LL, 11.255, 11.255, 11.23, 11.235},   // 08-12 18:30Z
+    {1755024300000LL, 11.235, 11.245, 11.21, 11.21},   // 08-12 18:45Z
+    {1755025200000LL, 11.215, 11.245, 11.215, 11.245},   // 08-12 19:00Z
+    {1755026100000LL, 11.25, 11.25, 11.23, 11.235},   // 08-12 19:15Z
+    {1755027000000LL, 11.23, 11.25, 11.22, 11.235},   // 08-12 19:30Z
+    {1755027900000LL, 11.23, 11.25, 11.2, 11.24},   // 08-12 19:45Z
+    {1755091800000LL, 11.29, 11.29, 11.19, 11.25},   // 08-13 13:30Z
+    {1755092700000LL, 11.255, 11.325, 11.25, 11.325},   // 08-13 13:45Z
+    {1755093600000LL, 11.325, 11.365, 11.32, 11.33},   // 08-13 14:00Z
+    {1755094500000LL, 11.335, 11.335, 11.26, 11.285},   // 08-13 14:15Z
+    {1755095400000LL, 11.285, 11.34, 11.28, 11.335},   // 08-13 14:30Z
+    {1755096300000LL, 11.33, 11.335, 11.3, 11.325},   // 08-13 14:45Z
+    {1755097200000LL, 11.33, 11.36, 11.325, 11.355},   // 08-13 15:00Z
+    {1755098100000LL, 11.355, 11.415, 11.355, 11.39},   // 08-13 15:15Z
+    {1755099000000LL, 11.39, 11.4, 11.375, 11.385},   // 08-13 15:30Z
+    {1755099900000LL, 11.385, 11.385, 11.345, 11.37},   // 08-13 15:45Z
+    {1755100800000LL, 11.375, 11.42, 11.37, 11.415},   // 08-13 16:00Z
+    {1755101700000LL, 11.415, 11.45, 11.415, 11.425},   // 08-13 16:15Z
+    {1755102600000LL, 11.425, 11.45, 11.425, 11.44},   // 08-13 16:30Z
+    {1755103500000LL, 11.445, 11.45, 11.435, 11.445},   // 08-13 16:45Z
+    {1755104400000LL, 11.44, 11.45, 11.41, 11.41},   // 08-13 17:00Z
+    {1755105300000LL, 11.415, 11.445, 11.415, 11.425},   // 08-13 17:15Z
+    {1755106200000LL, 11.425, 11.43, 11.4, 11.415},   // 08-13 17:30Z
+    {1755107100000LL, 11.415, 11.435, 11.415, 11.425},   // 08-13 17:45Z
+    {1755108000000LL, 11.425, 11.45, 11.415, 11.415},   // 08-13 18:00Z
+    {1755108900000LL, 11.415, 11.44, 11.415, 11.435},   // 08-13 18:15Z
+    {1755109800000LL, 11.44, 11.445, 11.42, 11.43},   // 08-13 18:30Z
+    {1755110700000LL, 11.43, 11.45, 11.43, 11.435},   // 08-13 18:45Z
+    {1755111600000LL, 11.435, 11.455, 11.435, 11.455},   // 08-13 19:00Z
+    {1755112500000LL, 11.455, 11.47, 11.455, 11.465},   // 08-13 19:15Z
+    {1755113400000LL, 11.465, 11.485, 11.46, 11.475},   // 08-13 19:30Z
+    {1755114300000LL, 11.475, 11.48, 11.425, 11.425},   // 08-13 19:45Z
+    {1755178200000LL, 11.3, 11.32, 11.215, 11.225},   // 08-14 13:30Z
+    {1755179100000LL, 11.225, 11.27, 11.22, 11.265},   // 08-14 13:45Z
+    {1755180000000LL, 11.265, 11.3, 11.25, 11.275},   // 08-14 14:00Z
+    {1755180900000LL, 11.27, 11.275, 11.25, 11.265},   // 08-14 14:15Z
+    {1755181800000LL, 11.265, 11.3, 11.265, 11.29},   // 08-14 14:30Z
+    {1755182700000LL, 11.29, 11.315, 11.29, 11.305},   // 08-14 14:45Z
+    {1755183600000LL, 11.3, 11.315, 11.295, 11.295},   // 08-14 15:00Z
+    {1755184500000LL, 11.3, 11.315, 11.29, 11.305},   // 08-14 15:15Z
+    {1755185400000LL, 11.31, 11.325, 11.295, 11.3},   // 08-14 15:30Z
+    {1755186300000LL, 11.295, 11.32, 11.27, 11.315},   // 08-14 15:45Z
+    {1755187200000LL, 11.31, 11.315, 11.29, 11.305},   // 08-14 16:00Z
+    {1755188100000LL, 11.305, 11.31, 11.28, 11.285},   // 08-14 16:15Z
+    {1755189000000LL, 11.29, 11.29, 11.275, 11.29},   // 08-14 16:30Z
+    {1755189900000LL, 11.285, 11.33, 11.285, 11.325},   // 08-14 16:45Z
+    {1755190800000LL, 11.32, 11.325, 11.31, 11.315},   // 08-14 17:00Z
+    {1755191700000LL, 11.32, 11.345, 11.315, 11.345},   // 08-14 17:15Z
+    {1755192600000LL, 11.345, 11.36, 11.345, 11.36},   // 08-14 17:30Z
+    {1755193500000LL, 11.36, 11.37, 11.35, 11.355},   // 08-14 17:45Z
+    {1755194400000LL, 11.355, 11.37, 11.355, 11.365},   // 08-14 18:00Z
+    {1755195300000LL, 11.36, 11.38, 11.355, 11.36},   // 08-14 18:15Z
+    {1755196200000LL, 11.355, 11.385, 11.355, 11.385},   // 08-14 18:30Z
+    {1755197100000LL, 11.38, 11.39, 11.37, 11.385},   // 08-14 18:45Z
+    {1755198000000LL, 11.38, 11.41, 11.38, 11.405},   // 08-14 19:00Z
+    {1755198900000LL, 11.405, 11.42, 11.405, 11.41},   // 08-14 19:15Z
+    {1755199800000LL, 11.415, 11.44, 11.41, 11.43},   // 08-14 19:30Z
+    {1755200700000LL, 11.435, 11.45, 11.43, 11.435},   // 08-14 19:45Z
+    {1755264600000LL, 11.45, 11.51, 11.45, 11.475},   // 08-15 13:30Z
+    {1755265500000LL, 11.48, 11.49, 11.43, 11.435},   // 08-15 13:45Z
+    {1755266400000LL, 11.43, 11.44, 11.41, 11.42},   // 08-15 14:00Z
+    {1755267300000LL, 11.42, 11.44, 11.41, 11.435},   // 08-15 14:15Z
+    {1755268200000LL, 11.43, 11.455, 11.425, 11.45},   // 08-15 14:30Z
+    {1755269100000LL, 11.455, 11.46, 11.435, 11.45},   // 08-15 14:45Z
+    {1755270000000LL, 11.445, 11.445, 11.43, 11.44},   // 08-15 15:00Z
+    {1755270900000LL, 11.44, 11.455, 11.43, 11.43},   // 08-15 15:15Z
+    {1755271800000LL, 11.435, 11.45, 11.43, 11.435},   // 08-15 15:30Z
+    {1755272700000LL, 11.435, 11.45, 11.43, 11.445},   // 08-15 15:45Z
+    {1755273600000LL, 11.44, 11.47, 11.44, 11.46},   // 08-15 16:00Z
+    {1755274500000LL, 11.465, 11.475, 11.455, 11.475},   // 08-15 16:15Z
+    {1755275400000LL, 11.47, 11.49, 11.46, 11.49},   // 08-15 16:30Z
+    {1755276300000LL, 11.485, 11.52, 11.485, 11.49},   // 08-15 16:45Z
+    {1755277200000LL, 11.485, 11.5, 11.485, 11.495},   // 08-15 17:00Z
+    {1755278100000LL, 11.495, 11.495, 11.48, 11.485},   // 08-15 17:15Z
+    {1755279000000LL, 11.485, 11.505, 11.485, 11.495},   // 08-15 17:30Z
+    {1755279900000LL, 11.495, 11.505, 11.495, 11.505},   // 08-15 17:45Z
+    {1755280800000LL, 11.5, 11.505, 11.475, 11.485},   // 08-15 18:00Z
+    {1755281700000LL, 11.485, 11.49, 11.47, 11.485},   // 08-15 18:15Z
+    {1755282600000LL, 11.485, 11.49, 11.48, 11.485},   // 08-15 18:30Z
+    {1755283500000LL, 11.485, 11.485, 11.46, 11.465},   // 08-15 18:45Z
+    {1755284400000LL, 11.465, 11.465, 11.44, 11.44},   // 08-15 19:00Z
+    {1755285300000LL, 11.44, 11.455, 11.44, 11.455},   // 08-15 19:15Z
+    {1755286200000LL, 11.455, 11.47, 11.45, 11.465},   // 08-15 19:30Z
+    {1755287100000LL, 11.465, 11.47, 11.425, 11.435},   // 08-15 19:45Z
+    {1755523800000LL, 11.41, 11.425, 11.37, 11.41},   // 08-18 13:30Z
+    {1755524700000LL, 11.42, 11.46, 11.42, 11.445},   // 08-18 13:45Z
+    {1755525600000LL, 11.445, 11.465, 11.44, 11.44},   // 08-18 14:00Z
+    {1755526500000LL, 11.445, 11.455, 11.425, 11.425},   // 08-18 14:15Z
+    {1755527400000LL, 11.425, 11.45, 11.425, 11.45},   // 08-18 14:30Z
+    {1755528300000LL, 11.45, 11.475, 11.435, 11.445},   // 08-18 14:45Z
+    {1755529200000LL, 11.445, 11.465, 11.43, 11.435},   // 08-18 15:00Z
+    {1755530100000LL, 11.43, 11.465, 11.43, 11.45},   // 08-18 15:15Z
+    {1755531000000LL, 11.455, 11.46, 11.45, 11.455},   // 08-18 15:30Z
+    {1755531900000LL, 11.455, 11.46, 11.45, 11.455},   // 08-18 15:45Z
+    {1755532800000LL, 11.455, 11.46, 11.42, 11.45},   // 08-18 16:00Z
+    {1755533700000LL, 11.445, 11.465, 11.445, 11.455},   // 08-18 16:15Z
+    {1755534600000LL, 11.455, 11.465, 11.455, 11.455},   // 08-18 16:30Z
+    {1755535500000LL, 11.455, 11.46, 11.445, 11.45},   // 08-18 16:45Z
+    {1755536400000LL, 11.445, 11.455, 11.435, 11.455},   // 08-18 17:00Z
+    {1755537300000LL, 11.455, 11.46, 11.455, 11.455},   // 08-18 17:15Z
+    {1755538200000LL, 11.455, 11.47, 11.445, 11.455},   // 08-18 17:30Z
+    {1755539100000LL, 11.455, 11.455, 11.425, 11.43},   // 08-18 17:45Z
+    {1755540000000LL, 11.43, 11.46, 11.43, 11.455},   // 08-18 18:00Z
+    {1755540900000LL, 11.45, 11.46, 11.44, 11.445},   // 08-18 18:15Z
+    {1755541800000LL, 11.445, 11.445, 11.435, 11.435},   // 08-18 18:30Z
+    {1755542700000LL, 11.435, 11.44, 11.435, 11.435},   // 08-18 18:45Z
+    {1755543600000LL, 11.435, 11.44, 11.42, 11.425},   // 08-18 19:00Z
+    {1755544500000LL, 11.425, 11.435, 11.42, 11.425},   // 08-18 19:15Z
+    {1755545400000LL, 11.425, 11.45, 11.425, 11.445},   // 08-18 19:30Z
+    {1755546300000LL, 11.445, 11.46, 11.445, 11.45},   // 08-18 19:45Z
+    {1755610200000LL, 11.52, 11.66, 11.5, 11.65},   // 08-19 13:30Z
+    {1755611100000LL, 11.645, 11.73, 11.635, 11.645},   // 08-19 13:45Z
+    {1755612000000LL, 11.65, 11.68, 11.64, 11.67},   // 08-19 14:00Z
+    {1755612900000LL, 11.67, 11.71, 11.67, 11.705},   // 08-19 14:15Z
+    {1755613800000LL, 11.71, 11.72, 11.665, 11.675},   // 08-19 14:30Z
+    {1755614700000LL, 11.675, 11.71, 11.635, 11.635},   // 08-19 14:45Z
+    {1755615600000LL, 11.635, 11.64, 11.62, 11.62},   // 08-19 15:00Z
+    {1755616500000LL, 11.625, 11.64, 11.6, 11.635},   // 08-19 15:15Z
+    {1755617400000LL, 11.63, 11.645, 11.615, 11.615},   // 08-19 15:30Z
+    {1755618300000LL, 11.615, 11.615, 11.56, 11.565},   // 08-19 15:45Z
+    {1755619200000LL, 11.57, 11.58, 11.56, 11.57},   // 08-19 16:00Z
+    {1755620100000LL, 11.565, 11.58, 11.555, 11.555},   // 08-19 16:15Z
+    {1755621000000LL, 11.55, 11.57, 11.54, 11.555},   // 08-19 16:30Z
+    {1755621900000LL, 11.555, 11.56, 11.535, 11.555},   // 08-19 16:45Z
+    {1755622800000LL, 11.56, 11.56, 11.54, 11.555},   // 08-19 17:00Z
+    {1755623700000LL, 11.555, 11.57, 11.55, 11.565},   // 08-19 17:15Z
+    {1755624600000LL, 11.565, 11.58, 11.565, 11.575},   // 08-19 17:30Z
+    {1755625500000LL, 11.575, 11.58, 11.555, 11.555},   // 08-19 17:45Z
+    {1755626400000LL, 11.555, 11.555, 11.515, 11.525},   // 08-19 18:00Z
+    {1755627300000LL, 11.525, 11.53, 11.51, 11.515},   // 08-19 18:15Z
+    {1755628200000LL, 11.51, 11.52, 11.51, 11.52},   // 08-19 18:30Z
+    {1755629100000LL, 11.52, 11.555, 11.52, 11.555},   // 08-19 18:45Z
+    {1755630000000LL, 11.555, 11.56, 11.545, 11.555},   // 08-19 19:00Z
+    {1755630900000LL, 11.555, 11.575, 11.545, 11.575},   // 08-19 19:15Z
+    {1755631800000LL, 11.58, 11.595, 11.575, 11.585},   // 08-19 19:30Z
+    {1755632700000LL, 11.585, 11.59, 11.57, 11.59},   // 08-19 19:45Z
+    {1755696600000LL, 11.52, 11.58, 11.505, 11.565},   // 08-20 13:30Z
+    {1755697500000LL, 11.565, 11.595, 11.515, 11.555},   // 08-20 13:45Z
+    {1755698400000LL, 11.555, 11.585, 11.52, 11.52},   // 08-20 14:00Z
+    {1755699300000LL, 11.525, 11.53, 11.485, 11.485},   // 08-20 14:15Z
+    {1755700200000LL, 11.485, 11.525, 11.48, 11.485},   // 08-20 14:30Z
+    {1755701100000LL, 11.485, 11.5, 11.475, 11.485},   // 08-20 14:45Z
+    {1755702000000LL, 11.485, 11.52, 11.47, 11.52},   // 08-20 15:00Z
+    {1755702900000LL, 11.515, 11.55, 11.51, 11.545},   // 08-20 15:15Z
+    {1755703800000LL, 11.54, 11.54, 11.505, 11.52},   // 08-20 15:30Z
+    {1755704700000LL, 11.525, 11.525, 11.48, 11.5},   // 08-20 15:45Z
+    {1755705600000LL, 11.5, 11.53, 11.485, 11.52},   // 08-20 16:00Z
+    {1755706500000LL, 11.515, 11.54, 11.515, 11.525},   // 08-20 16:15Z
+    {1755707400000LL, 11.525, 11.53, 11.5, 11.525},   // 08-20 16:30Z
+    {1755708300000LL, 11.525, 11.525, 11.5, 11.505},   // 08-20 16:45Z
+    {1755709200000LL, 11.505, 11.53, 11.505, 11.525},   // 08-20 17:00Z
+    {1755710100000LL, 11.525, 11.55, 11.52, 11.54},   // 08-20 17:15Z
+    {1755711000000LL, 11.535, 11.56, 11.535, 11.555},   // 08-20 17:30Z
+    {1755711900000LL, 11.56, 11.575, 11.555, 11.56},   // 08-20 17:45Z
+    {1755712800000LL, 11.56, 11.565, 11.53, 11.535},   // 08-20 18:00Z
+    {1755713700000LL, 11.535, 11.55, 11.525, 11.545},   // 08-20 18:15Z
+    {1755714600000LL, 11.55, 11.55, 11.535, 11.54},   // 08-20 18:30Z
+    {1755715500000LL, 11.545, 11.55, 11.52, 11.525},   // 08-20 18:45Z
+    {1755716400000LL, 11.525, 11.54, 11.52, 11.535},   // 08-20 19:00Z
+    {1755717300000LL, 11.535, 11.535, 11.5, 11.505},   // 08-20 19:15Z
+    {1755718200000LL, 11.505, 11.52, 11.505, 11.515},   // 08-20 19:30Z
+    {1755719100000LL, 11.515, 11.54, 11.49, 11.49},   // 08-20 19:45Z
+    {1755783000000LL, 11.42, 11.43, 11.23, 11.24},   // 08-21 13:30Z
+    {1755783900000LL, 11.24, 11.3, 11.2, 11.3},   // 08-21 13:45Z
+    {1755784800000LL, 11.295, 11.34, 11.29, 11.325},   // 08-21 14:00Z
+    {1755785700000LL, 11.33, 11.345, 11.305, 11.305},   // 08-21 14:15Z
+    {1755786600000LL, 11.31, 11.31, 11.27, 11.285},   // 08-21 14:30Z
+    {1755787500000LL, 11.285, 11.31, 11.28, 11.305},   // 08-21 14:45Z
+    {1755788400000LL, 11.305, 11.32, 11.275, 11.275},   // 08-21 15:00Z
+    {1755789300000LL, 11.275, 11.3, 11.275, 11.29},   // 08-21 15:15Z
+    {1755790200000LL, 11.295, 11.33, 11.29, 11.325},   // 08-21 15:30Z
+    {1755791100000LL, 11.325, 11.325, 11.305, 11.305},   // 08-21 15:45Z
+    {1755792000000LL, 11.305, 11.345, 11.3, 11.335},   // 08-21 16:00Z
+    {1755792900000LL, 11.335, 11.34, 11.32, 11.325},   // 08-21 16:15Z
+    {1755793800000LL, 11.325, 11.335, 11.315, 11.325},   // 08-21 16:30Z
+    {1755794700000LL, 11.325, 11.335, 11.305, 11.325},   // 08-21 16:45Z
+    {1755795600000LL, 11.325, 11.325, 11.305, 11.325},   // 08-21 17:00Z
+    {1755796500000LL, 11.325, 11.325, 11.295, 11.31},   // 08-21 17:15Z
+    {1755797400000LL, 11.31, 11.35, 11.31, 11.345},   // 08-21 17:30Z
+    {1755798300000LL, 11.345, 11.36, 11.345, 11.35},   // 08-21 17:45Z
+    {1755799200000LL, 11.35, 11.37, 11.345, 11.37},   // 08-21 18:00Z
+    {1755800100000LL, 11.365, 11.375, 11.345, 11.345},   // 08-21 18:15Z
+    {1755801000000LL, 11.34, 11.35, 11.335, 11.345},   // 08-21 18:30Z
+    {1755801900000LL, 11.345, 11.375, 11.34, 11.375},   // 08-21 18:45Z
+    {1755802800000LL, 11.37, 11.375, 11.36, 11.365},   // 08-21 19:00Z
+    {1755803700000LL, 11.365, 11.365, 11.34, 11.345},   // 08-21 19:15Z
+    {1755804600000LL, 11.345, 11.35, 11.33, 11.335},   // 08-21 19:30Z
+    {1755805500000LL, 11.33, 11.35, 11.32, 11.335},   // 08-21 19:45Z
+    {1755869400000LL, 11.39, 11.49, 11.39, 11.485},   // 08-22 13:30Z
+    {1755870300000LL, 11.485, 11.525, 11.475, 11.495},   // 08-22 13:45Z
+    {1755871200000LL, 11.5, 11.71, 11.5, 11.705},   // 08-22 14:00Z
+    {1755872100000LL, 11.7, 11.76, 11.655, 11.68},   // 08-22 14:15Z
+    {1755873000000LL, 11.68, 11.74, 11.68, 11.73},   // 08-22 14:30Z
+    {1755873900000LL, 11.725, 11.77, 11.715, 11.75},   // 08-22 14:45Z
+    {1755874800000LL, 11.75, 11.765, 11.705, 11.725},   // 08-22 15:00Z
+    {1755875700000LL, 11.72, 11.745, 11.71, 11.725},   // 08-22 15:15Z
+    {1755876600000LL, 11.725, 11.74, 11.705, 11.715},   // 08-22 15:30Z
+    {1755877500000LL, 11.715, 11.745, 11.71, 11.72},   // 08-22 15:45Z
+    {1755878400000LL, 11.72, 11.76, 11.705, 11.735},   // 08-22 16:00Z
+    {1755879300000LL, 11.73, 11.755, 11.705, 11.72},   // 08-22 16:15Z
+    {1755880200000LL, 11.72, 11.745, 11.72, 11.72},   // 08-22 16:30Z
+    {1755881100000LL, 11.725, 11.75, 11.72, 11.73},   // 08-22 16:45Z
+    {1755882000000LL, 11.735, 11.765, 11.73, 11.76},   // 08-22 17:00Z
+    {1755882900000LL, 11.755, 11.755, 11.73, 11.73},   // 08-22 17:15Z
+    {1755883800000LL, 11.74, 11.745, 11.73, 11.735},   // 08-22 17:30Z
+    {1755884700000LL, 11.74, 11.75, 11.715, 11.715},   // 08-22 17:45Z
+    {1755885600000LL, 11.72, 11.725, 11.7, 11.71},   // 08-22 18:00Z
+    {1755886500000LL, 11.71, 11.725, 11.71, 11.715},   // 08-22 18:15Z
+    {1755887400000LL, 11.715, 11.725, 11.695, 11.725},   // 08-22 18:30Z
+    {1755888300000LL, 11.72, 11.73, 11.71, 11.72},   // 08-22 18:45Z
+    {1755889200000LL, 11.715, 11.73, 11.715, 11.72},   // 08-22 19:00Z
+    {1755890100000LL, 11.72, 11.73, 11.71, 11.715},   // 08-22 19:15Z
+    {1755891000000LL, 11.715, 11.74, 11.715, 11.73},   // 08-22 19:30Z
+    {1755891900000LL, 11.73, 11.74, 11.715, 11.73},   // 08-22 19:45Z
+};
+constexpr int kF0811Count = sizeof(kF0811) / sizeof(kF0811[0]);
+
+std::vector<Bar> f0811_bars() {
+    std::vector<Bar> b;
+    for (int i = 0; i < kF0811Count; ++i) {
+        b.push_back(mk(kF0811[i].ts, kF0811[i].o, kF0811[i].h, kF0811[i].l,
+                       kF0811[i].c));
+    }
+    return b;
+}
+
+// NYSE:F 15, 2025-04-03 19:00Z .. 2025-04-04 15:15Z, with the ahtisham
+// levels = hand replay of the Pine indicators over the registry feed
+// (zoneHigh / zoneLow = ta.highest / ta.lowest of high[1] / low[1] over 20,
+// RMA-14 ATR from the feed start, offset 1.5 atr; scratchpad/r7/k/
+// aht_model.py). b0..b3 = 04-03 19:00Z..19:45Z, b4.. = 04-04 13:30Z..15:15Z.
+struct LvlRow { double o, h, l, c, buy_stop, sell_stop, mid; };
+enum BBar {
+    B0403_1945 = 3, B0404_1330 = 4, B0404_1345 = 5, B0404_1400 = 6,
+    B0404_1500 = 10, B0404_1515 = 11,
+};
+const LvlRow kAht0404[] = {
+    {9.68, 9.685, 9.65, 9.65, 9.9865, 9.5335, 9.7600},   // b0 04-03 19:00Z
+    {9.65, 9.65, 9.6, 9.605, 9.9507, 9.5343, 9.7425},   // b1 04-03 19:15Z
+    {9.605, 9.625, 9.595, 9.61, 9.9228, 9.5172, 9.7200},   // b2 04-03 19:30Z
+    {9.615, 9.615, 9.53, 9.545, 9.9110, 9.5090, 9.7100},   // b3 04-03 19:45Z
+    {9.32, 9.39, 9.21, 9.335, 9.9407, 9.4143, 9.6775},   // b4 04-04 13:30Z
+    {9.34, 9.435, 9.305, 9.385, 9.9464, 9.0886, 9.5175},   // b5 04-04 13:45Z
+    {9.38, 9.44, 9.345, 9.37, 9.9479, 9.0871, 9.5175},   // b6 04-04 14:00Z
+    {9.375, 9.42, 9.34, 9.375, 9.9477, 9.0873, 9.5175},   // b7 04-04 14:15Z
+    {9.38, 9.42, 9.33, 9.33, 9.9486, 9.0864, 9.5175},   // b8 04-04 14:30Z
+    {9.325, 9.395, 9.2, 9.365, 9.9606, 9.0744, 9.5175},   // b9 04-04 14:45Z
+    {9.36, 9.58, 9.345, 9.565, 9.9611, 9.0489, 9.5050},   // b10 04-04 15:00Z
+    {9.57, 9.66, 9.5, 9.5, 9.9325, 9.0425, 9.4875},   // b11 04-04 15:15Z
+};
+constexpr int kAht0404Count = sizeof(kAht0404) / sizeof(kAht0404[0]);
+
+std::vector<Bar> aht0404_bars() {
+    const int64_t t0403 = 1743706800000LL;   // 2025-04-03 19:00Z
+    const int64_t t0404 = 1743773400000LL;   // 2025-04-04 13:30Z
+    std::vector<Bar> b;
+    for (int i = 0; i < kAht0404Count; ++i) {
+        const int64_t ts = i < 4 ? t0403 + i * kMin15 : t0404 + (i - 4) * kMin15;
+        b.push_back(mk(ts, kAht0404[i].o, kAht0404[i].h, kAht0404[i].l,
+                       kAht0404[i].c));
+    }
+    return b;
+}
+
+class Probe : public BacktestEngine {
+public:
+    // NYSE:F: mintick 0.01, whole shares, Pine v6 defaults (margin 100,
+    // pyramiding 0 = one entry, no commission / slippage, margin call ON in
+    // TV — enabled per test where the tape shows its slices).
+    Probe(double capital, double pct, double margin = 100.0) {
+        initial_capital_ = capital;
+        syminfo_.pointvalue = 1.0;
+        syminfo_.mintick = 0.01;
+        syminfo_mintick_ = 0.01;
+        qty_step_ = 1.0;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = pct;
+        commission_type_ = CommissionType::PERCENT;
+        commission_value_ = 0.0;
+        margin_long_ = margin;
+        margin_short_ = margin;
+        pyramiding_ = 0;
+        slippage_ = 0;
+        process_orders_on_close_ = false;
+        set_margin_call_enabled(false);
+    }
+    std::function<void(Probe&, int)> script;
+    void on_bar(const Bar& /*bar*/) override {
+        if (script) script(*this, bar_index_);
+    }
+
+    double equity() const {
+        return current_equity() + open_profit(current_bar_.close);
+    }
+    double position_size() const { return signed_position_size(); }
+    bool flat() const { return position_side_ == PositionSide::FLAT; }
+    double close_now() const { return current_bar_.close; }
+    const PendingOrder* pending(const std::string& id) const {
+        for (const auto& o : pending_orders_) if (o.id == id) return &o;
+        return nullptr;
+    }
+    // Placement record: (bar, id, placed?, placement qty, sizing price).
+    struct Placement { int bar; std::string id; bool placed; double qty; double basis; };
+    std::vector<Placement> placements;
+    void entry_stop(const std::string& id, bool is_long, double level,
+                    const std::string& comment = "") {
+        strategy_entry(id, is_long, kNaN, level, kNaN, comment);
+        const PendingOrder* o = pending(id);
+        placements.push_back({bar_index_, id, o != nullptr,
+                              o ? o->default_stop_placement_qty : kNaN,
+                              o ? o->default_stop_sizing_price : kNaN});
+    }
+    const Placement* placement(int bar, const std::string& id) const {
+        for (const auto& p : placements) {
+            if (p.bar == bar && p.id == id) return &p;
+        }
+        return nullptr;
+    }
+    bool placed_on(int bar, const std::string& id) const {
+        const Placement* p = placement(bar, id);
+        return p != nullptr && p->placed;
+    }
+    int placements_of(const std::string& id) const {
+        int n = 0;
+        for (const auto& p : placements) if (p.id == id && p.placed) ++n;
+        return n;
+    }
+    int calls_of(const std::string& id) const {
+        int n = 0;
+        for (const auto& p : placements) if (p.id == id) ++n;
+        return n;
+    }
+    void enable_margin_call() { set_margin_call_enabled(true); }
+    using BacktestEngine::strategy_entry;
+    using BacktestEngine::strategy_exit;
+    using BacktestEngine::strategy_close;
+    using BacktestEngine::strategy_close_all;
+};
+
+// The four tapes' script: while flat a buy stop 0.20 above and/or a sell
+// stop 0.20 below the close, re-issued every bar; strategy.close_all the bar
+// after an entry (fills at the next open).
+void tape_script(Probe& e, bool longs, bool shorts) {
+    if (e.position_size() == 0) {
+        if (longs) e.entry_stop("L", true, e.close_now() + 0.20, "L");
+        if (shorts) e.entry_stop("S", false, e.close_now() - 0.20, "S");
+    } else {
+        e.strategy_close_all();
+    }
+}
+
+struct ExpectedTrade {
+    bool is_long; int entry_bar; double entry_price; double qty;
+    int exit_bar; double exit_price; double pnl;
+};
+
+void check_trades(const Probe& p, const std::vector<ExpectedTrade>& expected) {
+    CHECK(p.trade_count() == (int)expected.size());
+    for (size_t i = 0; i < expected.size() && (int)i < p.trade_count(); ++i) {
+        const Trade& t = p.get_trade((int)i);
+        const ExpectedTrade& x = expected[i];
+        CHECK(t.is_long == x.is_long);
+        CHECK(t.entry_bar_index == x.entry_bar);
+        CHECK_NEAR(t.entry_price, x.entry_price, 1e-9);
+        CHECK_NEAR(t.qty, x.qty, 1e-9);
+        CHECK(t.exit_bar_index == x.exit_bar);
+        CHECK_NEAR(t.exit_price, x.exit_price, 1e-9);
+        CHECK_NEAR(t.pnl, x.pnl, 1e-6);
+    }
+}
+
+// --- tape f15-stopsize-pct100 (pct 100, margin 100, both sides) ---
+// TV: 2 trades, both LONG touches — 08-19 13:30Z L 858 @11.65 (placed at the
+// 08-18 19:45Z close 11.45: level 11.65, 858 = floor(10,000 / 11.65); the
+// close would size 873), out 13:45Z @11.65; 08-22 14:00Z L 854 @11.70 (close
+// 11.50 -> level 11.70; 869 at the close), out 14:15Z @11.70. The sell stop
+// 0.20 below the close is NEVER placed (floor(eq / L) x tick(close) > eq on
+// every one of the 258 flat closes) although its level is touched three
+// times (08-11 14:30Z l 11.06 < 11.10, 08-14 13:30Z, 08-21 13:30Z).
+void test_pct100_tape() {
+    std::printf("-- pct100: longs sized at the level (858 / 854), the all-in sell stop below the close is never placed --\n");
+    Probe p(10000.0, 100.0);
+    p.script = [&](Probe& e, int) { tape_script(e, true, true); };
+    std::vector<Bar> bars = f0811_bars();
+    p.run(bars.data(), (int)bars.size());
+
+    // q858: the placement snapshot on the 08-18 19:45Z close.
+    const Probe::Placement* l = p.placement(A0818_1945, "L");
+    CHECK(l != nullptr && l->placed);
+    if (l != nullptr) {
+        CHECK_NEAR(l->qty, 858.0, 1e-9);
+        CHECK_NEAR(l->basis, 11.65, 1e-9);
+    }
+    const Probe::Placement* l2 = p.placement(A0822_1400 - 1, "L");
+    CHECK(l2 != nullptr && l2->placed);
+    if (l2 != nullptr) CHECK_NEAR(l2->qty, 854.0, 1e-9);
+
+    // The sell stop: called on every flat bar, placed on none.
+    CHECK(p.calls_of("S") > 250);
+    CHECK(p.placements_of("S") == 0);
+    CHECK(!p.placed_on(A0811_1415, "S"));   // touched 14:30Z (l 11.06 < 11.10)
+    CHECK(!p.placed_on(A0813_1945, "S"));   // touched 08-14 13:30Z
+    CHECK(!p.placed_on(A0820_1945, "S"));   // touched 08-21 13:30Z
+    const Probe::Placement* s = p.placement(A0818_1945, "S");
+    CHECK(s != nullptr && !s->placed);      // 11.25: 888 x 11.45 = 10,167.6 > 10,000
+
+    check_trades(p, {
+        {true, A0819_1330, 11.65, 858.0, A0819_1345, 11.65, 0.0},
+        {true, A0822_1400, 11.70, 854.0, A0822_1415, 11.70, 0.0},
+    });
+    CHECK(p.flat());
+}
+
+// --- tape f15-stopsize-short-only (pct 100, sell stop only) ---
+// TV: 0 trades. With no long order pending the result is identical, so the
+// never-placed short is not an OCA / opposite-order effect.
+void test_short_only_tape() {
+    std::printf("-- short-only: pct 100 sell stop below the close, no long pending: never placed, 0 trades --\n");
+    Probe p(10000.0, 100.0);
+    p.script = [&](Probe& e, int) { tape_script(e, false, true); };
+    std::vector<Bar> bars = f0811_bars();
+    p.run(bars.data(), (int)bars.size());
+    CHECK(p.trade_count() == 0);
+    CHECK(p.calls_of("S") == kF0811Count);
+    CHECK(p.placements_of("S") == 0);
+    CHECK(p.flat());
+}
+
+// --- tape f15-stopsize-pct50 (pct 50, both sides) ---
+// TV: 5 trades. Shorts place (floor(0.5 eq / L) x C <= eq) and fill at the
+// level: 08-11 14:30Z S 450 @11.09 (450 = floor(5,000 / 11.09); 442 at the
+// close 11.29) out 14:45Z @11.15 (-27); 08-14 13:30Z S 444 @11.22 (floor(0.5
+// x 9,973 / 11.22)) out @11.23 (-4.44); 08-19 13:30Z L 427 @11.65 out @11.65;
+// 08-21 13:30Z S 441 @11.29 out @11.24 (+22.05); 08-22 14:00Z L 426 @11.70
+// out @11.70.
+void test_pct50_tape() {
+    std::printf("-- pct50: shorts placed and filled at the level, 450 / 444 / 427 / 441 / 426 --\n");
+    Probe p(10000.0, 50.0);
+    p.script = [&](Probe& e, int) { tape_script(e, true, true); };
+    std::vector<Bar> bars = f0811_bars();
+    p.run(bars.data(), (int)bars.size());
+    CHECK(p.placed_on(A0811_1415, "S"));
+    const Probe::Placement* s = p.placement(A0811_1415, "S");
+    if (s != nullptr) {
+        CHECK_NEAR(s->qty, 450.0, 1e-9);
+        CHECK_NEAR(s->basis, 11.09, 1e-9);
+    }
+    check_trades(p, {
+        {false, A0811_1430, 11.09, 450.0, A0811_1445, 11.15, -27.0},
+        {false, A0814_1330, 11.22, 444.0, A0814_1345, 11.23, -4.44},
+        {true,  A0819_1330, 11.65, 427.0, A0819_1345, 11.65, 0.0},
+        {false, A0821_1330, 11.29, 441.0, A0821_1345, 11.24, 22.05},
+        {true,  A0822_1400, 11.70, 426.0, A0822_1415, 11.70, 0.0},
+    });
+    CHECK(p.flat());
+}
+
+// --- tape f15-stopsize-short-m50 (pct 100, margin 50, sell stop only) ---
+// TV: 3 short touch fills sized floor(eq / L) — the margin halves the
+// placement cost (floor(eq/L) x C x 0.5 <= eq): 08-11 14:30Z 901 @11.09 out
+// @11.15 (-54.06); 08-14 13:30Z 886 @11.22 out @11.23 (-8.86); 08-21 13:30Z
+// 880 @11.29 out @11.24 (+44).
+void test_short_m50_tape() {
+    std::printf("-- short-m50: margin 50 places the all-in sell stop, fills 901 / 886 / 880 at the level --\n");
+    Probe p(10000.0, 100.0, 50.0);
+    p.script = [&](Probe& e, int) { tape_script(e, false, true); };
+    std::vector<Bar> bars = f0811_bars();
+    p.run(bars.data(), (int)bars.size());
+    CHECK(p.placed_on(A0811_1415, "S"));
+    check_trades(p, {
+        {false, A0811_1430, 11.09, 901.0, A0811_1445, 11.15, -54.06},
+        {false, A0814_1330, 11.22, 886.0, A0814_1345, 11.23, -8.86},
+        {false, A0821_1330, 11.29, 880.0, A0821_1345, 11.24, 44.0},
+    });
+    CHECK(p.flat());
+}
+
+// --- ahtisham F@15 2025-08-19 13:30Z: the first-bar LONG gap-through TV fills ---
+// Equity 9,414.16 (TV cumulative before the trade), buyStopLevel 11.5069 at
+// the 08-18 19:45Z close 11.45 -> level 11.51, qty 817 = floor(9,414.16 /
+// 11.51). 08-19 opens 11.52 through the level: fill at the rounded open,
+// 817 x 11.52 = 9,411.84 <= 9,414.16 admitted — TV's q817 @11.52. Sized at
+// the close (822) the same fill costs 9,469.44 and is declined (the engine's
+// 0/19 before this change).
+void test_0819_long_gap_through_fills_817() {
+    std::printf("-- 08-19 13:30Z long gap-through: 817 = floor(eq / 11.51) x 11.52 admitted --\n");
+    Probe p(9414.16, 100.0);
+    p.script = [&](Probe& e, int bar) {
+        if (bar == A0818_1945) e.entry_stop("Long", true, 11.5069, "EXPANSION UP");
+        if (bar == A0819_1345 && e.position_size() > 0) e.strategy_close_all();
+    };
+    std::vector<Bar> bars = f0811_bars();
+    p.run(bars.data(), (int)bars.size());
+    CHECK(p.placed_on(A0818_1945, "Long"));
+    const Probe::Placement* l = p.placement(A0818_1945, "Long");
+    if (l != nullptr) {
+        CHECK_NEAR(l->qty, 817.0, 1e-9);
+        CHECK_NEAR(l->basis, 11.51, 1e-9);
+    }
+    CHECK(p.trade_count() == 1);
+    if (p.trade_count() >= 1) {
+        const Trade& t = p.get_trade(0);
+        CHECK(t.is_long);
+        CHECK(t.entry_bar_index == A0819_1330);
+        CHECK_NEAR(t.entry_price, 11.52, 1e-9);
+        CHECK_NEAR(t.qty, 817.0, 1e-9);
+        CHECK(t.entry_comment == "EXPANSION UP");
+    }
+}
+
+// --- ahtisham F@15 2025-08-21 13:30Z: a first-bar SHORT gap-through is NOT filled ---
+// Equity 9,451.56, sellStopLevel 11.4225 at the 08-20 19:45Z close 11.49 ->
+// level 11.42, qty 827 = floor(9,451.56 / 11.42); 827 x 11.49 = 9,502.23 >
+// 9,451.56: the placement is rejected and nothing rests, so the 08-21 open
+// 11.42 through the level fills nothing (TV NOFILL; the engine filled 822
+// @11.42 here before this change).
+void test_0821_short_gap_through_not_filled() {
+    std::printf("-- 08-21 13:30Z first-bar short gap-through: never placed, no fill --\n");
+    Probe p(9451.56, 100.0);
+    p.script = [&](Probe& e, int bar) {
+        if (bar == A0820_1945) e.entry_stop("Short", false, 11.4225, "EXPANSION DOWN");
+    };
+    std::vector<Bar> bars = f0811_bars();
+    p.run(bars.data(), (int)bars.size());
+    const Probe::Placement* s = p.placement(A0820_1945, "Short");
+    CHECK(s != nullptr && !s->placed);
+    CHECK(p.trade_count() == 0);
+    CHECK(p.flat());
+}
+
+// --- ahtisham F@15 first divergence: 2025-04-03 19:45Z .. 04-04 15:15Z ---
+// TV equity 9,742.34 after trade 1. At the 04-03 19:45Z close 9.545 (-> 9.55)
+// the sell stop 9.5090 -> 9.50 sizes 1,025 and 1,025 x 9.55 = 9,788.75 >
+// 9,742.34: not placed; the buy stop 9.9110 -> 9.92 (982) is. 04-04 13:30Z
+// gaps down to 9.32 through 9.50: NOTHING fills (the engine filled 1,020
+// @9.32 here before this change — its first divergence on this probe). At
+// the 13:30Z close 9.335 (-> 9.34) the sell stop 9.4143 -> 9.41 is already
+// beyond the close: a market order sized at tick(close), 1,043 = floor(
+// 9,742.34 / 9.34), filling at the 13:45Z open 9.34 (1,043 x 9.34 = 9,741.62
+// <= 9,742.34). TV's tape: trade 2 = 88 @9.34 margin-called 13:45Z @9.44,
+// trade 3 = 955 @9.34 stopped 15:00Z @9.52 ("Fakeout", the 9.5175 mid ->
+// 9.52 buy stop).
+void aht_script(Probe& e, int bar, bool with_exits) {
+    const LvlRow& r = kAht0404[bar];
+    if (e.position_size() == 0) {
+        e.entry_stop("Long", true, r.buy_stop, "EXPANSION UP");
+        e.entry_stop("Short", false, r.sell_stop, "EXPANSION DOWN");
+    }
+    if (!with_exits) return;
+    if (e.position_size() > 0) {
+        const double tp = r.buy_stop + std::fabs(r.buy_stop - r.mid) * 2.0;
+        e.strategy_exit("L-Exit", "Long", tp, r.mid);
+    }
+    if (e.position_size() < 0) {
+        const double tp = r.sell_stop - std::fabs(r.sell_stop - r.mid) * 2.0;
+        e.strategy_exit("S-Exit", "Short", tp, r.mid);
+    }
+}
+
+void test_ahtisham_0404_first_divergence() {
+    std::printf("-- ahtisham 04-04: no gap fill at 13:30Z, the beyond-level short is market-sized 1,043 at the 13:45Z open --\n");
+    Probe p(9742.34, 100.0);
+    p.script = [&](Probe& e, int bar) {
+        aht_script(e, bar, /*with_exits=*/true);
+        if (bar == B0404_1330) {
+            // The bar that gapped through the never-placed 9.50 sell stop.
+            CHECK(e.flat());
+            CHECK(e.trade_count() == 0);
+        }
+    };
+    std::vector<Bar> bars = aht0404_bars();
+    p.run(bars.data(), (int)bars.size());
+
+    // 04-03 19:45Z: the sell stop is rejected at placement, the buy stop rests.
+    const Probe::Placement* s0 = p.placement(B0403_1945, "Short");
+    CHECK(s0 != nullptr && !s0->placed);
+    const Probe::Placement* l0 = p.placement(B0403_1945, "Long");
+    CHECK(l0 != nullptr && l0->placed);
+    if (l0 != nullptr) {
+        CHECK_NEAR(l0->qty, 982.0, 1e-9);        // floor(9,742.34 / 9.92)
+        CHECK_NEAR(l0->basis, 9.92, 1e-9);
+    }
+    // 04-04 13:30Z close: the sell stop 9.41 is beyond the 9.34 close ->
+    // sized at tick(close), not at the level (1,035) nor at the open (1,045).
+    const Probe::Placement* s1 = p.placement(B0404_1330, "Short");
+    CHECK(s1 != nullptr && s1->placed);
+    if (s1 != nullptr) {
+        CHECK_NEAR(s1->qty, 1043.0, 1e-9);
+        CHECK_NEAR(s1->basis, 9.34, 1e-9);
+    }
+    // 13:45Z: short 1,043 @9.34; stopped 15:00Z @9.52 (margin call off here:
+    // one trade carries the whole lot).
+    CHECK(p.trade_count() == 1);
+    if (p.trade_count() >= 1) {
+        const Trade& t = p.get_trade(0);
+        CHECK(!t.is_long);
+        CHECK(t.entry_bar_index == B0404_1345);
+        CHECK_NEAR(t.entry_price, 9.34, 1e-9);
+        CHECK_NEAR(t.qty, 1043.0, 1e-9);
+        CHECK(t.entry_comment == "EXPANSION DOWN");
+        CHECK(t.exit_bar_index == B0404_1500);
+        CHECK_NEAR(t.exit_price, 9.52, 1e-9);
+    }
+}
+
+// The same sequence with TV's margin call on: the 13:45Z bar (h 9.435 ->
+// 9.44) slices the under-margined lot — TV's trade 2, 88 @9.34 -> @9.44 —
+// and the remaining 955 are stopped 15:00Z @9.52 (trade 3). The entries
+// still sum to the 1,043 sized at tick(close).
+void test_ahtisham_0404_margin_call_slices() {
+    std::printf("-- ahtisham 04-04 with margin call: 88 sliced @9.44 on the fill bar, 955 stopped @9.52 --\n");
+    Probe p(9742.34, 100.0);
+    p.enable_margin_call();
+    p.script = [&](Probe& e, int bar) { aht_script(e, bar, /*with_exits=*/true); };
+    std::vector<Bar> bars = aht0404_bars();
+    p.run(bars.data(), (int)bars.size());
+    double entered = 0.0;
+    bool all_short_at_0345 = p.trade_count() > 0;
+    for (int i = 0; i < p.trade_count(); ++i) {
+        const Trade& t = p.get_trade(i);
+        entered += t.qty;
+        if (t.is_long || t.entry_bar_index != B0404_1345
+            || std::fabs(t.entry_price - 9.34) > 1e-9) {
+            all_short_at_0345 = false;
+        }
+    }
+    CHECK(all_short_at_0345);
+    CHECK_NEAR(entered, 1043.0, 1e-9);
+    CHECK(p.trade_count() == 2);
+    if (p.trade_count() == 2) {
+        const Trade& mc = p.get_trade(0);
+        CHECK_NEAR(mc.qty, 88.0, 1e-9);
+        CHECK(mc.exit_bar_index == B0404_1345);
+        CHECK_NEAR(mc.exit_price, 9.44, 1e-9);
+        const Trade& rest = p.get_trade(1);
+        CHECK_NEAR(rest.qty, 955.0, 1e-9);
+        CHECK(rest.exit_bar_index == B0404_1500);
+        CHECK_NEAR(rest.exit_price, 9.52, 1e-9);
+    }
+}
+
+// --- rule 2 on a default stop: a rejected same-id re-issue cancels the resting order ---
+// (family E, xau-flatten-replace-c10983; the K pin: "a rejected placement is
+// dropped and only the script's next call re-issues it".) Synthetic bars,
+// mintick 0.01, whole shares, pct 100: close 11.44, sell stop 11.43 -> 874 =
+// floor(10,000 / 11.43), 874 x 11.44 = 9,998.56 <= 10,000 PLACED (an all-in
+// sell stop one tick below the close can pass when the lot floor absorbs
+// the tick). Bar 1 (no touch) closes 11.60: the re-issue at the same level
+// costs 874 x 11.60 = 10,138.4 > 10,000 -> rejected AND the resting 874 is
+// cancelled; bar 2 gaps through the level (o 11.30) and fills nothing.
+// Armed once (no re-issue) the resting order fills the gap: 874 @11.30
+// (874 x 11.30 = 9,876.2 <= 10,000), the placement quantity, not the 884 a
+// fill-time re-size at 11.30 would open.
+void test_rejected_reissue_cancels_resting_default_stop() {
+    std::printf("-- rejected same-id re-issue cancels the resting default stop; armed once it fills the gap with its placement qty --\n");
+    std::vector<Bar> bars = {
+        mk(1000, 11.40, 11.45, 11.38, 11.44),
+        mk(2000, 11.50, 11.60, 11.45, 11.60),
+        mk(3000, 11.30, 11.35, 11.25, 11.32),
+        mk(4000, 11.32, 11.33, 11.31, 11.32),
+    };
+    for (bool reissue : {true, false}) {
+        Probe p(10000.0, 100.0);
+        p.script = [&](Probe& e, int bar) {
+            if (bar == 0 || (reissue && bar == 1)) {
+                e.entry_stop("S", false, 11.43, "S");
+            }
+        };
+        p.run(bars.data(), (int)bars.size());
+        CHECK(p.placed_on(0, "S"));
+        const Probe::Placement* s = p.placement(0, "S");
+        if (s != nullptr) {
+            CHECK_NEAR(s->qty, 874.0, 1e-9);
+            CHECK_NEAR(s->basis, 11.43, 1e-9);
+        }
+        if (reissue) {
+            CHECK(!p.placed_on(1, "S"));
+            CHECK(p.pending("S") == nullptr);
+            CHECK(p.flat());
+            CHECK(p.trade_count() == 0);
+        } else {
+            CHECK(!p.flat());
+            CHECK(p.position_size() < 0);
+            CHECK_NEAR(-p.position_size(), 874.0, 1e-9);
+        }
+    }
+}
+
+}  // namespace
+
+int main() {
+    std::printf("--- default_pct_stop_sizing (round 7 family K, log-20260905t084529z-c7b22df1) ---\n");
+    test_pct100_tape();
+    test_short_only_tape();
+    test_pct50_tape();
+    test_short_m50_tape();
+    test_0819_long_gap_through_fills_817();
+    test_0821_short_gap_through_not_filled();
+    test_ahtisham_0404_first_divergence();
+    test_ahtisham_0404_margin_call_slices();
+    test_rejected_reissue_cancels_resting_default_stop();
+    std::printf("\n=== Results: %d passed, %d failed ===\n",
+                tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_stop_decline_continue_path.cpp
+++ b/tests/test_stop_decline_continue_path.cpp
@@ -4,13 +4,27 @@
  * ordinary historical path scanner must consider the later member. All other
  * rejection causes and order-book/scheduler shapes retain their old paths.
  *
- * The declined member is an all-in DEFAULT percent-of-equity short stop
- * touched intrabar: its qty is 10000/90 and the fill-time gate costs it at
- * the bar OPEN 100 (11,111 > 10,000). Round 7 re-based that gate to the
- * fill price for the explicit-qty / FIXED / CASH / >100% partition only
- * (design-stop-entry-placement-admission); the default percent <= 100 stop
- * keeps the open basis, so this shape — the ahtisham volatility-expansion
- * probe's — still declines (tests/test_stop_entry_admission.cpp).
+ * Round 7 family K (tests/test_default_pct_stop_sizing.cpp) changed what this
+ * file's historical shape does: the all-in DEFAULT percent-of-equity sell
+ * stop 90 below the signal close 100 is sized at its level (10000 / 90) and
+ * REJECTED AT THE CALL (111.11 x 100 = 11,111 > 10,000), so it never reaches
+ * the book — there is no path-first member to decline at the fill and no
+ * fence on the later long, which fills its 110 touch alone in every
+ * configuration below. (A sell stop that IS accepted at the call costs less
+ * at its fill — the level or a lower open — than at its placement close, so
+ * a fill-time margin decline of a true-flat pair's leading short needs an
+ * equity drop while resting, which a true-flat pair cannot have. The
+ * continuation is a dormant safety net on that shape.)
+ *
+ * What stays pinned here: the continuation scope predicate as a pure
+ * function on a two-stop book (continuation_scope builds the book under
+ * margin 0 so the family-K admission does not empty it), the kernel's
+ * results on the historical shape, and — the buy-stop-leading orientation —
+ * a long declined at a gap-up open (family K: sized at the level, costed at
+ * the rounded open) followed by the later short touch, which TradingView
+ * applies as the same-bar second touch (classify_order_eligibility's
+ * LongFirst pass-1 rule) and which fills at its level with its placement
+ * quantity.
  */
 
 #include <cmath>
@@ -101,9 +115,18 @@ public:
     void long_only() { risk_direction_ = RiskDirection::LONG_ONLY; }
     void enable_pooc() { process_orders_on_close_ = true; }
     void enable_coof() { calc_on_order_fills_ = true; }
+    void set_lots(double step) { qty_step_ = step; }
     bool continuation_scope(bool magnifier = false) {
         bar_index_ = 0;
+        // Build the two-stop book with the placement check disabled (margin
+        // 0): the predicate under test reads the book's shape, not the
+        // family-K admission that drops the all-in short at the call.
+        const double ml = margin_long_, ms = margin_short_;
+        margin_long_ = 0.0;
+        margin_short_ = 0.0;
         on_bar(Bar{});
+        margin_long_ = ml;
+        margin_short_ = ms;
         const bool scoped = internal::dual_stop_margin_decline_can_continue_path(
             pending_orders_, internal::DualEntryStopPathWinner::ShortFirst,
             process_orders_on_close_, calc_on_order_fills_, magnifier);
@@ -114,12 +137,17 @@ public:
     PositionSide side() const { return position_side_; }
     double qty() const { return position_qty_; }
     double entry_price() const { return position_entry_price_; }
+    bool pending(const std::string& id) const {
+        for (const auto& o : pending_orders_) if (o.id == id) return true;
+        return false;
+    }
 };
 
 // O=100 is tied between H=111 and L=89, so the synthesized path is
-// O->L->H->C. The short stop at 90 is first. Its all-in qty is 10000/90,
-// but admission costs that qty at open 100, so it declines. The later long
-// stop is affordable because its qty is 10000/110.
+// O->L->H->C. Historically the short stop at 90 was first and declined at
+// the open-costed fill; under family K its call is rejected (11,111 > 10,000
+// at the signal close) and only the long rests, sized 10000/110 at its
+// level (9,090.9 <= 10,000 placed; 10,000 <= 10,000 admitted at the touch).
 Bar low_first_dual_touch() {
     return bar(2'000, 100.0, 111.0, 89.0, 100.0);
 }
@@ -137,22 +165,53 @@ void run_pair(DualStopProbe& probe, bool magnifier = false) {
     }
 }
 
-void test_margin_decline_continues_to_affordable_later_stop() {
-    std::printf("margin decline continues to the affordable later stop\n");
-    DualStopProbe scope_probe;
-    CHECK(scope_probe.continuation_scope());
-    DualStopProbe probe;
-    run_pair(probe);
+void check_long_alone(const DualStopProbe& probe) {
     CHECK(probe.side() == PositionSide::LONG);
     CHECK(std::fabs(probe.entry_price() - 110.0) < 1e-9);
     CHECK(std::fabs(probe.qty() - (10'000.0 / 110.0)) < 1e-9);
     CHECK(probe.trade_count() == 0);
+    CHECK(!probe.pending("S"));
+}
+
+void test_rejected_all_in_short_leaves_later_stop_to_fill() {
+    std::printf("rejected all-in short (family K placement) leaves the later stop to fill alone\n");
+    DualStopProbe scope_probe;
+    CHECK(scope_probe.continuation_scope());
+    DualStopProbe probe;
+    run_pair(probe);
+    check_long_alone(probe);
+}
+
+// The buy-stop-leading orientation, whole shares, signal close 100: the buy
+// stop 105 sizes 95 = floor(10000 / 105) and places (9,500 <= 10,000); the
+// sell stop 99.5 sizes 100 and places (100 x 100 = 10,000 <= 10,000 — the lot
+// floor absorbs the half tick). Bar 1 opens 106 through the buy stop: the
+// long is DECLINED at the fill (95 x 106 = 10,070 > 10,000, costed at the
+// rounded open) and dropped; the sell stop is touched later on the path
+// (l 99) and fills at its level with its placement quantity (100 x 99.5 =
+// 9,950 <= 10,000).
+void test_long_gap_decline_then_short_touch_fills() {
+    std::printf("long declined at the gap-up open, the later short touch fills at its level\n");
+    DualStopProbe probe;
+    probe.set_lots(1.0);
+    probe.long_stop = 105.0;
+    probe.short_stop = 99.5;
+    Bar bars[] = {
+        bar(1'000, 100.0, 100.0, 100.0, 100.0),
+        bar(2'000, 106.0, 107.0, 99.0, 100.0),
+    };
+    probe.run(bars, 2);
+    CHECK(probe.side() == PositionSide::SHORT);
+    CHECK(std::fabs(probe.entry_price() - 99.5) < 1e-9);
+    CHECK(std::fabs(probe.qty() - 100.0) < 1e-9);
+    CHECK(probe.trade_count() == 0);
+    CHECK(!probe.pending("L"));
 }
 
 void test_accepted_first_stop_preserves_existing_second_touch_result() {
     std::printf("accepted first stop preserves the existing dual-touch result\n");
     DualStopProbe probe;
-    probe.short_stop = 100.0;  // marketable at open; qty*open == equity
+    probe.short_stop = 100.0;  // at the close: market-at-next-open, qty*open == equity
     run_pair(probe);
     // The accepted short opens first; the existing path logic then applies the
     // later long touch, closing most of it. The margin-decline continuation
@@ -163,16 +222,15 @@ void test_accepted_first_stop_preserves_existing_second_touch_result() {
     CHECK(probe.trade_count() == 1);
 }
 
-void test_non_margin_rejection_does_not_continue() {
-    std::printf("risk rejection does not release the later stop\n");
+void test_non_margin_rejection_does_not_change_shape() {
+    std::printf("risk direction leaves the historical shape unchanged\n");
     DualStopProbe scope_probe;
     scope_probe.long_only();
     CHECK(scope_probe.continuation_scope());
     DualStopProbe probe;
     probe.long_only();
     run_pair(probe);
-    CHECK(probe.side() == PositionSide::FLAT);
-    CHECK(probe.trade_count() == 0);
+    check_long_alone(probe);
 }
 
 void test_oca_pair_is_out_of_scope() {
@@ -183,8 +241,7 @@ void test_oca_pair_is_out_of_scope() {
     DualStopProbe probe;
     probe.use_oca = true;
     run_pair(probe);
-    CHECK(probe.side() == PositionSide::FLAT);
-    CHECK(probe.trade_count() == 0);
+    check_long_alone(probe);
 }
 
 void test_pooc_is_out_of_scope() {
@@ -195,8 +252,7 @@ void test_pooc_is_out_of_scope() {
     DualStopProbe probe;
     probe.enable_pooc();
     run_pair(probe);
-    CHECK(probe.side() == PositionSide::FLAT);
-    CHECK(probe.trade_count() == 0);
+    check_long_alone(probe);
 }
 
 void test_coof_is_out_of_scope() {
@@ -207,10 +263,7 @@ void test_coof_is_out_of_scope() {
     DualStopProbe probe;
     probe.enable_coof();
     run_pair(probe);
-    CHECK(probe.side() == PositionSide::LONG);
-    CHECK(std::fabs(probe.qty() - (10'000.0 / 110.0)) < 1e-9);
-    CHECK(std::fabs(probe.entry_price() - 110.0) < 1e-9);
-    CHECK(probe.trade_count() == 0);
+    check_long_alone(probe);
 }
 
 void test_mixed_order_books_are_out_of_scope() {
@@ -227,44 +280,43 @@ void test_mixed_order_books_are_out_of_scope() {
         DualStopProbe probe;
         probe.mixed_order = kind;
         run_pair(probe);
+        // The third order fills its share (the market at the open 100, the
+        // limit / raw limit at 95 on the way down) and the long stop adds
+        // 10000/110 at 110 on the way up; nothing is fenced because the
+        // short never reached the book.
         CHECK(probe.side() == PositionSide::LONG);
-        if (kind == DualStopProbe::MixedOrder::Market) {
-            const double stop_qty = 10'000.0 / 110.0;
-            const double expected_qty = 1.0 + stop_qty;
-            const double expected_price =
-                (100.0 + stop_qty * 110.0) / expected_qty;
-            CHECK(std::fabs(probe.qty() - expected_qty) < 1e-9);
-            CHECK(std::fabs(probe.entry_price() - expected_price) < 1e-9);
-        } else {
-            CHECK(std::fabs(probe.qty() - 1.0) < 1e-9);
-            CHECK(std::fabs(probe.entry_price() - 95.0) < 1e-9);
-        }
+        const double stop_qty = 10'000.0 / 110.0;
+        const double expected_qty = 1.0 + stop_qty;
+        const double third_price =
+            kind == DualStopProbe::MixedOrder::Market ? 100.0 : 95.0;
+        const double expected_price =
+            (third_price + stop_qty * 110.0) / expected_qty;
+        CHECK(std::fabs(probe.qty() - expected_qty) < 1e-9);
+        CHECK(std::fabs(probe.entry_price() - expected_price) < 1e-9);
         CHECK(probe.trade_count() == 0);
     }
 }
 
 void test_non_true_flat_pair_is_out_of_scope() {
-    std::printf("post-close flat provenance does not release the later stop\n");
+    std::printf("post-close flat provenance: predicate false, shape unchanged\n");
     DualStopProbe scope_probe;
     scope_probe.mark_as_after_close = true;
     CHECK(!scope_probe.continuation_scope());
     DualStopProbe probe;
     probe.mark_as_after_close = true;
     run_pair(probe);
-    CHECK(probe.side() == PositionSide::FLAT);
-    CHECK(probe.trade_count() == 0);
+    check_long_alone(probe);
 }
 
 void test_different_signal_bars_are_out_of_scope() {
-    std::printf("different-signal stop pair does not release the later stop\n");
+    std::printf("different-signal stop pair: predicate false, shape unchanged\n");
     DualStopProbe scope_probe;
     scope_probe.split_signal_bars = true;
     CHECK(!scope_probe.continuation_scope());
     DualStopProbe probe;
     probe.split_signal_bars = true;
     run_pair(probe);
-    CHECK(probe.side() == PositionSide::FLAT);
-    CHECK(probe.trade_count() == 0);
+    check_long_alone(probe);
 }
 
 void test_magnifier_is_out_of_scope() {
@@ -273,18 +325,16 @@ void test_magnifier_is_out_of_scope() {
     CHECK(!scope_probe.continuation_scope(true));
     DualStopProbe probe;
     run_pair(probe, true);
-    CHECK(probe.side() == PositionSide::LONG);
-    CHECK(std::fabs(probe.qty() - (10'000.0 / 110.0)) < 1e-9);
-    CHECK(std::fabs(probe.entry_price() - 110.0) < 1e-9);
-    CHECK(probe.trade_count() == 0);
+    check_long_alone(probe);
 }
 
 }  // namespace
 
 int main() {
-    test_margin_decline_continues_to_affordable_later_stop();
+    test_rejected_all_in_short_leaves_later_stop_to_fill();
+    test_long_gap_decline_then_short_touch_fills();
     test_accepted_first_stop_preserves_existing_second_touch_result();
-    test_non_margin_rejection_does_not_continue();
+    test_non_margin_rejection_does_not_change_shape();
     test_oca_pair_is_out_of_scope();
     test_pooc_is_out_of_scope();
     test_coof_is_out_of_scope();

--- a/tests/test_stop_entry_admission.cpp
+++ b/tests/test_stop_entry_admission.cpp
@@ -26,10 +26,15 @@
  *
  * Scope: the explicit-qty / default FIXED / CASH / default percent > 100
  * sizing partition (every tape passes an explicit qty). A DEFAULT
- * percent_of_equity <= 100 stop takes neither half: no placement check and
- * the fill-time gate keeps KI-62's bar-OPEN basis — the ahtisham regression
- * at the end of this file (cand-round7-engine-a-20260905: costing the
- * all-in default at the level admitted 394 short touches TV never fills).
+ * percent_of_equity <= 100 stop takes the SAME placement half with its own
+ * quantity — sized at the tick-snapped LEVEL, family K, ledger note
+ * log-20260905t084529z-c7b22df1, tests/test_default_pct_stop_sizing.cpp —
+ * and the same fill half on that quantity; KI-62's bar-OPEN basis is
+ * retired. The ahtisham regression at the end of this file
+ * (cand-round7-engine-a-20260905: costing the all-in default at the level
+ * with a FILL-time quantity admitted 394 short touches TV never fills) is
+ * now explained by the placement half: the all-in sell stop below the
+ * close is never placed.
  *
  * Feed bars are the registry's NYSE:F 15 (mintick 0.01, whole shares) and
  * OANDA:XAUUSD 15 (mintick 0.005, lot 0.01) bars, UTC, `lab bars`. Tape
@@ -1022,6 +1027,11 @@ void test_margin_zero_control() {
 // 1859.63 >= l 1853.57, all-in 5.3133 x 1859.63 = 9,880.8 <= 9,880.86 at the
 // level where 5.3133 x 1866.16 = 9,915.5 > 9,880.86 declines at the open
 // (TV: no trade; 394 such shorts over the range, 591 -> 1,177 trades).
+// Family K (this round) explains it from the placement side: the 05:00Z
+// call sizes the sell stop at the level (5.3133 = floor(9,880.86 / 1859.63,
+// 0.0001)) and rejects it at the close (5.3133 x 1866.16 = 9,915.5 >
+// 9,880.86) — nothing rests for the 05:15Z touch. The buy stop at the level
+// 1912.40 sizes 5.1667 (9,880.8 <= 9,880.86) and fills the touch unchanged.
 struct EthRow { double o, h, l, c, buy_stop, sell_stop, mid; };
 constexpr int kEthCount = 56;   // 2025-04-02 04:15Z .. 18:00Z
 enum EthBar {
@@ -1098,7 +1108,7 @@ std::vector<Bar> eth_bars() {
 }
 
 void test_ahtisham_default_pct_stop() {
-    std::printf("-- ahtisham: default percent 100 x margin 100, the 05:15Z short touch is declined at the open, the 15:30Z long touch fills --\n");
+    std::printf("-- ahtisham: default percent 100 x margin 100, the 05:00Z sell stop is never placed (no 05:15Z touch fill), the 15:30Z long touch fills 5.1667 sized at the level --\n");
     Probe p(9880.86, 100.0, 0.01, 0.0001);
     p.use_default_percent(100.0);
     p.script = [&](Probe& e, int bar) {
@@ -1114,9 +1124,15 @@ void test_ahtisham_default_pct_stop() {
             e.entry_stop("Long", true, r.buy_stop, kNaN, "EXPANSION UP");
             e.entry_stop("Short", false, r.sell_stop, kNaN, "EXPANSION DOWN");
             if (bar == E0402_0500) {
-                // No placement check on a default-sized stop: both rest.
+                // Family K placement check: the all-in sell stop below the
+                // close (5.3133 x 1866.16 > 9,880.86) is rejected; the buy
+                // stop rests, sized at its level.
                 CHECK(e.pending("Long"));
-                CHECK(e.pending("Short"));
+                CHECK(!e.pending("Short"));
+            }
+            if (bar == E0402_1515) {
+                CHECK(e.pending("Long"));
+                CHECK(!e.pending("Short"));
             }
         }
         if (e.position_size() > 0) {

--- a/tests/test_stop_entry_placement_open_qty.cpp
+++ b/tests/test_stop_entry_placement_open_qty.cpp
@@ -1,10 +1,19 @@
 /*
- * Production placement-frozen STOP admission semantics.
+ * Production placement-frozen STOP sizing semantics (round 7, family K).
  *
- * One tightly scoped true-flat all-in pure STOP snapshots its quantity at
- * placement. A next-bar open-marketable fill uses that quantity for admission
- * and dispatch; intrabar touches and all non-target controls keep ordinary
- * fill-time sizing.
+ * A DEFAULT percent_of_equity <= 100 pure STOP is sized when strategy.entry
+ * is called — at the tick-snapped level, or at tick(close) when the level is
+ * already at/beyond the close (TV's market-at-next-open order) — and is
+ * placement-checked on that quantity at tick(close) (family E). The frozen
+ * quantity is what admission costs and dispatch opens on every fill shape
+ * (gap-through, intrabar touch, delayed touch); it is never re-sized while
+ * resting. Non-default sizing, limit and stop-limit shapes carry no snapshot.
+ *
+ * Rule, tapes (scratchpad/r7/pins/f15-stopsize-*) and the ahtisham decode:
+ * PendingOrder::default_stop_placement_qty (engine.hpp) and
+ * tests/test_default_pct_stop_sizing.cpp. Before this round the snapshot
+ * was a next-open-only, all-in, margin-100 special case sized at the CLOSE;
+ * the expectations re-pinned here are listed in the commit.
  */
 
 #include <cmath>
@@ -88,48 +97,57 @@ public:
     bool is_long = false;
     bool explicit_qty = false;
     int reissue_bar = -1;
+    double reissue_stop = kNaN;   // level of the re-issue (default: same)
     PostPlacementMutation post_placement_mutation =
         PostPlacementMutation::NONE;
     double stop = 120.0;
     double limit = 80.0;
     double placement_snapshot_qty = kNaN;
+    double placement_snapshot_basis = kNaN;
     double reissue_snapshot_qty = kNaN;
+    bool placed_at_0 = false;
+    bool placed_at_reissue = false;
 
     void on_bar(const Bar&) override {
         if (bar_index_ != 0 && bar_index_ != reissue_bar) return;
         const double qty = explicit_qty ? 7.0 : kNaN;
+        const double level = (bar_index_ == reissue_bar && !std::isnan(reissue_stop))
+            ? reissue_stop : stop;
         switch (shape) {
             case Shape::STOP:
-                strategy_entry("E", is_long, kNaN, stop, qty);
+                strategy_entry("E", is_long, kNaN, level, qty);
                 break;
             case Shape::LIMIT:
                 strategy_entry("E", is_long, limit, kNaN, qty);
                 break;
             case Shape::STOP_LIMIT:
-                strategy_entry("E", is_long, limit, stop, qty);
+                strategy_entry("E", is_long, limit, level, qty);
                 break;
         }
         const PendingOrder* order = pending();
-        if (order != nullptr) {
-            if (bar_index_ == 0) {
-                placement_snapshot_qty =
-                    order->stop_placement_open_qty;
-            } else if (bar_index_ == reissue_bar) {
-                reissue_snapshot_qty = order->stop_placement_open_qty;
+        if (bar_index_ == 0) {
+            placed_at_0 = order != nullptr;
+            if (order != nullptr) {
+                placement_snapshot_qty = order->default_stop_placement_qty;
+                placement_snapshot_basis = order->default_stop_sizing_price;
+            }
+        } else if (bar_index_ == reissue_bar) {
+            placed_at_reissue = order != nullptr;
+            if (order != nullptr) {
+                reissue_snapshot_qty = order->default_stop_placement_qty;
             }
         }
         if (bar_index_ != 0) return;
         // Mutate only after the placement snapshot has been captured. Each
-        // case therefore proves that consumption re-validates current broker
-        // state and falls back to the ordinary fill-time path.
+        // case therefore proves what consumption does with a snapshot whose
+        // broker state moved underneath it.
         switch (post_placement_mutation) {
             case PostPlacementMutation::NONE:
                 break;
             case PostPlacementMutation::REALIZED_EQUITY_GAIN:
                 // Model an independent intervening round trip that realizes a
                 // gain and returns broker state to flat before this STOP's
-                // next-open adjudication. Flatness alone must not authorize a
-                // stale placement-equity snapshot.
+                // next-open adjudication.
                 net_profit_sum_ = 1000.0;
                 break;
             case PostPlacementMutation::COMMISSION:
@@ -171,29 +189,49 @@ static void run(Probe& probe, const std::vector<Bar>& bars) {
 }
 
 void test_default_placement_snapshot() {
-    std::printf("-- production default captures the narrow STOP snapshot --\n");
+    std::printf("-- production default captures the STOP snapshot --\n");
 
-    Probe probe;
-    run(probe, {bar(1000, 100, 100, 100, 100)});
-    CHECK(probe.pending() != nullptr);
-    if (probe.pending() != nullptr) {
-        CHECK(std::isnan(probe.pending()->qty));
-        CHECK(std::isnan(probe.pending()->frozen_default_qty));
-        CHECK_NEAR(probe.pending()->stop_placement_open_qty,
+    // A short stop ABOVE the close (120 > 100) is already beyond the level:
+    // TV's market-at-next-open order, sized at tick(close) = 100 -> 100.
+    Probe beyond;
+    run(beyond, {bar(1000, 100, 100, 100, 100)});
+    CHECK(beyond.pending() != nullptr);
+    if (beyond.pending() != nullptr) {
+        CHECK(std::isnan(beyond.pending()->qty));
+        CHECK(std::isnan(beyond.pending()->frozen_default_qty));
+        CHECK_NEAR(beyond.pending()->default_stop_placement_qty,
                    100.0, 1e-12);
-        CHECK_NEAR(probe.pending()->stop_placement_open_equity,
+        CHECK_NEAR(beyond.pending()->default_stop_sizing_price,
+                   100.0, 1e-12);
+        CHECK_NEAR(beyond.pending()->default_stop_placement_equity,
                    10000.0, 1e-12);
-        CHECK_NEAR(probe.pending()->stop_placement_signal_close,
+        CHECK_NEAR(beyond.pending()->default_stop_placement_signal_close,
                    100.0, 1e-12);
+    }
+
+    // A buy stop above the close is sized at the LEVEL: floor(10000 / 120,
+    // 0.0001) = 83.3333, placement cost 83.3333 x 100 <= 10000.
+    Probe at_level;
+    at_level.is_long = true;
+    at_level.stop = 120.0;
+    run(at_level, {bar(1000, 100, 100, 100, 100)});
+    CHECK(at_level.pending() != nullptr);
+    if (at_level.pending() != nullptr) {
+        CHECK_NEAR(at_level.pending()->default_stop_placement_qty,
+                   83.3333, 1e-12);
+        CHECK_NEAR(at_level.pending()->default_stop_sizing_price,
+                   120.0, 1e-12);
     }
 }
 
 void test_positive_gap_declines_both_directions() {
     std::printf("-- higher-notional gap-open declines long and short --\n");
 
+    // Beyond-level short (market-sized 100 at the close 100): the 110 open
+    // costs 11000 > 10000 -> declined, dropped.
     Probe short_probe;
     short_probe.is_long = false;
-    short_probe.stop = 120.0;  // short STOP is already marketable at open 110
+    short_probe.stop = 120.0;
     run(short_probe, {
         bar(1000, 100, 100, 100, 100),
         bar(2000, 110, 111, 109, 110),
@@ -201,31 +239,57 @@ void test_positive_gap_declines_both_directions() {
     CHECK(short_probe.side() == PositionSide::FLAT);
     CHECK(short_probe.trade_count() == 0);
 
+    // Buy stop 105 sized at the level (95.2380): the gap-through at 110
+    // costs 10476.18 > 10000 -> declined, dropped.
     Probe long_probe;
     long_probe.is_long = true;
-    long_probe.stop = 105.0;   // long STOP is marketable at open 110
+    long_probe.stop = 105.0;
     run(long_probe, {
         bar(1000, 100, 100, 100, 100),
         bar(2000, 110, 111, 109, 110),
     });
+    CHECK(long_probe.placed_at_0);
+    CHECK_NEAR(long_probe.placement_snapshot_qty, 95.238, 1e-9);
     CHECK(long_probe.side() == PositionSide::FLAT);
     CHECK(long_probe.trade_count() == 0);
 }
 
 void test_accepted_gap_dispatches_placement_quantity() {
-    std::printf("-- admitted gap dispatches placement-frozen qty --\n");
+    std::printf("-- admitted gap dispatches placement-frozen qty; the all-in sell stop below the close is never placed --\n");
 
+    // Re-pinned (tapes pct100 / short-only): an all-in sell stop BELOW the
+    // close is rejected at placement — floor(10000 / 95) = 105.2631 x 100 =
+    // 10526.3 > 10000 — so the 90 gap-open through it fills nothing (the
+    // pre-round-7 snapshot filled 100 @90 here).
     Probe short_probe;
     short_probe.is_long = false;
-    short_probe.stop = 95.0;   // open 90 is through the short STOP
+    short_probe.stop = 95.0;
     run(short_probe, {
         bar(1000, 100, 100, 100, 100),
         bar(2000, 90, 91, 89, 90),
     });
-    CHECK(short_probe.side() == PositionSide::SHORT);
-    CHECK_NEAR(short_probe.entry_price(), 90.0, 1e-12);
-    CHECK_NEAR(short_probe.position_qty(), 100.0, 1e-9);
+    CHECK(!short_probe.placed_at_0);
+    CHECK(short_probe.side() == PositionSide::FLAT);
+    CHECK(short_probe.trade_count() == 0);
 
+    // At pct 50 the same sell stop places (52.6315 x 100 <= 10000) and the
+    // gap-open fills the placement quantity at the rounded open 90 —
+    // 52.6315, not the 55.5555 a fill-time re-size at 90 would open.
+    Probe half(QtyType::PERCENT_OF_EQUITY, 50.0, 100.0);
+    half.is_long = false;
+    half.stop = 95.0;
+    run(half, {
+        bar(1000, 100, 100, 100, 100),
+        bar(2000, 90, 91, 89, 90),
+    });
+    CHECK(half.placed_at_0);
+    CHECK_NEAR(half.placement_snapshot_qty, 52.6315, 1e-9);
+    CHECK(half.side() == PositionSide::SHORT);
+    CHECK_NEAR(half.entry_price(), 90.0, 1e-12);
+    CHECK_NEAR(half.position_qty(), 52.6315, 1e-9);
+
+    // Beyond-level long (85 <= 100): market-sized 100 at the close, fills the
+    // 90 open (9000 <= 10000) with that quantity.
     Probe long_probe;
     long_probe.is_long = true;
     long_probe.stop = 85.0;    // deliberately wrong-side stop, open-marketable
@@ -241,9 +305,10 @@ void test_accepted_gap_dispatches_placement_quantity() {
 void test_one_step_favorable_gap_keeps_signal_close_lot() {
     std::printf("-- one-step favorable gap keeps signal-close lot --\n");
 
+    // Beyond-level short stop (4000 > 3988.94): market-sized at the close.
     // Placement equity 13118.817086 and signal close 3988.94 floor to 3.2887
-    // contracts, while
-    // re-dividing at the next open 3988.93 produces 3.2888. TV exports 3.2887.
+    // contracts, while re-dividing at the next open 3988.93 produces 3.2888.
+    // TV exports 3.2887.
     Probe probe(QtyType::PERCENT_OF_EQUITY, 100.0, 100.0,
                 13118.817086);
     probe.is_long = false;
@@ -308,16 +373,24 @@ void test_zero_open_falls_back_without_frozen_qty() {
 void test_replacement_reissues_the_snapshot() {
     std::printf("-- same-id reissue replaces, rather than reuses, snapshot --\n");
 
-    Probe probe;
+    // pct 50 (an all-in sell stop below the close would never place). Bar 0:
+    // sell stop 50 -> floor(5000 / 50) = 100, 100 x 100 <= 10000 placed. Bar
+    // 1 (no touch) re-issues at 40 -> 125 = floor(5000 / 40), 125 x 80 =
+    // 10000 <= 10000 placed, replacing the 100. Bar 2 gaps through 40: the
+    // re-issued 125 fills at the open 40 (125 x 40 = 5000).
+    Probe probe(QtyType::PERCENT_OF_EQUITY, 50.0, 100.0);
     probe.is_long = false;
     probe.stop = 50.0;
     probe.reissue_bar = 1;
+    probe.reissue_stop = 40.0;
     run(probe, {
         bar(1000, 100, 100, 100, 100),
         bar(2000, 80, 81, 79, 80),
         bar(3000, 40, 41, 39, 40),
     });
+    CHECK(probe.placed_at_0);
     CHECK_NEAR(probe.placement_snapshot_qty, 100.0, 1e-12);
+    CHECK(probe.placed_at_reissue);
     CHECK_NEAR(probe.reissue_snapshot_qty, 125.0, 1e-12);
     CHECK(probe.side() == PositionSide::SHORT);
     CHECK_NEAR(probe.entry_price(), 40.0, 1e-12);
@@ -326,10 +399,39 @@ void test_replacement_reissues_the_snapshot() {
     CHECK(probe.pending() == nullptr);
 }
 
-void test_intervening_equity_change_while_flat_falls_back() {
-    std::printf("-- intervening realized-equity change invalidates snapshot --\n");
+void test_rejected_reissue_cancels_resting_snapshot() {
+    std::printf("-- a rejected same-id reissue cancels the resting default stop --\n");
 
-    Probe probe;
+    // pct 50: bar 0 sell stop 50 places 100 (100 x 100 <= 10000). Bar 1
+    // closes 210 and re-issues the same level: 100 x 210 = 21000 > 10000 ->
+    // rejected, and the resting 100 is cancelled (family E rule 2,
+    // xau-flatten-replace-c10983). Bar 2 gaps through 50 and fills nothing.
+    Probe probe(QtyType::PERCENT_OF_EQUITY, 50.0, 100.0);
+    probe.is_long = false;
+    probe.stop = 50.0;
+    probe.reissue_bar = 1;
+    run(probe, {
+        bar(1000, 100, 100, 100, 100),
+        bar(2000, 200, 211, 199, 210),
+        bar(3000, 40, 41, 39, 40),
+    });
+    CHECK(probe.placed_at_0);
+    CHECK(!probe.placed_at_reissue);
+    CHECK(probe.pending() == nullptr);
+    CHECK(probe.side() == PositionSide::FLAT);
+    CHECK(probe.trade_count() == 0);
+}
+
+void test_intervening_equity_change_while_flat_keeps_snapshot() {
+    std::printf("-- intervening realized-equity change does not re-size the resting stop --\n");
+
+    // Re-pinned: the quantity is fixed at the call (K pin: qty = floor(equity
+    // x pct / tick(level)) at the call; rule 2: only the script's next call
+    // re-issues it). pct 50 sell stop 95 -> 52.6315 placed; realized equity
+    // then moves to 11000 with nothing re-issued; the 90 gap-open fills the
+    // placement lot 52.6315 (a fill-time re-size would open 61.1111), and the
+    // fill is admitted against the equity at the fill (4736.8 <= 11000).
+    Probe probe(QtyType::PERCENT_OF_EQUITY, 50.0, 100.0);
     probe.is_long = false;
     probe.stop = 95.0;
     probe.post_placement_mutation =
@@ -338,18 +440,24 @@ void test_intervening_equity_change_while_flat_falls_back() {
         bar(1000, 100, 100, 100, 100),
         bar(2000, 90, 91, 89, 90),
     });
-    CHECK_NEAR(probe.placement_snapshot_qty, 100.0, 1e-12);
+    CHECK_NEAR(probe.placement_snapshot_qty, 52.6315, 1e-9);
     CHECK(probe.side() == PositionSide::SHORT);
     CHECK_NEAR(probe.entry_price(), 90.0, 1e-12);
-    // Current realized equity is 11000, so ordinary fill-time sizing is
-    // floor((11000 / 90) / 0.0001) * 0.0001 = 122.2222, not stale 100.
-    CHECK_NEAR(probe.position_qty(), 122.2222, 1e-9);
-    CHECK_NEAR(probe.ledger_qty(), 122.2222, 1e-9);
+    CHECK_NEAR(probe.position_qty(), 52.6315, 1e-9);
+    CHECK_NEAR(probe.ledger_qty(), 52.6315, 1e-9);
 }
 
-void test_placement_to_fill_config_changes_fall_back() {
-    std::printf("-- placement-to-fill config changes use ordinary fallback --\n");
+void test_placement_to_fill_config_changes() {
+    std::printf("-- placement-to-fill config changes: the snapshot holds while the partition holds --\n");
 
+    // Buy stop 105 above the close 100: 95.238 = floor(10000 / 105) placed
+    // (9523.8 <= 10000). Bar 1 opens 104 and touches 105: the placement lot
+    // fills at the level (95.238 x 105 = 9999.99 <= 10000) whatever moved
+    // in the commission / slippage / margin settings since the call — the
+    // order's quantity is the order's. Slippage moves the booked price one
+    // tick. A declaration change to FIXED sizing leaves the default-percent
+    // partition, so the snapshot is not consumed and the fill-time FIXED
+    // quantity (7) opens.
     struct Expected {
         PostPlacementMutation mutation;
         PositionSide side;
@@ -358,31 +466,29 @@ void test_placement_to_fill_config_changes_fall_back() {
     };
     const Expected expected[] = {
         {PostPlacementMutation::COMMISSION,
-         PositionSide::SHORT, 111.0001, 90.0},
-        // Slippage moves the short fill to 89.99 and ordinary fill-time sizing
-        // becomes 111.1234; consuming the placement lot would instead open 100.
+         PositionSide::LONG, 95.238, 105.0},
         {PostPlacementMutation::SLIPPAGE,
-         PositionSide::SHORT, 111.1234, 89.99},
+         PositionSide::LONG, 95.238, 105.01},
         {PostPlacementMutation::MARGIN,
-         PositionSide::SHORT, 111.1111, 90.0},
+         PositionSide::LONG, 95.238, 105.0},
         {PostPlacementMutation::DEFAULT_SIZING,
-         PositionSide::SHORT, 7.0, 90.0},
+         PositionSide::LONG, 7.0, 105.0},
     };
     for (const Expected& value : expected) {
         Probe probe;
-        probe.is_long = false;
-        probe.stop = 95.0;
+        probe.is_long = true;
+        probe.stop = 105.0;
         probe.post_placement_mutation = value.mutation;
         run(probe, {
             bar(1000, 100, 100, 100, 100),
-            bar(2000, 90, 91, 89, 90),
+            bar(2000, 104, 106, 103, 105),
         });
-        CHECK_NEAR(probe.placement_snapshot_qty, 100.0, 1e-12);
+        CHECK_NEAR(probe.placement_snapshot_qty, 95.238, 1e-9);
         CHECK(probe.side() == value.side);
         CHECK_NEAR(probe.position_qty(), value.qty, 1e-9);
         CHECK_NEAR(probe.ledger_qty(), value.qty, 1e-9);
         if (value.side != PositionSide::FLAT) {
-            CHECK_NEAR(probe.entry_price(), value.price, 1e-12);
+            CHECK_NEAR(probe.entry_price(), value.price, 1e-9);
         }
         CHECK(probe.pending() == nullptr);
     }
@@ -391,10 +497,8 @@ void test_placement_to_fill_config_changes_fall_back() {
 void test_scope_controls_remain_ordinary() {
     std::printf("-- intrabar, delayed, fractional, explicit and shape controls --\n");
 
-    // Intrabar touch is not an open-marketable gap. Existing admission uses
-    // fill-time qty at stop=120, costed at open=110, so it admits (the
-    // default percent-100 stop keeps the open basis; round 7 re-based only
-    // the explicit-qty / FIXED / CASH / >100% partition to the fill price).
+    // Intrabar touch: the buy stop 120 was sized at the level (83.3333) and
+    // fills there (83.3333 x 120 = 9999.996 <= 10000).
     Probe intrabar;
     intrabar.is_long = true;
     intrabar.stop = 120.0;
@@ -406,9 +510,11 @@ void test_scope_controls_remain_ordinary() {
     CHECK_NEAR(intrabar.entry_price(), 120.0, 1e-12);
     CHECK_NEAR(intrabar.position_qty(), 83.3333, 1e-9);
 
-    // A STOP first becoming marketable two bars after placement is outside the
-    // exact next-bar replay cell and remains fill-time-sized.
-    Probe delayed;
+    // A STOP first becoming marketable two bars after placement still carries
+    // its placement quantity: pct 50 sell stop 80 -> 62.5 (an all-in sell
+    // stop below the close would not place), the bar-2 gap-open 70 fills
+    // 62.5 (a fill-time re-size at 70 would open 71.4285).
+    Probe delayed(QtyType::PERCENT_OF_EQUITY, 50.0, 100.0);
     delayed.is_long = false;
     delayed.stop = 80.0;
     run(delayed, {
@@ -417,8 +523,13 @@ void test_scope_controls_remain_ordinary() {
         bar(3000, 70, 71, 69, 70),
     });
     CHECK(delayed.side() == PositionSide::SHORT);
-    CHECK_NEAR(delayed.position_qty(), 142.8571, 1e-9);
+    CHECK_NEAR(delayed.entry_price(), 70.0, 1e-12);
+    CHECK_NEAR(delayed.position_qty(), 62.5, 1e-9);
 
+    // Beyond-level short at pct 50: market-sized at the close, 50 =
+    // floor(5000 / 100), fills the 110 open with 50 (5500 <= 10000) — not the
+    // 45.4545 a fill-time re-size at the open would open (the ahtisham 04-04
+    // 13:45Z 1,043 = floor(eq / tick(close)) shape).
     Probe fractional(QtyType::PERCENT_OF_EQUITY, 50.0, 100.0);
     fractional.is_long = false;
     fractional.stop = 120.0;
@@ -427,8 +538,9 @@ void test_scope_controls_remain_ordinary() {
         bar(2000, 110, 111, 109, 110),
     });
     CHECK(fractional.side() == PositionSide::SHORT);
-    CHECK_NEAR(fractional.position_qty(), 45.4545, 1e-9);
+    CHECK_NEAR(fractional.position_qty(), 50.0, 1e-9);
 
+    // Explicit qty: family E, no snapshot; 7 x 100 placed, 7 x 110 admitted.
     Probe explicit_stop;
     explicit_stop.is_long = false;
     explicit_stop.stop = 120.0;
@@ -437,6 +549,7 @@ void test_scope_controls_remain_ordinary() {
         bar(1000, 100, 100, 100, 100),
         bar(2000, 110, 111, 109, 110),
     });
+    CHECK(std::isnan(explicit_stop.placement_snapshot_qty));
     CHECK(explicit_stop.side() == PositionSide::SHORT);
     CHECK_NEAR(explicit_stop.position_qty(), 7.0, 1e-12);
 
@@ -446,7 +559,7 @@ void test_scope_controls_remain_ordinary() {
     CHECK(limit_only.pending() != nullptr);
     if (limit_only.pending() != nullptr) {
         CHECK(std::isnan(
-            limit_only.pending()->stop_placement_open_qty));
+            limit_only.pending()->default_stop_placement_qty));
     }
 
     Probe stop_limit;
@@ -455,14 +568,14 @@ void test_scope_controls_remain_ordinary() {
     CHECK(stop_limit.pending() != nullptr);
     if (stop_limit.pending() != nullptr) {
         CHECK(std::isnan(
-            stop_limit.pending()->stop_placement_open_qty));
+            stop_limit.pending()->default_stop_placement_qty));
     }
 }
 
 }  // namespace
 
 int main() {
-    std::printf("--- production STOP placement open qty ---\n");
+    std::printf("--- production STOP placement qty (round 7 family K) ---\n");
     test_default_placement_snapshot();
     test_positive_gap_declines_both_directions();
     test_accepted_gap_dispatches_placement_quantity();
@@ -470,8 +583,9 @@ int main() {
     test_prequantized_dispatch_preserves_exact_binary_lot();
     test_zero_open_falls_back_without_frozen_qty();
     test_replacement_reissues_the_snapshot();
-    test_intervening_equity_change_while_flat_falls_back();
-    test_placement_to_fill_config_changes_fall_back();
+    test_rejected_reissue_cancels_resting_snapshot();
+    test_intervening_equity_change_while_flat_keeps_snapshot();
+    test_placement_to_fill_config_changes();
     test_scope_controls_remain_ordinary();
 
     std::printf("\n=== Results: %d passed, %d failed ===\n",


### PR DESCRIPTION
Round-7f engine candidate `8e21d36` (on the round-7e head 8d9ec8d; codegen unchanged at 65e7fd0), gated PASS against baseline `pineforge-parity-baseline-20260905-engine-8d9ec8d4` (fast pr-gate, hard 0 regressions): 4162 → 4163 excellent+strong (99.4%), +2 tiers, 0 down.

Pinned on TradingView (NYSE:F 15m `lab tv` tapes, 121/126 entries with qty + price and every non-fill): a default `percent_of_equity` stop entry is sized at the tick-snapped stop level (`qty = floor(equity × pct / tick(level))`), then placement-checked as `qty × tick(close) × margin% ≤ equity` (a 100%-equity sell stop below the close is never placed); an accepted order fills at the level on a touch or at the tick-rounded open on a gap-through, subject to `qty × fill ≤ equity`. The engine's previous open-based cost (KI-62) filled first-bar short gap-throughs TradingView never fills and declined long ones it fills.

Tests: ctest 175/175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pyos7rr4EChCzh3H6S3Vob