### PR TITLE
fix: apply rounded signal costs to high-value fractional lots

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Prefer zero install? The hosted server at **[mcp.pineforge.dev/mcp](https://mcp.
 git clone https://github.com/pineforge-4pass/pineforge-engine.git && cd pineforge-engine
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
-ctest --test-dir build --output-on-failure     # 215 tests
+ctest --test-dir build --output-on-failure     # 216 tests
 bash tutorial/run.sh                            # MACD on BTC/USDT, end to end
 python3 tutorial/run_stream.py                  # OHLCV warm-up → realtime trades
 ```
@@ -190,7 +190,7 @@ PyneCore's 15 non-excellent strategies involve `strategy.exit(stop=…, limit=�
 - `libpineforge.a` — the static runtime: order matching and fills, sizing and margin, the bar magnifier, 66 indicator classes, `request.security()`, time and session math.
 - `<pineforge/pineforge.h>` — the public C ABI, the stability-pinned consumer surface.
 - `<pineforge/*.hpp>` — internal C++ headers the transpiler emits against (not part of the stability guarantee).
-- 215 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
+- 216 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
 - `corpus/` — the 312-strategy public validation corpus (submodule).
 - `benchmarks/` — the three-way comparison harness and the throughput package.
 - `scripts/` — `run_corpus.sh`, `verify_corpus.py`, `run_strategy.py` (load any `.so` via ctypes), `regen_corpus_cpp.sh`, `coverage.sh`.
@@ -244,7 +244,7 @@ src/                    26 .cpp files split by concern
   ├── ta_*.cpp                        66 indicator classes (moving averages, oscillators,
   │                                   volatility/trend, extremes/volume, misc)
   └── magnifier / matrix / session_time / timeframe / timezone / math / str_utils
-tests/                  215 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
+tests/                  216 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
 corpus/                 public submodule: 312 strategies + the 1-minute feed and derived 15m bars
 benchmarks/             three-way comparison harness, throughput package, results/
 scripts/                run_corpus.sh, verify_corpus.py, run_strategy.py, regen_corpus_cpp.sh, coverage.sh

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 TradingView's strategy tester is the reference every Pine author trusts, and nothing outside TradingView reproduced it — until now. PineForge is a C++17 runtime with a stable C ABI that runs PineScript v6 strategies exactly the way TradingView's broker emulator does: same fills, same sizing, same margin calls, same trailing stops, same `request.security()` buckets, on any OHLCV you give it, in microseconds per bar.
 
-- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,166 excellent, 24 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,816,973 matched by the verifier.
+- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,167 excellent, 23 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,127 matched by the verifier.
 - **Open.** Engine, transpiler, corpus, benchmarks and the validation tooling are all public and Apache-2.0. The only thing you cannot download is the closed test set, because TradingView's Terms of Service forbid redistributing community scripts.
 - **Fast.** In-process, no interpreter: median **162× faster than PyneCore** on 99 timed strategies. Parameter sweeps re-run a loaded `.so` with new inputs — no recompile, no fork.
 - **Deterministic to the bit.** Two runs with the same inputs produce identical trade lists. Same on Linux and macOS.
@@ -108,23 +108,23 @@ Every PineForge-compiled strategy `.so` exports this same ABI — write the harn
 
 ## Validation scoreboard
 
-**Round 23 · 2026-09-07:** **4,166 excellent / 24 strong / zero moderate** across all **4,190 scored probes**. This round adds two excellent results, with zero regressions on any canonical metric.
+**Round 24 · 2026-09-07:** **4,167 excellent / 23 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
 
 | Board | Test set | Result | TradingView trades evaluated |
 |---|---|---|---|
 | **Public** — [open corpus](https://github.com/pineforge-4pass/pineforge-corpus) | 312 reference strategies, Apache-2.0, reproducible by anyone | **309/309 graded excellent** (ETH/USDT-perp 15m; the corpus' declared engine-only / anomaly probes are not graded) | 429,866 |
-| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,857 excellent + 24 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
+| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,858 excellent + 23 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
 
-**2,819,967 TradingView trades** evaluated, **2,816,973 matched by the verifier** (99.89%), from the round 23 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
+**2,819,967 TradingView trades** evaluated, **2,817,127 matched by the verifier** (99.90%), from the round 24 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
 
-Round 23 improves the BTC/USDT 15m **Trendline and Horizontal Breakout** and **LL: Momentum and Curl Master** strategies from strong to excellent. Their combined **10,742 trade rows** match TradingView exactly on side, time, price, and quantity. The engine fix uses shared broker state and order ownership; it contains no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
+Round 24 improves the BTC/USDT 15m **Ajay Fibonacci Market Structure Pro AI V2.1** strategy from strong to excellent. All **4,850 trade rows** match TradingView exactly on side, time, price, and quantity. The engine fix uses shared broker state and order ownership; it contains no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
 
 ### The closed test, lane by lane
 
 | Market · timeframe | Probes | Excellent | Strong | Moderate |
 |---|---:|---:|---:|---:|
 | BINANCE:ETHUSDT.P · 15m *(hard lane: zero regression allowed)* | 395 | 394 | 1 | — |
-| BINANCE:BTCUSDT · 15m | 354 | 350 | 4 | — |
+| BINANCE:BTCUSDT · 15m | 354 | 351 | 3 | — |
 | BINANCE:BTCUSDT · 1D | 259 | 259 | — | — |
 | CME_MINI:ES1! · 15m | 174 | 173 | 1 | — |
 | CME_MINI:ES1! · 1D | 117 | 117 | — | — |
@@ -138,7 +138,7 @@ Round 23 improves the BTC/USDT 15m **Trendline and Horizontal Breakout** and **L
 | OANDA:EURUSD · 15m | 373 | 365 | 8 | — |
 | OANDA:XAUUSD · 15m | 376 | 374 | 2 | — |
 | OANDA:XAUUSD · 1D | 248 | 248 | — | — |
-| **Total** | **3,881** | **3,857** | **24** | **0** |
+| **Total** | **3,881** | **3,858** | **23** | **0** |
 
 ### How a probe is graded
 

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -72,9 +72,10 @@ enum class PositionSide { FLAT, LONG, SHORT };
 // floors the ten-digit equity's raw double quotient 4583.999999999999 to
 // 4583, the float-accumulated ledger's 4584.000000000001 or a 1e-6-nudged
 // floor gives 4584, one share the account cannot pay at the 238.78 fill), so
-// rule 1 sizes every lot-stepped instrument (tv_money_lot_sizing); rules
-// 2 and 5 stay scoped by tv_money_scope — outside it the exact fill-price
-// admission already decides (1094521.681 -> Q 4584 dropped on AAPL). Rule 3
+// rule 1 sizes every lot-stepped instrument (tv_money_lot_sizing). Rule 2
+// additionally covers ordinary, fee-free high-value fractional lots (R24);
+// rule 5 stays scoped by tv_money_scope. Other admission keeps its existing
+// checks (1094521.681 -> Q 4584 dropped on AAPL). Rule 3
 // additionally covers ordinary MARKET-opened, fee/slippage-free single-position
 // fractional unit-pointvalue/same-currency books with lot value >=1 (R21 pins).
 //   5. WHOLE-ORDER DROP (round 9 family R follow-up, campaign notes
@@ -2009,6 +2010,47 @@ protected:
         const double lot_value = qty_step_ * price * syminfo_.pointvalue
                                  * active_account_currency_fx();
         return std::isfinite(lot_value) && lot_value < 1.0;
+    }
+    // R24 signal-cost controls: a fractional lot worth >=1 account unit can
+    // still cross the rounded-money admission boundary. BTC Q9.36259 at
+    // 112380.33 costs 1052170.9538547, rounded to 1052170.954; exact signal
+    // equity 1052170.9536054998 therefore keeps only a reversal's close leg.
+    // XAU Q300 at 3443.625 likewise rejects capital cost-0.0001, while exact
+    // cost and cost+0.0001 admit, despite the cheaper next opening price.
+    // This extends rule 2 alone; rule 5 and margin valuation keep their scope.
+    bool rounded_signal_cost_scope(const PendingOrder& order) const {
+        if (tv_money_scope(order.sizing_price)) return true;
+        if (!(qty_step_ > 0.0 && qty_step_ < 1.0)
+            || !std::isfinite(order.sizing_price) || order.sizing_price <= 0.0
+            || !std::isfinite(order.sizing_equity)
+            || !std::isfinite(order.frozen_default_qty)
+            || order.sizing_fx != 1.0 || active_account_currency_fx() != 1.0
+            || !account_currency_fx_timestamps_.empty()
+            || syminfo_.pointvalue != 1.0
+            || commission_value_ != 0.0 || slippage_ != 0
+            || process_orders_on_close_ || calc_on_order_fills_
+            || bar_magnifier_enabled_ || coof_scheduler_active_
+            || stream_warmup_mode_ || stream_phase_ != StreamPhase::IDLE
+            || pyramiding_ < 0 || pyramiding_ > 1
+            || position_entry_count_ > 1 || pyramid_entries_.size() > 1
+            || max_intraday_filled_orders_ > 0
+            || risk_max_intraday_loss_ != 0.0 || risk_max_drawdown_ != 0.0
+            || risk_max_cons_loss_days_ > 0 || order.incarnation == 0) {
+            return false;
+        }
+        for (const auto& other : pending_orders_) {
+            if (other.incarnation == order.incarnation) continue;
+            // Coqueued unpriced strategy.close legs are part of the pins.
+            // Competing entries and priced/trailing brackets retain their
+            // existing admission and transaction-ordering paths.
+            if (other.type != OrderType::EXIT
+                || !std::isnan(other.limit_price) || !std::isnan(other.stop_price)
+                || !std::isnan(other.trail_points) || !std::isnan(other.trail_price)
+                || !std::isnan(other.profit_ticks) || !std::isnan(other.loss_ticks)) {
+                return false;
+            }
+        }
+        return true;
     }
     // Rule 1's scope (round 10 family AE): the ten-digit equity and the raw
     // lot floor size EVERY lot-stepped instrument — integer shares included

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -4974,7 +4974,7 @@ void BacktestEngine::apply_filled_order_to_state(
         && std::isfinite(order.sizing_price) && order.sizing_price > 0.0
         && default_qty_type_ == QtyType::PERCENT_OF_EQUITY
         && std::abs(default_qty_value_ - 100.0) < 1e-12
-        && tv_money_scope(order.sizing_price)) {
+        && rounded_signal_cost_scope(order)) {
         const double margin_dir = order.is_long ? margin_long_ : margin_short_;
         const PositionSide requested_side =
             order.is_long ? PositionSide::LONG : PositionSide::SHORT;
@@ -5024,8 +5024,10 @@ void BacktestEngine::apply_filled_order_to_state(
                 }
                 order.affordability_close_only = true;
                 order.rounded_signal_cost_close_only = true;
-            } else if (!close_first_flat_open) {
+            } else if (!close_first_flat_open && tv_money_scope(order.sizing_price)) {
                 // Rule 5: the price-scale margin check (comment above).
+                // The R24 high-value fractional-lot extension pins rule 2
+                // only; it does not widen this independent price-scale rule.
                 const double notional_per_price =
                     order.frozen_default_qty * syminfo_.pointvalue * fx_s;
                 const double affordable_price = tv_money_round(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    test_high_value_signal_cost
     test_short_margin_script_state
     test_ringbuffer
     test_timeframe

--- a/tests/test_high_value_signal_cost.cpp
+++ b/tests/test_high_value_signal_cost.cpp
@@ -1,0 +1,176 @@
+// R24 covered BTC/XAU controls isolate signal-cost admission when a fractional
+// minimum lot is worth more than one account unit. Synthetic timestamps keep
+// these compact command fixtures independent of a historical backtest.
+#include <pineforge/engine.hpp>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+constexpr double qnan = std::numeric_limits<double>::quiet_NaN();
+int passed = 0, failed = 0;
+#define CHECK(x) do { if (x) ++passed; else { ++failed; std::printf("FAIL %d %s\n", __LINE__, #x); } } while (0)
+bool near(double a, double b) { return std::abs(a - b) < 1e-8; }
+
+class Reversal : public BacktestEngine {
+public:
+    bool separate_close, explicit_quantity;
+    bool resting_bracket = false;
+    double observed = qnan, frozen = qnan;
+    Reversal(double extra, bool separate = true, bool literal = false)
+        : separate_close(separate), explicit_quantity(literal) {
+        initial_capital_ = 1060181.9245162997 + extra;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100.0;
+        qty_step_ = 0.00001;
+        syminfo_mintick_ = 0.01;
+        syminfo_.pointvalue = 1.0;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        pyramiding_ = 0;
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry("Short", false, qnan, qnan, 9.10793);
+            if (resting_bracket) strategy_exit("Resting", "Short", 100.0, 200000.0);
+        }
+        if (bar_index_ == 1) {
+            strategy_entry("Long", true, qnan, qnan, explicit_quantity ? 9.36259 : qnan);
+            for (const auto& order : pending_orders_) {
+                if (order.id == "Long") frozen = order.frozen_default_qty;
+            }
+            if (separate_close) strategy_close("Short", "Separate close");
+        }
+        if (bar_index_ == 2) { observed = signed_position_size(); strategy_close_all(); }
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+};
+
+void test_reversal_signal_cost_boundary() {
+    const std::vector<Bar> bars = {
+        {111500.77, 111500.77, 111500.77, 111500.77, 1, 1000},
+        {111500.77, 112400.0, 111500.77, 112380.33, 1, 2000},
+        {112380.32, 112485.28, 112300.0, 112448.7, 1, 3000},
+        {112297.92, 112575.27, 112259.05, 112312.64, 1, 4000},
+    };
+    for (double extra : {-0.001, -0.0004, -0.0001, 0.0, 0.0001, 0.0003, 0.0004, 0.0005, 0.001}) {
+        Reversal engine(extra);
+        engine.run(bars.data(), static_cast<int>(bars.size()));
+        const bool admitted = extra <= -0.0004 || extra >= 0.0004;
+        const double quantity = extra <= -0.0004 ? 9.36258 : 9.36259;
+        CHECK(near(engine.frozen, quantity));
+        CHECK(near(engine.observed, admitted ? quantity : 0.0));
+        CHECK(engine.rows().size() == (admitted ? 2u : 1u));
+        if (engine.rows().empty()) continue;
+        CHECK(engine.rows()[0].exit_time == 3000);
+        CHECK(near(engine.rows()[0].qty, 9.10793));
+        CHECK(near(engine.rows()[0].exit_price, 112380.32));
+        if (admitted && engine.rows().size() == 2) {
+            CHECK(engine.rows()[1].entry_time == 3000);
+            CHECK(near(engine.rows()[1].qty, quantity));
+        }
+    }
+    // Without a separate close, a rounded-cost decline must still close the
+    // old side. This distinguishes it from the whole-order price-scale drop.
+    Reversal bare(0.0, false);
+    bare.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(near(bare.observed, 0.0));
+    CHECK(bare.rows().size() == 1);
+    CHECK(!bare.rows().empty() && bare.rows()[0].exit_time == 3000);
+    // Literal quantities already use the max(signal, fill) affordability path.
+    Reversal literal(0.0, true, true);
+    literal.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(near(literal.observed, 0.0));
+    CHECK(literal.rows().size() == 1);
+    // A prearmed priced bracket is outside the newly pinned simple market
+    // transaction. Its existing admission remains unchanged.
+    Reversal bracket(0.0);
+    bracket.resting_bracket = true;
+    bracket.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(near(bracket.observed, 9.36259));
+    CHECK(bracket.rows().size() == 2);
+}
+
+enum class Context { ORDINARY, FEE, FX, MULTIPLIER, INTEGER_LOTS, CLOSE_FILL, RESTING_ENTRY };
+class Flat : public BacktestEngine {
+public:
+    double observed = qnan;
+    Context context;
+    Flat(double capital, double step, double tick, Context mode = Context::ORDINARY)
+        : context(mode) {
+        initial_capital_ = capital;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100.0;
+        qty_step_ = step;
+        syminfo_mintick_ = tick;
+        syminfo_.pointvalue = 1.0;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        pyramiding_ = 0;
+        if (mode == Context::FEE) commission_value_ = 0.1;
+        if (mode == Context::FX) account_currency_fx_ = 2.0;
+        if (mode == Context::MULTIPLIER) syminfo_.pointvalue = 2.0;
+        if (mode == Context::INTEGER_LOTS) qty_step_ = 1.0;
+        if (mode == Context::CLOSE_FILL) process_orders_on_close_ = true;
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry("Long", true);
+            if (context == Context::RESTING_ENTRY) strategy_entry("Parked", true, 300.0, qnan, 0.01);
+        }
+        if (bar_index_ == 1) { observed = signed_position_size(); strategy_close_all(); }
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+};
+
+void test_flat_signal_cost_across_price_scales() {
+    const std::vector<Bar> btc = {
+        {112380.33, 112380.33, 112380.33, 112380.33, 1, 1000},
+        {112380.32, 112485.28, 112300.0, 112448.7, 1, 2000},
+        {112297.92, 112575.27, 112259.05, 112312.64, 1, 3000},
+    };
+    for (double extra : {0.0, 0.0004}) {
+        Flat engine(1052170.9536054998 + extra, 0.00001, 0.01);
+        engine.run(btc.data(), static_cast<int>(btc.size()));
+        CHECK(near(engine.observed, extra == 0.0 ? 0.0 : 9.36259));
+        CHECK(engine.rows().size() == (extra == 0.0 ? 0u : 1u));
+    }
+    const std::vector<Bar> xau = {
+        {3445.31, 3446.015, 3443.295, 3443.625, 1, 1000},
+        {3443.565, 3446.015, 3443.295, 3444.0, 1, 2000},
+        {3439.505, 3441.0, 3438.0, 3440.0, 1, 3000},
+    };
+    for (double extra : {-0.001, -0.0001, 0.0, 0.0001}) {
+        Flat engine(1033087.5 + extra, 0.01, 0.001);
+        engine.run(xau.data(), static_cast<int>(xau.size()));
+        const bool admitted = extra != -0.0001;
+        CHECK(near(engine.observed, !admitted ? 0.0 : extra == -0.001 ? 299.99 : 300.0));
+        CHECK(engine.rows().size() == (admitted ? 1u : 0u));
+        if (admitted && engine.rows().size() == 1) {
+            CHECK(near(engine.rows()[0].entry_price, 3443.565));
+            CHECK(near(engine.rows()[0].exit_price, 3439.505));
+        }
+    }
+    // These financial contexts retain their existing fill/trim behavior; the
+    // new fee-free, same-currency, ordinary single-market scope must not turn
+    // their admitted position into a signal-cost rejection.
+    for (Context mode : {Context::FEE, Context::FX, Context::MULTIPLIER,
+                         Context::INTEGER_LOTS, Context::CLOSE_FILL, Context::RESTING_ENTRY}) {
+        double capital = 1033087.4999;
+        if (mode == Context::FX || mode == Context::MULTIPLIER) capital = 2066174.9999;
+        if (mode == Context::CLOSE_FILL) capital = 1033156.3729;
+        Flat engine(capital, 0.01, 0.001, mode);
+        engine.run(xau.data(), static_cast<int>(xau.size()));
+        CHECK(engine.observed > 0.0);
+        CHECK(!engine.rows().empty());
+    }
+}
+}
+int main() {
+    test_reversal_signal_cost_boundary();
+    test_flat_signal_cost_across_price_scales();
+    std::printf("%d passed, %d failed\n", passed, failed);
+    return failed ? 1 : 0;
+}


### PR DESCRIPTION
Default 100%-equity market orders on high-value fractional lot grids could bypass rounded signal-cost admission. A cheaper next opening price then admitted an order TradingView rejects at the signal, opening an unwanted position instead of keeping only a reversal's closing leg.

Extend the existing rounded signal-cost rule to the supported ordinary, fee-free, same-currency market shape. The implementation uses broker state and order ownership, with no strategy, symbol, date, or benchmark-ID conditions. The independent price-scale rule, required-margin rounding, lot sizing, explicit/cash/fixed admission, grading metrics, verifier, harness, population, and tapes remain unchanged.

Refresh the README with the measured round 24 scoreboard, per-lane counts, verifier totals, and 216-test inventory.

Validation on frozen `bfdbe9618c122fada4c22fd17746625254a06a6a`:

- All 4,190 probes measured on Cloud Run: **4,167 excellent / 23 strong / zero moderate**. Ajay BTC moves strong to excellent; the other 4,189 canonical results are unchanged. Zero errors, coverage gaps, or regressions, including all 704 hard probes.
- All **4,850 Ajay trade rows** match TradingView on side, time, price, and quantity. Seventeen covered TradingView controls across BTC and XAUUSD pin capital boundaries, bare/coqueued reversals, flat entries, and the existing explicit-quantity path.
- **216/216 tests pass** after a full rebuild, including baseline-red/new-green regression fixtures and financial compatibility controls. C ABI and library freshness checks pass.
- Independent Grok 4.6 high review of the exact final candidate: **P0/P1/P2 = 0**. Final sweep results also verify every README lane and trade-count aggregate.

Codegen stays pinned to `3fd97fe28abd7b191cb376d9f5db4e056fcfae4b`. No product release or compute-plane deployment is included.

Formal Cloud Run gate `pineforge-pr-gate-lh4t8`: **PASS**, target score **+1**, 704 hard probes with zero regressions or tolerated exceptions. Gated snapshot: `14e129519500e5d5e0fe7d961a9e1766f516224126e721040a78c2ceb7a2831c`.
