### PR TITLE
Fix close-time margin state and flat order admission

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 TradingView's strategy tester is the reference every Pine author trusts, and nothing outside TradingView reproduced it — until now. PineForge is a C++17 runtime with a stable C ABI that runs PineScript v6 strategies exactly the way TradingView's broker emulator does: same fills, same sizing, same margin calls, same trailing stops, same `request.security()` buckets, on any OHLCV you give it, in microseconds per bar.
 
-- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,168 excellent, 22 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,133 matched by the verifier.
+- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,169 excellent, 21 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,135 matched by the verifier.
 - **Open.** Engine, transpiler, corpus, benchmarks and the validation tooling are all public and Apache-2.0. The only thing you cannot download is the closed test set, because TradingView's Terms of Service forbid redistributing community scripts.
 - **Fast.** In-process, no interpreter: median **162× faster than PyneCore** on 99 timed strategies. Parameter sweeps re-run a loaded `.so` with new inputs — no recompile, no fork.
 - **Deterministic to the bit.** Two runs with the same inputs produce identical trade lists. Same on Linux and macOS.
@@ -108,23 +108,23 @@ Every PineForge-compiled strategy `.so` exports this same ABI — write the harn
 
 ## Validation scoreboard
 
-**Round 25 · 2026-09-07:** **4,168 excellent / 22 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
+**Round 26 · 2026-09-07:** **4,169 excellent / 21 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
 
 | Board | Test set | Result | TradingView trades evaluated |
 |---|---|---|---|
 | **Public** — [open corpus](https://github.com/pineforge-4pass/pineforge-corpus) | 312 reference strategies, Apache-2.0, reproducible by anyone | **309/309 graded excellent** (ETH/USDT-perp 15m; the corpus' declared engine-only / anomaly probes are not graded) | 429,866 |
-| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,859 excellent + 22 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
+| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,860 excellent + 21 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
 
-**2,819,967 TradingView trades** evaluated, **2,817,133 matched by the verifier** (99.90%), from the round 25 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
+**2,819,967 TradingView trades** evaluated, **2,817,135 matched by the verifier** (99.90%), from the round 26 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
 
-Round 25 improves the BTC/USDT 15m **Inside Day Breakout** strategy from strong to excellent. All **386 trade rows** match TradingView exactly on side, time, price, and quantity. The engine now exposes margin liquidation after a stop entry at the bar open before the script runs, allowing the script to place its replacement on time while preserving an unhit pending entry. The fix uses shared broker state and order ownership; it contains no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
+Round 26 improves the BTC/USDT 15m **Win The Trade EMA 9 + VWAP** strategy from strong to excellent, with **100% trade matching and zero count gap**. The engine settles carried-short margin liquidation before the close-time script runs and applies rounded signal-cost admission to new orders filled at that close. Some margin-split quantities still differ from TradingView. The fixes use shared broker state and order ownership; they contain no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
 
 ### The closed test, lane by lane
 
 | Market · timeframe | Probes | Excellent | Strong | Moderate |
 |---|---:|---:|---:|---:|
 | BINANCE:ETHUSDT.P · 15m *(hard lane: zero regression allowed)* | 395 | 394 | 1 | — |
-| BINANCE:BTCUSDT · 15m | 354 | 352 | 2 | — |
+| BINANCE:BTCUSDT · 15m | 354 | 353 | 1 | — |
 | BINANCE:BTCUSDT · 1D | 259 | 259 | — | — |
 | CME_MINI:ES1! · 15m | 174 | 173 | 1 | — |
 | CME_MINI:ES1! · 1D | 117 | 117 | — | — |
@@ -138,7 +138,7 @@ Round 25 improves the BTC/USDT 15m **Inside Day Breakout** strategy from strong 
 | OANDA:EURUSD · 15m | 373 | 365 | 8 | — |
 | OANDA:XAUUSD · 15m | 376 | 374 | 2 | — |
 | OANDA:XAUUSD · 1D | 248 | 248 | — | — |
-| **Total** | **3,881** | **3,859** | **22** | **0** |
+| **Total** | **3,881** | **3,860** | **21** | **0** |
 
 ### How a probe is graded
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Prefer zero install? The hosted server at **[mcp.pineforge.dev/mcp](https://mcp.
 git clone https://github.com/pineforge-4pass/pineforge-engine.git && cd pineforge-engine
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
-ctest --test-dir build --output-on-failure     # 217 tests
+ctest --test-dir build --output-on-failure     # 219 tests
 bash tutorial/run.sh                            # MACD on BTC/USDT, end to end
 python3 tutorial/run_stream.py                  # OHLCV warm-up → realtime trades
 ```
@@ -190,7 +190,7 @@ PyneCore's 15 non-excellent strategies involve `strategy.exit(stop=…, limit=�
 - `libpineforge.a` — the static runtime: order matching and fills, sizing and margin, the bar magnifier, 66 indicator classes, `request.security()`, time and session math.
 - `<pineforge/pineforge.h>` — the public C ABI, the stability-pinned consumer surface.
 - `<pineforge/*.hpp>` — internal C++ headers the transpiler emits against (not part of the stability guarantee).
-- 217 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
+- 219 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
 - `corpus/` — the 312-strategy public validation corpus (submodule).
 - `benchmarks/` — the three-way comparison harness and the throughput package.
 - `scripts/` — `run_corpus.sh`, `verify_corpus.py`, `run_strategy.py` (load any `.so` via ctypes), `regen_corpus_cpp.sh`, `coverage.sh`.
@@ -244,7 +244,7 @@ src/                    26 .cpp files split by concern
   ├── ta_*.cpp                        66 indicator classes (moving averages, oscillators,
   │                                   volatility/trend, extremes/volume, misc)
   └── magnifier / matrix / session_time / timeframe / timezone / math / str_utils
-tests/                  217 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
+tests/                  219 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
 corpus/                 public submodule: 312 strategies + the 1-minute feed and derived 15m bars
 benchmarks/             three-way comparison harness, throughput package, results/
 scripts/                run_corpus.sh, verify_corpus.py, run_strategy.py, regen_corpus_cpp.sh, coverage.sh

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1899,6 +1899,10 @@ protected:
     // Ordinary sub-contract shorts expose completed liquidation to the
     // close-time script (R23 opening and carried-position TV controls).
     void process_short_margin_before_script(const Bar& bar);
+    // An unchanged carried POOC short finishes its adverse-path margin event
+    // before the close script observes or reverses it. The caller proves no
+    // resting order filled earlier on this bar.
+    void process_carried_pooc_short_margin_before_script(const Bar& bar);
     // finding-308: chronological pre-exit forced-liquidation slice. Called
     // from the process_pending_orders fill loop immediately BEFORE a priced
     // exit of the live position is applied. Fires only when (a) no margin
@@ -2015,6 +2019,51 @@ protected:
                                  * active_account_currency_fx();
         return std::isfinite(lot_value) && lot_value < 1.0;
     }
+    // POOC flat-parent controls: cost rounding also precedes admission at the
+    // terminal close. Named child brackets created after the sole pending
+    // parent have no live owner yet; they cannot compete for its opening cash.
+    bool rounded_pooc_flat_signal_cost_scope(const PendingOrder& order) const {
+        if (!process_orders_on_close_ || calc_on_order_fills_
+            || bar_magnifier_enabled_ || coof_scheduler_active_
+            || stream_warmup_mode_ || stream_phase_ != StreamPhase::IDLE
+            || order.type != OrderType::MARKET || order.incarnation == 0
+            || order.created_bar != bar_index_
+            || order.created_position_side != PositionSide::FLAT
+            || order.created_after_position_close_in_bar
+            || order.created_by_same_id_replacement
+            || order.oca_type != 0 || !order.oca_name.empty()
+            || position_side_ != PositionSide::FLAT
+            || position_entry_count_ != 0 || !pyramid_entries_.empty()
+            || !(qty_step_ > 0.0 && qty_step_ < 1.0)
+            || !std::isfinite(order.sizing_price) || order.sizing_price <= 0.0
+            || order.sizing_fx != 1.0 || active_account_currency_fx() != 1.0
+            || !account_currency_fx_timestamps_.empty()
+            || syminfo_.pointvalue != 1.0 || commission_value_ != 0.0
+            || slippage_ != 0 || pyramiding_ < 0 || pyramiding_ > 1
+            || max_intraday_filled_orders_ > 0
+            || risk_max_intraday_loss_ != 0.0 || risk_max_drawdown_ != 0.0
+            || risk_max_cons_loss_days_ > 0 || pending_orders_.size() > 3) {
+            return false;
+        }
+        for (const auto& other : pending_orders_) {
+            if (other.incarnation == order.incarnation) continue;
+            const bool priced = std::isfinite(other.limit_price)
+                || std::isfinite(other.stop_price);
+            const bool trailing = std::isfinite(other.trail_offset)
+                && (std::isfinite(other.trail_points) || std::isfinite(other.trail_price));
+            if (other.type != OrderType::EXIT || other.from_entry.empty()
+                || other.created_bar != order.created_bar
+                || other.created_seq <= order.created_seq
+                || other.dormant_bracket || other.dormant_reissue_pending
+                || (!priced && !trailing)) {
+                return false;
+            }
+            // Matching from_entry attaches only if this parent is admitted.
+            // A different named from_entry has neither a live lot (flat) nor
+            // another pending parent (every other object is an EXIT).
+        }
+        return true;
+    }
     // R24 signal-cost controls: a fractional lot worth >=1 account unit can
     // still cross the rounded-money admission boundary. BTC Q9.36259 at
     // 112380.33 costs 1052170.9538547, rounded to 1052170.954; exact signal
@@ -2024,6 +2073,7 @@ protected:
     // This extends rule 2 alone; rule 5 and margin valuation keep their scope.
     bool rounded_signal_cost_scope(const PendingOrder& order) const {
         if (tv_money_scope(order.sizing_price)) return true;
+        if (rounded_pooc_flat_signal_cost_scope(order)) return true;
         if (!(qty_step_ > 0.0 && qty_step_ < 1.0)
             || !std::isfinite(order.sizing_price) || order.sizing_price <= 0.0
             || !std::isfinite(order.sizing_equity)

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -1099,6 +1099,72 @@ void BacktestEngine::process_short_margin_before_script(const Bar& bar) {
     }
 }
 
+// A carried POOC short owns the whole current bar before its terminal close
+// evaluation. The old order pass has completed without a broker fill, so an
+// unfilled owned bracket cannot postpone the high's margin event until after
+// the script closes or reverses the position. TV's partial-close control reads
+// -12.33168 after a .11264 liquidation, then closes half (6.16584); a reversal
+// closes that same reduced remainder and opens only its requested new quantity.
+// Fresh close fills and bars with an earlier fill keep their existing paths.
+void BacktestEngine::process_carried_pooc_short_margin_before_script(const Bar& bar) {
+    if (!process_orders_on_close_ || !margin_call_enabled_
+        || position_side_ != PositionSide::SHORT
+        || calc_on_order_fills_ || coof_scheduler_active_ || bar_magnifier_enabled_
+        || stream_warmup_mode_ || stream_phase_ != StreamPhase::IDLE
+        || position_open_bar_ < 0 || position_open_bar_ >= bar_index_
+        || bar.timestamp != current_bar_.timestamp
+        || !std::isfinite(bar.open) || !std::isfinite(bar.high)
+        || !std::isfinite(bar.low) || !std::isfinite(bar.close)
+        || !(position_qty_ > 0.0) || !std::isfinite(position_qty_)
+        || !(qty_step_ > 0.0 && qty_step_ < 1.0)
+        || pyramiding_ < 0 || pyramiding_ > 1
+        || position_entry_count_ != 1 || pyramid_entries_.size() != 1
+        || pyramid_entries_.front().entry_bar_index != position_open_bar_
+        || pyramid_entries_.front().entry_incarnation == 0
+        || pending_orders_.size() > 1
+        || commission_value_ != 0.0 || slippage_ != 0
+        || margin_short_ != 100.0 || syminfo_.pointvalue != 1.0
+        || active_account_currency_fx() != 1.0
+        || !account_currency_fx_timestamps_.empty()
+        || max_intraday_filled_orders_ > 0
+        || risk_max_intraday_loss_ != 0.0 || risk_max_drawdown_ != 0.0
+        || risk_max_cons_loss_days_ > 0
+        || last_margin_call_event_bar_ == bar_index_) {
+        return;
+    }
+    // These controls cover exact required-margin valuation. A sub-account-unit
+    // lot uses the separately rounded-money cascade; its carried POOC state
+    // still has unresolved ownership/budget evidence and retains its existing
+    // scheduling. Use the broker's established financial class at this same
+    // adverse mark, rather than inferring the class from a symbol or strategy.
+    if (tv_money_scope(round_to_mintick(bar.high))) return;
+    for (const auto& order : pending_orders_) {
+        // The completed old-order pass proved this bracket unfilled. Reject
+        // competing entries/closes, foreign/global owners and deferred order
+        // lifecycles; none of those transactions is part of this checkpoint.
+        const bool priced = std::isfinite(order.limit_price)
+            || std::isfinite(order.stop_price);
+        const bool trailing = std::isfinite(order.trail_offset)
+            && (std::isfinite(order.trail_points) || std::isfinite(order.trail_price));
+        if (order.type != OrderType::EXIT
+            || order.from_entry != pyramid_entries_.front().entry_id
+            || order.created_bar >= bar_index_
+            || order.dormant_bracket || order.dormant_reissue_pending
+            || !std::isnan(order.profit_ticks) || !std::isnan(order.loss_ticks)
+            || (!priced && !trailing)) {
+            return;
+        }
+    }
+    const std::size_t trades_before = trades_.size();
+    process_margin_call(bar);
+    if (trades_.size() != trades_before) {
+        // A partial has consumed this high. A new close fill still receives
+        // its separate opening-affordability event after the script.
+        intrabar_exit_margin_call_bar_ = bar_index_;
+        if (position_side_ == PositionSide::FLAT) purge_exit_orders();
+    }
+}
+
 void BacktestEngine::process_margin_call(const Bar& bar) {
     // Consume first, including on disabled/degenerate paths. This is an event
     // attached to the just-completed fill cycle, never durable per-position

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -192,6 +192,9 @@ void BacktestEngine::dispatch_bar() {
             && broker_fill_event_seq_ == fills_before_pending) {
             tv_money_long_margin_call(current_bar_, /*carried_pooc_pre_close=*/true);
         }
+        if (broker_fill_event_seq_ == fills_before_pending) {
+            process_carried_pooc_short_margin_before_script(current_bar_);
+        }
         update_per_trade_extremes();             // step 2: update before strategy reads
         invoke_chart_on_bar(current_bar_);       // step 3: strategy logic
         flush_same_bar_close();                  // step 3b: surviving strategy.close fill

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(TEST_SOURCES
     test_stop_open_margin_script_state
+    test_carried_pooc_short_margin_state
+    test_pooc_flat_signal_cost
     test_high_value_signal_cost
     test_short_margin_script_state
     test_ringbuffer

--- a/tests/test_carried_pooc_short_margin_state.cpp
+++ b/tests/test_carried_pooc_short_margin_state.cpp
@@ -1,0 +1,236 @@
+// A carried short's completed adverse-path liquidation is visible to the
+// process_orders_on_close script, before a close or reversal sizes its order.
+// Compact command fixtures use synthetic timestamps, with quantities/prices
+// independently pinned by the R26 bare, reversal, half, funded and trail TV
+// controls. The original historical probe remains unchanged.
+#include <pineforge/engine.hpp>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+constexpr double qnan = std::numeric_limits<double>::quiet_NaN();
+int passed = 0, failed = 0;
+#define CHECK(x) do { if (x) ++passed; else { ++failed; std::printf("FAIL %d %s\n", __LINE__, #x); } } while (0)
+bool near(double a, double b) { return std::abs(a - b) < 1e-8; }
+
+enum class Action { HOLD, REVERSE, HALF };
+class CarriedShort : public BacktestEngine {
+public:
+    Action action;
+    bool trail = false;
+    bool parked_entry = false;
+    double first_view = qnan, second_view = qnan, final_view = qnan;
+    std::size_t second_closed = 0;
+    explicit CarriedShort(Action value, double capital = 1392521.546177, double price_scale = 1.0)
+        : action(value) {
+        initial_capital_ = capital * price_scale;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        qty_step_ = 0.00001;
+        syminfo_mintick_ = 0.01 * price_scale;
+        syminfo_.pointvalue = 1.0;
+        margin_long_ = margin_short_ = 100.0;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        pyramiding_ = 0;
+        process_orders_on_close_ = true;
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) strategy_entry("S", false, qnan, qnan, 12.60172);
+        if (bar_index_ == 1) first_view = signed_position_size();
+        if (bar_index_ == 2) {
+            second_view = signed_position_size();
+            second_closed = trades_.size();
+            if (action == Action::REVERSE) strategy_entry("L", true, qnan, qnan, 2.0);
+            if (action == Action::HALF) strategy_close("S", "half", qnan, 50.0);
+        }
+        if (trail) strategy_exit("Trail", "S", qnan, qnan, 1000.0, 1000.0);
+        if (parked_entry && bar_index_ == 0) strategy_entry("Parked", true, 1.0, qnan, 0.001);
+        if (bar_index_ == 3) { final_view = signed_position_size(); strategy_close_all(); }
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+};
+
+const std::vector<Bar> bars = {
+    {110727.28, 110920.00, 110502.44, 110502.45, 1, 1000},
+    {110502.44, 110675.31, 110500.00, 110675.30, 1, 2000},
+    {110675.31, 111326.20, 110666.66, 110981.97, 1, 3000},
+    {110981.98, 111168.00, 110818.18, 110820.93, 1, 4000},
+};
+
+void test_carried_script_reads_partial_before_close_or_reverse() {
+    for (Action action : {Action::HOLD, Action::REVERSE, Action::HALF}) {
+        for (bool trail : {false, true}) {
+            CarriedShort engine(action);
+            engine.trail = trail;
+            engine.run(bars.data(), static_cast<int>(bars.size()));
+            CHECK(near(engine.first_view, -12.44432));
+            CHECK(near(engine.second_view, -12.33168));
+            CHECK(engine.second_closed == 2);
+            CHECK(engine.rows().size() == (action == Action::HOLD ? 3u : 4u));
+            if (engine.rows().size() < 3) continue;
+            CHECK(engine.rows()[0].exit_id == "__margin_call__");
+            CHECK(engine.rows()[0].exit_time == 2000);
+            CHECK(near(engine.rows()[0].qty, 0.1574));
+            CHECK(near(engine.rows()[0].exit_price, 110675.31));
+            CHECK(engine.rows()[1].exit_id == "__margin_call__");
+            CHECK(engine.rows()[1].exit_time == 3000);
+            CHECK(near(engine.rows()[1].qty, 0.11264));
+            CHECK(near(engine.rows()[1].exit_price, 111326.2));
+            if (action == Action::HALF) {
+                CHECK(near(engine.rows()[2].qty, 6.16584));
+                CHECK(near(engine.final_view, -6.16584));
+            } else if (action == Action::REVERSE) {
+                CHECK(near(engine.rows()[2].qty, 12.33168));
+                CHECK(near(engine.final_view, 2.0));
+            } else {
+                CHECK(near(engine.final_view, -12.33168));
+            }
+        }
+    }
+}
+
+void test_funded_and_competing_order_controls() {
+    CarriedShort funded(Action::REVERSE, 2000000.0);
+    funded.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(near(funded.first_view, -12.60172));
+    CHECK(near(funded.second_view, -12.60172));
+    CHECK(funded.second_closed == 0);
+    CHECK(funded.rows().size() == 2);
+    CHECK(near(funded.final_view, 2.0));
+    // A competing pending ENTRY keeps its established transaction scheduling.
+    CarriedShort competing(Action::REVERSE);
+    competing.parked_entry = true;
+    competing.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(near(competing.second_view, -12.44432));
+    // The same command topology with prices and capital rescaled together
+    // enters the broker's separate rounded-margin financial class. Keep its
+    // established script timing until that class has its own complete proof.
+    std::vector<Bar> smaller = bars;
+    for (auto& bar : smaller) {
+        bar.open *= 0.00001; bar.high *= 0.00001;
+        bar.low *= 0.00001; bar.close *= 0.00001;
+    }
+    CarriedShort rounded_margin(Action::REVERSE, 1392521.546177, 0.00001);
+    rounded_margin.run(smaller.data(), static_cast<int>(smaller.size()));
+    CHECK(near(rounded_margin.first_view, -12.60172));
+    CHECK(rounded_margin.second_closed == 1);
+}
+
+class FreshShort : public BacktestEngine {
+public:
+    double view = qnan;
+    explicit FreshShort(bool stop) : stop_(stop) {
+        initial_capital_ = 1000.0;
+        qty_step_ = 0.01;
+        syminfo_mintick_ = 0.01;
+        syminfo_.pointvalue = 1.0;
+        margin_long_ = margin_short_ = 100.0;
+        process_orders_on_close_ = true;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry("S", false, qnan, qnan, 10.0);
+            if (stop_) strategy_exit("Stop", "S", qnan, 101.0);
+        }
+        if (bar_index_ == 1) { view = signed_position_size(); strategy_close_all(); }
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+private:
+    bool stop_;
+};
+
+void test_fresh_close_fill_and_earlier_stop_are_not_replayed() {
+    const std::vector<Bar> fresh = {
+        {100.0, 200.0, 99.0, 100.0, 1, 1000},
+        {100.0, 100.0, 99.0, 99.0, 1, 2000},
+    };
+    FreshShort engine(false);
+    engine.run(fresh.data(), static_cast<int>(fresh.size()));
+    CHECK(near(engine.view, -10.0));
+    CHECK(engine.rows().size() == 1);
+    CHECK(!engine.rows().empty() && engine.rows()[0].exit_id != "__margin_call__");
+    const std::vector<Bar> stop = {
+        {100.0, 100.0, 100.0, 100.0, 1, 1000},
+        {100.0, 120.0, 99.0, 110.0, 1, 2000},
+    };
+    FreshShort stopped(true);
+    stopped.run(stop.data(), static_cast<int>(stop.size()));
+    CHECK(near(stopped.view, 0.0));
+    CHECK(stopped.rows().size() == 1);
+    CHECK(!stopped.rows().empty() && stopped.rows()[0].exit_id == "Stop");
+}
+
+class FullReplacement : public BacktestEngine {
+public:
+    double view = qnan;
+    bool dead_bracket_visible = false;
+    FullReplacement() {
+        initial_capital_ = 9064.334481;
+        qty_step_ = 0.00001;
+        syminfo_mintick_ = 0.01;
+        syminfo_.pointvalue = 1.0;
+        margin_long_ = margin_short_ = 100.0;
+        process_orders_on_close_ = true;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        pyramiding_ = 0;
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry("S", false, qnan, qnan, 0.07912);
+            strategy_exit("Owned", "S", qnan, 130000.0);
+        }
+        if (bar_index_ == 1) {
+            view = signed_position_size();
+            for (const auto& order : pending_orders_) {
+                if (order.id == "Owned") dead_bracket_visible = true;
+            }
+            if (view == 0.0) {
+                strategy_entry("S", false, qnan, qnan, 0.07);
+                strategy_exit("Owned", "S", qnan, 114460.0);
+            }
+        }
+        if (bar_index_ == 3) strategy_close_all();
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+};
+
+void test_full_liquidation_retires_only_the_old_owned_bracket() {
+    const std::vector<Bar> replacement = {
+        {114643.19, 114781.21, 114555.00, 114555.00, 1, 1000},
+        {114555.00, 114564.69, 114350.57, 114400.00, 1, 2000},
+        {114400.01, 114600.94, 114378.99, 114454.93, 1, 3000},
+        {114454.93, 114521.97, 114402.65, 114437.70, 1, 4000},
+    };
+    FullReplacement engine;
+    engine.run(replacement.data(), static_cast<int>(replacement.size()));
+    CHECK(near(engine.view, 0.0));
+    CHECK(!engine.dead_bracket_visible);
+    CHECK(engine.rows().size() == 2);
+    if (engine.rows().size() != 2) return;
+    CHECK(engine.rows()[0].exit_id == "__margin_call__");
+    CHECK(near(engine.rows()[0].qty, 0.07912));
+    CHECK(near(engine.rows()[0].exit_price, 114564.69));
+    CHECK(engine.rows()[1].entry_time == 2000);
+    CHECK(near(engine.rows()[1].qty, 0.07));
+    CHECK(near(engine.rows()[1].entry_price, 114400.0));
+    CHECK(engine.rows()[1].exit_id == "Owned");
+    CHECK(engine.rows()[1].exit_time == 3000);
+    CHECK(near(engine.rows()[1].exit_price, 114460.0));
+}
+}
+
+int main() {
+    test_carried_script_reads_partial_before_close_or_reverse();
+    test_funded_and_competing_order_controls();
+    test_fresh_close_fill_and_earlier_stop_are_not_replayed();
+    test_full_liquidation_retires_only_the_old_owned_bracket();
+    std::printf("%d passed, %d failed\n", passed, failed);
+    return failed ? 1 : 0;
+}

--- a/tests/test_pooc_flat_signal_cost.cpp
+++ b/tests/test_pooc_flat_signal_cost.cpp
@@ -1,0 +1,98 @@
+// Covered POOC controls pin rounded signal-cost admission while flat. A child
+// bracket has no live owner until its sole parent entry is admitted.
+#include <pineforge/engine.hpp>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+constexpr double qnan = std::numeric_limits<double>::quiet_NaN();
+int passed = 0, failed = 0;
+#define CHECK(x) do { if (x) ++passed; else { ++failed; std::printf("FAIL %d %s\n", __LINE__, #x); } } while (0)
+bool near(double a, double b) { return std::abs(a - b) < 1e-8; }
+
+class FlatClose : public BacktestEngine {
+public:
+    bool children, long_entry;
+    double frozen = qnan;
+    FlatClose(double capital, double step, double tick, bool brackets, bool is_long = true)
+        : children(brackets), long_entry(is_long) {
+        initial_capital_ = capital;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100.0;
+        qty_step_ = step;
+        syminfo_mintick_ = tick;
+        syminfo_.pointvalue = 1.0;
+        margin_long_ = margin_short_ = 100.0;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        pyramiding_ = 0;
+        process_orders_on_close_ = true;
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry(long_entry ? "L" : "S", long_entry);
+            for (const auto& order : pending_orders_) {
+                if (order.type == OrderType::MARKET) frozen = order.frozen_default_qty;
+            }
+            if (children) {
+                strategy_exit("LX", "L", qnan, qnan, 1000.0, 1000.0);
+                strategy_exit("SX", "S", qnan, qnan, 1000.0, 1000.0);
+            }
+        }
+        if (bar_index_ == 1) strategy_close_all();
+    }
+    bool entered() const {
+        for (const auto& trade : trades_) if (trade.entry_time == 1000) return true;
+        return false;
+    }
+};
+
+void test_terminal_close_cost_with_child_brackets() {
+    const std::vector<Bar> bars = {
+        {106583.05, 106623.12, 106288.48, 106320.56, 1, 1000},
+        {106320.56, 106360.15, 105852.37, 105852.38, 1, 2000},
+    };
+    for (bool children : {false, true}) {
+        for (bool is_long : {false, true}) {
+            for (double extra : {-0.001, 0.0, 0.000002, 0.000004, 0.001}) {
+                FlatClose engine(3026704.995997007 + extra, 0.00001, 0.01, children, is_long);
+                engine.run(bars.data(), static_cast<int>(bars.size()));
+                const bool admitted = extra < 0.0 || extra >= 0.000004;
+                CHECK(near(engine.frozen, extra < 0.0 ? 28.46772 : 28.46773));
+                CHECK(engine.entered() == admitted);
+            }
+        }
+    }
+}
+
+void test_close_cost_at_another_lot_and_price_scale() {
+    const std::vector<Bar> bars = {
+        {3445.31, 3446.015, 3443.295, 3443.625, 1, 1000},
+        {3443.565, 3446.015, 3443.295, 3444.0, 1, 2000},
+    };
+    for (double extra : {-0.0001, 0.0001}) {
+        FlatClose engine(1033087.5 + extra, 0.01, 0.001, false);
+        engine.run(bars.data(), static_cast<int>(bars.size()));
+        CHECK(near(engine.frozen, 300.0));
+        CHECK(engine.entered() == (extra > 0.0));
+    }
+    // The fractional 300.02 lot is a lower-rounded-cost boundary and admits
+    // on both sides of the subsequent rounded required-margin event.
+    for (double capital : {1033156.3729, 1033156.3731}) {
+        FlatClose engine(capital, 0.01, 0.001, false);
+        engine.run(bars.data(), static_cast<int>(bars.size()));
+        CHECK(near(engine.frozen, 300.02));
+        CHECK(engine.entered());
+    }
+}
+}
+
+int main() {
+    test_terminal_close_cost_with_child_brackets();
+    test_close_cost_at_another_lot_and_price_scale();
+    std::printf("%d passed, %d failed\n", passed, failed);
+    return failed ? 1 : 0;
+}


### PR DESCRIPTION
Close-time execution could expose a short position before its margin liquidation and admit a new order whose rounded signal cost exceeds equity. These errors changed reversal quantities and later entry decisions.

Settle carried-short margin events before the script runs, and apply the existing rounded signal-cost rule to fresh, true-flat orders filled at the close. The new margin ordering uses the existing class where required margin is computed without monetary rounding. Physical position and order ownership bound both paths. Financial arithmetic and the independent price-scale admission rule remain unchanged; there are no strategy, symbol, date, or benchmark-ID conditions.

Refresh the README with the measured round 26 scoreboard, lane counts, verifier totals, and 219-test inventory.

Validation on final `490f1805427fd3233abd27b242f61f66fbbd31fc`:

- All **4,190 probes** measured on Cloud Run: **4,169 excellent / 21 strong / zero moderate**. BTC Win The Trade EMA 9 + VWAP becomes excellent; the other **4,189 canonical results are identical**. Zero errors, coverage gaps, or regressions.
- The target retains **100% matching**, closes the count gap from 1 to 0, and has zero unmatched pairs. Some margin-split quantities still differ from TradingView and are explicitly disclosed in the README.
- TradingView controls cover full/partial/funded margin state, owned trailing exits, replacement lifetime, and BTC/XAU signal-cost boundaries. Earlier regressing variants remain recorded as rejected.
- **219/219 tests pass**, with C ABI and build freshness verified. The independent Codex component audit and Grok 4.6 high review of the exact final commit both report **P0/P1/P2 = 0**.
- Formal Cloud Run gate `pineforge-pr-gate-4pbcf`: **PASS**, target score **+1**, all **704 hard probes** unchanged with zero tolerated exceptions. Snapshot: `73f1aeee1e6bc09cb3d3f4c7af00f0601d224e9293efedaef453069c7163ae79`.

Codegen remains `3fd97fe28abd7b191cb376d9f5db4e056fcfae4b`. Grading metrics, verifier, harness, population, tapes, and FX policy are unchanged.
