### PR TITLE
Fix stop-open margin state before script evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 TradingView's strategy tester is the reference every Pine author trusts, and nothing outside TradingView reproduced it — until now. PineForge is a C++17 runtime with a stable C ABI that runs PineScript v6 strategies exactly the way TradingView's broker emulator does: same fills, same sizing, same margin calls, same trailing stops, same `request.security()` buckets, on any OHLCV you give it, in microseconds per bar.
 
-- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,167 excellent, 23 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,127 matched by the verifier.
+- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,168 excellent, 22 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,133 matched by the verifier.
 - **Open.** Engine, transpiler, corpus, benchmarks and the validation tooling are all public and Apache-2.0. The only thing you cannot download is the closed test set, because TradingView's Terms of Service forbid redistributing community scripts.
 - **Fast.** In-process, no interpreter: median **162× faster than PyneCore** on 99 timed strategies. Parameter sweeps re-run a loaded `.so` with new inputs — no recompile, no fork.
 - **Deterministic to the bit.** Two runs with the same inputs produce identical trade lists. Same on Linux and macOS.
@@ -108,23 +108,23 @@ Every PineForge-compiled strategy `.so` exports this same ABI — write the harn
 
 ## Validation scoreboard
 
-**Round 24 · 2026-09-07:** **4,167 excellent / 23 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
+**Round 25 · 2026-09-07:** **4,168 excellent / 22 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
 
 | Board | Test set | Result | TradingView trades evaluated |
 |---|---|---|---|
 | **Public** — [open corpus](https://github.com/pineforge-4pass/pineforge-corpus) | 312 reference strategies, Apache-2.0, reproducible by anyone | **309/309 graded excellent** (ETH/USDT-perp 15m; the corpus' declared engine-only / anomaly probes are not graded) | 429,866 |
-| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,858 excellent + 23 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
+| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,859 excellent + 22 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
 
-**2,819,967 TradingView trades** evaluated, **2,817,127 matched by the verifier** (99.90%), from the round 24 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
+**2,819,967 TradingView trades** evaluated, **2,817,133 matched by the verifier** (99.90%), from the round 25 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
 
-Round 24 improves the BTC/USDT 15m **Ajay Fibonacci Market Structure Pro AI V2.1** strategy from strong to excellent. All **4,850 trade rows** match TradingView exactly on side, time, price, and quantity. The engine fix uses shared broker state and order ownership; it contains no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
+Round 25 improves the BTC/USDT 15m **Inside Day Breakout** strategy from strong to excellent. All **386 trade rows** match TradingView exactly on side, time, price, and quantity. The engine now exposes margin liquidation after a stop entry at the bar open before the script runs, allowing the script to place its replacement on time while preserving an unhit pending entry. The fix uses shared broker state and order ownership; it contains no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
 
 ### The closed test, lane by lane
 
 | Market · timeframe | Probes | Excellent | Strong | Moderate |
 |---|---:|---:|---:|---:|
 | BINANCE:ETHUSDT.P · 15m *(hard lane: zero regression allowed)* | 395 | 394 | 1 | — |
-| BINANCE:BTCUSDT · 15m | 354 | 351 | 3 | — |
+| BINANCE:BTCUSDT · 15m | 354 | 352 | 2 | — |
 | BINANCE:BTCUSDT · 1D | 259 | 259 | — | — |
 | CME_MINI:ES1! · 15m | 174 | 173 | 1 | — |
 | CME_MINI:ES1! · 1D | 117 | 117 | — | — |
@@ -138,7 +138,7 @@ Round 24 improves the BTC/USDT 15m **Ajay Fibonacci Market Structure Pro AI V2.1
 | OANDA:EURUSD · 15m | 373 | 365 | 8 | — |
 | OANDA:XAUUSD · 15m | 376 | 374 | 2 | — |
 | OANDA:XAUUSD · 1D | 248 | 248 | — | — |
-| **Total** | **3,881** | **3,858** | **23** | **0** |
+| **Total** | **3,881** | **3,859** | **22** | **0** |
 
 ### How a probe is graded
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Prefer zero install? The hosted server at **[mcp.pineforge.dev/mcp](https://mcp.
 git clone https://github.com/pineforge-4pass/pineforge-engine.git && cd pineforge-engine
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
-ctest --test-dir build --output-on-failure     # 216 tests
+ctest --test-dir build --output-on-failure     # 217 tests
 bash tutorial/run.sh                            # MACD on BTC/USDT, end to end
 python3 tutorial/run_stream.py                  # OHLCV warm-up → realtime trades
 ```
@@ -190,7 +190,7 @@ PyneCore's 15 non-excellent strategies involve `strategy.exit(stop=…, limit=�
 - `libpineforge.a` — the static runtime: order matching and fills, sizing and margin, the bar magnifier, 66 indicator classes, `request.security()`, time and session math.
 - `<pineforge/pineforge.h>` — the public C ABI, the stability-pinned consumer surface.
 - `<pineforge/*.hpp>` — internal C++ headers the transpiler emits against (not part of the stability guarantee).
-- 216 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
+- 217 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
 - `corpus/` — the 312-strategy public validation corpus (submodule).
 - `benchmarks/` — the three-way comparison harness and the throughput package.
 - `scripts/` — `run_corpus.sh`, `verify_corpus.py`, `run_strategy.py` (load any `.so` via ctypes), `regen_corpus_cpp.sh`, `coverage.sh`.
@@ -244,7 +244,7 @@ src/                    26 .cpp files split by concern
   ├── ta_*.cpp                        66 indicator classes (moving averages, oscillators,
   │                                   volatility/trend, extremes/volume, misc)
   └── magnifier / matrix / session_time / timeframe / timezone / math / str_utils
-tests/                  216 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
+tests/                  217 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
 corpus/                 public submodule: 312 strategies + the 1-minute feed and derived 15m bars
 benchmarks/             three-way comparison harness, throughput package, results/
 scripts/                run_corpus.sh, verify_corpus.py, run_strategy.py, regen_corpus_cpp.sh, coverage.sh

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -215,6 +215,10 @@ struct PyramidEntry {
     // Exact ordinary MARKET fill at the next bar open. Priced/RAW entries
     // cannot infer this provenance from an equal numeric entry price.
     bool ordinary_market_open = false;
+    // A flat-born pure STOP strategy.entry actually filled at the bar open.
+    // Keep this separate from MARKET provenance: equal fill prices do not
+    // make the two order classes interchangeable for affordability rules.
+    bool ordinary_stop_open = false;
 };
 
 struct Trade {

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -1011,6 +1011,9 @@ bool BacktestEngine::entry_bar_post_fill_adverse(const Bar& bar,
 // reproduce Ycelestine July 6: a full liquidation before the script permits
 // its flat-gated Long entry. A resting own bracket that did not fill does not
 // postpone that margin event; after a full close it belongs to the old cycle.
+// R25 covered controls extend this ordering to a flat-born pure STOP entry
+// actually filled at the open. One other pure STOP that never touched the
+// broker's bar cannot postpone liquidation and retains its pending lifetime.
 void BacktestEngine::process_short_margin_before_script(const Bar& bar) {
     if (!margin_call_enabled_ || position_side_ != PositionSide::SHORT
         || process_orders_on_close_ || calc_on_order_fills_
@@ -1023,7 +1026,8 @@ void BacktestEngine::process_short_margin_before_script(const Bar& bar) {
         || !(qty_step_ > 0.0 && qty_step_ < 1.0)
         || pyramiding_ < 0 || pyramiding_ > 1
         || position_entry_count_ != 1 || pyramid_entries_.size() != 1
-        || !pyramid_entries_.front().ordinary_market_open
+        || !(pyramid_entries_.front().ordinary_market_open
+             || pyramid_entries_.front().ordinary_stop_open)
         || pyramid_entries_.front().entry_bar_index != position_open_bar_
         || commission_value_ != 0.0 || slippage_ != 0
         || margin_short_ != 100.0 || syminfo_.pointvalue != 1.0
@@ -1036,10 +1040,40 @@ void BacktestEngine::process_short_margin_before_script(const Bar& bar) {
         return;
     }
     for (const auto& order : pending_orders_) {
-        // Pending entries/closes, foreign or global brackets, and dormant or
-        // trailing lifecycles retain their established scheduling. The order
-        // kernel has already evaluated this ordinary own priced bracket over
-        // the bar; if it filled, the resulting position is what we see here.
+        if (order.type == OrderType::ENTRY
+            && pyramid_entries_.front().ordinary_stop_open) {
+            // An unfilled order may have been triggered and deferred by a
+            // broker rule. Prove this pure STOP was unhit over the entire
+            // tick-quantized bar before treating it as independent.
+            const Bar trigger_bar = broker_trigger_bar(bar);
+            double pending_touch = 0.0;
+            if (order.created_bar >= bar_index_
+                || order.created_position_side != PositionSide::FLAT
+                || order.created_while_in_position
+                || order.created_after_position_close_in_bar
+                || order.created_during_coof_recalc
+                || !std::isfinite(order.stop_price)
+                || !std::isnan(order.limit_price)
+                || order.stop_limit_activated
+                || !std::isnan(order.trail_points)
+                || !std::isnan(order.trail_price)
+                || !std::isnan(order.trail_offset)
+                || !order.oca_name.empty() || order.oca_type != 0
+                || !std::isfinite(trigger_bar.open)
+                || !std::isfinite(trigger_bar.high)
+                || !std::isfinite(trigger_bar.low)
+                || !std::isfinite(trigger_bar.close)
+                || internal::entry_stop_first_touch(
+                    trigger_bar, internal::bar_path_uses_high_first(bar),
+                    order.stop_price, order.is_long, &pending_touch)) {
+                return;
+            }
+            continue;
+        }
+        // Other entries/closes, foreign/global brackets, and dormant or
+        // trailing lifecycles keep their scheduling. The order kernel has
+        // already evaluated this ordinary own priced bracket over the bar;
+        // if it filled, the resulting position is what we see here.
         if (order.type != OrderType::EXIT
             || order.from_entry != pyramid_entries_.front().entry_id
             || order.dormant_bracket || order.dormant_reissue_pending
@@ -1057,8 +1091,8 @@ void BacktestEngine::process_short_margin_before_script(const Bar& bar) {
         // must not revisit that high after the script.
         intrabar_exit_margin_call_bar_ = bar_index_;
         if (position_side_ == PositionSide::FLAT) {
-            // No pending parent entry passed the scope check above. Retire the
-            // old cycle's bracket now; the upcoming script can independently
+            // Retire only EXIT brackets from the old cycle. An unhit pending
+            // ENTRY survives, and the upcoming script can independently
             // attach an explicit bracket to a newly placed replacement.
             purge_exit_orders();
         }
@@ -5823,6 +5857,33 @@ void BacktestEngine::apply_filled_order_to_state(
             && pyramid_entries_.front().entry_bar_index == bar_index_
             && position_entry_price_ == round_to_mintick(bar.open)) {
             pyramid_entries_.front().ordinary_market_open = true;
+        }
+        if (order.type == OrderType::ENTRY
+            && std::isfinite(order.stop_price)
+            && std::isnan(order.limit_price)
+            && !order.stop_limit_activated
+            && std::isnan(order.trail_points)
+            && std::isnan(order.trail_price)
+            && std::isnan(order.trail_offset)
+            && order.oca_name.empty() && order.oca_type == 0
+            && !process_orders_on_close_ && !calc_on_order_fills_
+            && !bar_magnifier_enabled_ && !coof_scheduler_active_
+            && !stream_warmup_mode_ && stream_phase_ == StreamPhase::IDLE
+            && !order.created_during_coof_recalc
+            && !order.created_while_in_position
+            && !order.created_after_position_close_in_bar
+            && order.created_position_side == PositionSide::FLAT
+            && order.created_bar < bar_index_
+            && position_side_before_fill == PositionSide::FLAT
+            && position_side_ != PositionSide::FLAT
+            && pyramid_entries_.size() == 1
+            && order.incarnation != 0
+            && pyramid_entries_.front().entry_incarnation == order.incarnation
+            && pyramid_entries_.front().entry_bar_index == bar_index_
+            && pyramid_entries_.front().entry_path_position == 0.0
+            && std::isfinite(bar.open)
+            && position_entry_price_ == round_to_mintick(bar.open)) {
+            pyramid_entries_.front().ordinary_stop_open = true;
         }
         ++broker_fill_event_seq_;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    test_stop_open_margin_script_state
     test_high_value_signal_cost
     test_short_margin_script_state
     test_ringbuffer

--- a/tests/test_stop_open_margin_script_state.cpp
+++ b/tests/test_stop_open_margin_script_state.cpp
@@ -1,0 +1,352 @@
+// R25 covered TV controls: a pure STOP filled at the opening point exposes
+// its completed margin event to the script; an unhit pending entry survives.
+// Compact command fixtures use synthetic timestamps, not historical replay.
+#include <pineforge/engine.hpp>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+constexpr double qnan = std::numeric_limits<double>::quiet_NaN();
+int passed = 0, failed = 0;
+#define CHECK(x) do { if (x) ++passed; else { ++failed; std::printf("FAIL %d %s\n", __LINE__, #x); } } while (0)
+bool near(double a, double b) { return std::abs(a - b) < 1e-8; }
+
+const std::vector<Bar> bars = {
+    {114643.19, 114781.21, 114555.0, 114555.0, 1, 1000},
+    {114555.0, 114564.69, 114350.57, 114400.0, 1, 2000},
+    {114400.01, 114600.94, 114378.99, 114454.93, 1, 3000},
+    {114454.93, 114521.97, 114402.65, 114437.7, 1, 4000},
+    {114437.71, 114657.0, 114437.7, 114514.05, 1, 5000},
+    {114514.05, 114865.32, 114449.91, 114697.22, 1, 6000},
+};
+
+class StopBook : public BacktestEngine {
+public:
+    bool opposite, half_close, smaller, carried_half;
+    double first_view = qnan;
+    double carried_view = qnan;
+    std::size_t first_closed = 0;
+    StopBook(bool other = true, double capital = 9064.3344809999962,
+             bool half = false, bool less = false, bool carry = false)
+        : opposite(other), half_close(half), smaller(less), carried_half(carry) {
+        initial_capital_ = capital;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100;
+        qty_step_ = 0.00001;
+        syminfo_mintick_ = 0.01;
+        syminfo_.pointvalue = 1;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 0;
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 1) {
+            first_view = signed_position_size();
+            first_closed = trades_.size();
+        }
+        if (bar_index_ == 2) carried_view = signed_position_size();
+        if (bar_index_ <= 1 && signed_position_size() == 0) {
+            if (opposite) strategy_entry("Long", true, qnan, 117030.0, current_equity() / 117030.0);
+            const double quantity = smaller ? 0.07911 : current_equity() / 114560.0;
+            strategy_entry("Short", false, qnan, 114560.0, quantity);
+        }
+        if (signed_position_size() < 0) {
+            strategy_exit("Exit Short", "Short", qnan, 117030.0);
+            strategy_cancel("Long");
+        }
+        if (signed_position_size() > 0) {
+            strategy_exit("Exit Long", "Long", qnan, 114560.0);
+            strategy_cancel("Short");
+        }
+        if (half_close && bar_index_ == 1) strategy_close("Short", "half", qnan, 50.0);
+        if (carried_half && bar_index_ == 2) strategy_close("Short", "carry half", qnan, 50.0);
+        if (bar_index_ == 4) strategy_close_all();
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+};
+
+void test_full_stop_liquidation_and_replacement() {
+    for (bool opposite : {false, true}) {
+        StopBook engine(opposite);
+        engine.run(bars.data(), static_cast<int>(bars.size()));
+        CHECK(near(engine.first_view, 0));
+        CHECK(engine.first_closed == 1);
+        CHECK(engine.rows().size() == 3);
+        if (engine.rows().size() != 3) continue;
+        CHECK(engine.rows()[0].exit_id == "__margin_call__");
+        CHECK(engine.rows()[0].exit_time == 2000);
+        CHECK(near(engine.rows()[0].qty, 0.07912));
+        CHECK(near(engine.rows()[0].exit_price, 114564.69));
+        CHECK(engine.rows()[1].entry_time == 3000);
+        CHECK(engine.rows()[1].exit_id == "__margin_call__");
+        CHECK(near(engine.rows()[1].qty, 0.00064));
+        CHECK(near(engine.rows()[1].entry_price, 114400.01));
+        CHECK(engine.rows()[2].exit_time == 6000);
+        CHECK(near(engine.rows()[2].qty, 0.07847));
+        CHECK(near(engine.rows()[2].exit_price, 114514.05));
+    }
+}
+
+void test_partial_and_no_opening_event() {
+    StopBook partial(true, 11456.0, true);
+    partial.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(near(partial.first_view, -0.09996));
+    CHECK(partial.first_closed == 1);
+    CHECK(partial.rows().size() == 3);
+    if (partial.rows().size() == 3) {
+        CHECK(partial.rows()[0].exit_id == "__margin_call__");
+        CHECK(near(partial.rows()[0].qty, 0.00004));
+        CHECK(partial.rows()[1].exit_comment == "half");
+        CHECK(near(partial.rows()[1].qty, 0.04998));
+        CHECK(near(partial.rows()[2].qty, 0.04998));
+    }
+    StopBook funded(true, 9064.3344809999962, false, true);
+    funded.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(near(funded.first_view, -0.07911));
+    CHECK(funded.first_closed == 0);
+    CHECK(funded.rows().size() == 2);
+    if (funded.rows().size() == 2) {
+        CHECK(funded.rows()[0].exit_time == 3000);
+        CHECK(near(funded.rows()[0].qty, 0.00016));
+        CHECK(near(funded.rows()[1].qty, 0.07895));
+    }
+    // TV's carried-bar comment reads -0.07895 before the 50% close; it then
+    // closes 0.03947 and retains 0.03948. The original STOP's open provenance
+    // remains attached to the same physical lot across this partial.
+    StopBook carried(true, 9064.3344809999962, false, true, true);
+    carried.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(near(carried.carried_view, -0.07895));
+    CHECK(carried.rows().size() == 3);
+    if (carried.rows().size() == 3) {
+        CHECK(carried.rows()[0].exit_time == 3000);
+        CHECK(near(carried.rows()[0].qty, 0.00016));
+        CHECK(carried.rows()[1].exit_time == 4000);
+        CHECK(carried.rows()[1].exit_comment == "carry half");
+        CHECK(near(carried.rows()[1].qty, 0.03947));
+        CHECK(near(carried.rows()[2].qty, 0.03948));
+    }
+}
+
+class PathAndLifetime : public BacktestEngine {
+public:
+    bool preserve;
+    double first_view = qnan;
+    PathAndLifetime(bool keep) : preserve(keep) {
+        initial_capital_ = 9064.3344809999962;
+        qty_step_ = 0.00001;
+        syminfo_mintick_ = 0.01;
+        syminfo_.pointvalue = 1;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 0;
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            if (preserve) strategy_entry("Long", true, qnan, 117030.0, 0.01);
+            strategy_entry("Short", false, qnan, preserve ? 114560.0 : 114500.0, 0.07912);
+        }
+        if (bar_index_ == 1) {
+            first_view = signed_position_size();
+            if (!preserve) strategy_close_all();
+        }
+        if (preserve && signed_position_size() > 0) strategy_close_all();
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+};
+
+void test_prior_high_and_pending_entry_lifetime() {
+    PathAndLifetime path(false);
+    path.run(bars.data(), 3);
+    CHECK(near(path.first_view, -0.07912));
+    CHECK(path.rows().size() == 1);
+    if (path.rows().size() == 1) {
+        CHECK(path.rows()[0].entry_time == 2000);
+        CHECK(near(path.rows()[0].entry_price, 114500.0));
+        CHECK(near(path.rows()[0].qty, 0.07912));
+        CHECK(path.rows()[0].exit_time == 3000);
+    }
+    std::vector<Bar> later = {bars[0], bars[1],
+        {116900.0, 117040.0, 116890.0, 117010.0, 1, 3000},
+        {116686.43, 116800.0, 116600.0, 116700.0, 1, 4000}};
+    PathAndLifetime keep(true);
+    keep.run(later.data(), static_cast<int>(later.size()));
+    CHECK(near(keep.first_view, 0));
+    CHECK(keep.rows().size() == 2);
+    if (keep.rows().size() == 2) {
+        CHECK(keep.rows()[0].exit_id == "__margin_call__");
+        CHECK(keep.rows()[1].is_long);
+        CHECK(keep.rows()[1].entry_time == 3000);
+        CHECK(near(keep.rows()[1].entry_price, 117030.0));
+        CHECK(near(keep.rows()[1].qty, 0.01));
+    }
+}
+
+enum class Origin { STOP, MARKET, LIMIT, STOP_LIMIT, RAW_STOP, OCA_STOP,
+                    REPLACED_STOP, REUSED_ID, ZERO_STOP, DECLINED_ADD };
+class OriginBook : public BacktestEngine {
+public:
+    Origin mode;
+    bool stop_origin = false, market_origin = false, final_stop = false;
+    uint64_t first_incarnation = 0, final_incarnation = 0;
+    explicit OriginBook(Origin value) : mode(value) {
+        initial_capital_ = 1000.0;
+        qty_step_ = 0.01;
+        syminfo_mintick_ = 0.01;
+        pyramiding_ = 0;
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            if (mode == Origin::RAW_STOP) {
+                strategy_order("S", false, 0.5, qnan, 101.0);
+            } else {
+                const bool market = mode == Origin::MARKET
+                    || mode == Origin::ZERO_STOP || mode == Origin::DECLINED_ADD;
+                const double limit = mode == Origin::LIMIT || mode == Origin::STOP_LIMIT ? 99.0 : qnan;
+                const double stop = market || mode == Origin::LIMIT ? qnan : 101.0;
+                if (mode == Origin::REPLACED_STOP)
+                    strategy_entry("S", false, qnan, 99.0, 0.4);
+                strategy_entry("S", false, limit, stop, 0.5, "",
+                    mode == Origin::OCA_STOP ? "siblings" : "",
+                    mode == Origin::OCA_STOP ? 1 : 0);
+            }
+        }
+        if (bar_index_ == 1 && !pyramid_entries_.empty()) {
+            const auto& entry = pyramid_entries_.front();
+            stop_origin = entry.ordinary_stop_open;
+            market_origin = entry.ordinary_market_open;
+            first_incarnation = entry.entry_incarnation;
+            if (mode == Origin::REUSED_ID) {
+                strategy_close("S", "", qnan, qnan, true);
+                strategy_entry("S", false, qnan, qnan, 0.5);
+            }
+            if (mode == Origin::ZERO_STOP || mode == Origin::DECLINED_ADD)
+                strategy_entry("S", false, qnan, 101.0,
+                    mode == Origin::ZERO_STOP ? 0.0 : 0.5);
+        }
+        if (bar_index_ == 2 && !pyramid_entries_.empty()) {
+            final_stop = pyramid_entries_.front().ordinary_stop_open;
+            final_incarnation = pyramid_entries_.front().entry_incarnation;
+        }
+    }
+};
+
+void test_origin_is_an_accepted_physical_stop_fill() {
+    const Bar tape[] = {{100, 101, 99, 100, 1, 1000},
+                        {100, 101, 99, 100, 1, 2000},
+                        {100, 101, 99, 100, 1, 3000}};
+    for (Origin mode : {Origin::STOP, Origin::MARKET, Origin::LIMIT,
+                        Origin::STOP_LIMIT, Origin::RAW_STOP, Origin::OCA_STOP,
+                        Origin::REPLACED_STOP, Origin::REUSED_ID,
+                        Origin::ZERO_STOP, Origin::DECLINED_ADD}) {
+        OriginBook engine(mode);
+        engine.run(tape, 3);
+        CHECK(engine.first_incarnation != 0);
+        const bool pure_stop = mode == Origin::STOP || mode == Origin::REPLACED_STOP
+            || mode == Origin::REUSED_ID;
+        CHECK(engine.stop_origin == pure_stop);
+        CHECK(engine.market_origin == (mode == Origin::MARKET
+            || mode == Origin::ZERO_STOP || mode == Origin::DECLINED_ADD));
+        if (mode == Origin::REUSED_ID) {
+            CHECK(!engine.final_stop);
+            CHECK(engine.first_incarnation != engine.final_incarnation);
+        }
+        if (mode == Origin::ZERO_STOP || mode == Origin::DECLINED_ADD) {
+            CHECK(!engine.final_stop);
+            CHECK(engine.first_incarnation == engine.final_incarnation);
+        }
+    }
+}
+
+// Exercise the checkpoint independently of the earlier order loop. A touched
+// but deferred entry is still pending, so pending alone cannot prove unhit.
+class PendingGuard : public BacktestEngine {
+public:
+    explicit PendingGuard(int scenario) {
+        initial_capital_ = 50;
+        current_bar_ = {100, 100.01, 99, 99.5, 1, 2000};
+        bar_index_ = position_open_bar_ = 1;
+        position_side_ = PositionSide::SHORT;
+        position_qty_ = 0.5;
+        position_entry_price_ = 100;
+        position_entry_time_ = 2000;
+        position_entry_count_ = 1;
+        qty_step_ = syminfo_mintick_ = 0.01;
+        PyramidEntry entry{};
+        entry.price = 100;
+        entry.qty = 0.5;
+        entry.time = 2000;
+        entry.entry_id = "S";
+        entry.entry_bar_index = 1;
+        entry.entry_incarnation = 7;
+        entry.ordinary_stop_open = true;
+        pyramid_entries_.push_back(entry);
+        PendingOrder pending{};
+        pending.id = "L";
+        pending.type = OrderType::ENTRY;
+        pending.is_long = true;
+        pending.limit_price = qnan;
+        pending.stop_price = 103;
+        pending.trail_points = pending.trail_price = pending.trail_offset = qnan;
+        pending.qty = 0.1;
+        pending.created_bar = 0;
+        pending.incarnation = 8;
+        switch (scenario) {
+        case 1: pending.stop_price = 100.01; break;
+        case 2: current_bar_.high = 100.006; pending.stop_price = 100.008; break;
+        case 3: pending.oca_name = "siblings"; break;
+        case 4: pending.oca_type = 1; break;
+        case 5: pending.limit_price = 103; break;
+        case 6: pending.stop_limit_activated = true; break;
+        case 7: pending.created_after_position_close_in_bar = true; break;
+        case 8: pending.created_position_side = PositionSide::SHORT; break;
+        case 9: pending.created_bar = 1; break;
+        case 10: pending.trail_offset = 1; break;
+        case 11: pending.type = OrderType::MARKET; break;
+        case 12: current_bar_.high = INFINITY; break;
+        case 13: pending.stop_price = INFINITY; break;
+        case 14:
+            pyramid_entries_[0].ordinary_stop_open = false;
+            pyramid_entries_[0].ordinary_market_open = true;
+            break;
+        case 15: pending.created_during_coof_recalc = true; break;
+        case 16: pending.created_while_in_position = true; break;
+        case 17: pending_orders_.push_back(pending); break;
+        default: break;
+        }
+        pending_orders_.push_back(pending);
+    }
+    void on_bar(const Bar&) override {}
+    void checkpoint() { process_short_margin_before_script(current_bar_); }
+    std::size_t closed() const { return trades_.size(); }
+    std::size_t pending() const { return pending_orders_.size(); }
+    double quantity() const { return position_qty_; }
+};
+
+void test_only_proven_unhit_pending_entries_are_independent() {
+    PendingGuard unhit(0);
+    unhit.checkpoint();
+    CHECK(unhit.closed() == 1);
+    CHECK(near(unhit.quantity(), 0));
+    CHECK(unhit.pending() == 1);
+    for (int scenario = 1; scenario <= 17; ++scenario) {
+        PendingGuard other(scenario);
+        const auto count = other.pending();
+        other.checkpoint();
+        CHECK(other.closed() == 0);
+        CHECK(near(other.quantity(), 0.5));
+        CHECK(other.pending() == count);
+    }
+}
+}
+int main() {
+    test_full_stop_liquidation_and_replacement();
+    test_partial_and_no_opening_event();
+    test_prior_high_and_pending_entry_lifetime();
+    test_origin_is_an_accepted_physical_stop_fill();
+    test_only_proven_unhit_pending_entries_are_independent();
+    std::printf("%d passed, %d failed\n", passed, failed);
+    return failed ? 1 : 0;
+}


### PR DESCRIPTION
Margin liquidation after a stop entry filled at the bar open happened after script evaluation. Scripts could still see the closed short and delay a flat-gated replacement by one bar.

Track actual pure-stop fills at the open and settle their margin event before the script runs. The new path covers ordinary, fee-free 100%-margin shorts of at most one contract on fractional lot grids. An unhit pending stop entry survives full liquidation; exits from the closed position are retired. Eligibility uses broker properties and physical order ownership, with no strategy, symbol, date, or benchmark-ID conditions. Admission, stop prices, margin arithmetic, and grading remain unchanged.

Update the README with the measured round 25 scoreboard, lane counts, verifier totals, and 217-test inventory.

Validation on final `f23828836ea588d1ef9207bb4e040dcbcb105b60`:

- All **4,190 probes** measured on Cloud Run: **4,168 excellent / 22 strong / zero moderate**. Inside Day Breakout BTC moves strong to excellent; the other **4,189 canonical results are identical**. Zero errors, coverage gaps, or regressions.
- All **386 target trade rows** match TradingView on side, time, price, and quantity. Ten covered TradingView controls pin full/partial liquidation visibility, carried positions, prior-high exclusion, and pending-entry lifetime.
- **217/217 tests pass**, including 153 new fixture assertions; C ABI and build freshness pass. Runtime and tests are byte-identical between the reviewed implementation and final README commit.
- Independent Grok 4.6 high review of the exact final commit: **P0/P1/P2 = 0**. Independent Codex audit also has zero findings.
- Formal Cloud Run gate `pineforge-pr-gate-87hs2`: **PASS**, target score **+1**, all **704 hard probes** unchanged with zero tolerated exceptions. Snapshot: `426be4f93c4fed3dc92bee6509beb429e22c54daba2c7bd9caaf9bf7d501bc22`.

Codegen remains `3fd97fe28abd7b191cb376d9f5db4e056fcfae4b`. Verifier, harness, population, tapes, and FX policy are unchanged.
