### PR TITLE
Fix small margin deficits using tracked rounding error

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 TradingView's strategy tester is the reference every Pine author trusts, and nothing outside TradingView reproduced it — until now. PineForge is a C++17 runtime with a stable C ABI that runs PineScript v6 strategies exactly the way TradingView's broker emulator does: same fills, same sizing, same margin calls, same trailing stops, same `request.security()` buckets, on any OHLCV you give it, in microseconds per bar.
 
-- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,169 excellent, 21 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,135 matched by the verifier.
+- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,170 excellent, 20 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,198 matched by the verifier.
 - **Open.** Engine, transpiler, corpus, benchmarks and the validation tooling are all public and Apache-2.0. The only thing you cannot download is the closed test set, because TradingView's Terms of Service forbid redistributing community scripts.
 - **Fast.** In-process, no interpreter: median **162× faster than PyneCore** on 99 timed strategies. Parameter sweeps re-run a loaded `.so` with new inputs — no recompile, no fork.
 - **Deterministic to the bit.** Two runs with the same inputs produce identical trade lists. Same on Linux and macOS.
@@ -108,16 +108,16 @@ Every PineForge-compiled strategy `.so` exports this same ABI — write the harn
 
 ## Validation scoreboard
 
-**Round 26 · 2026-09-07:** **4,169 excellent / 21 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
+**Round 27 · 2026-09-07:** **4,170 excellent / 20 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
 
 | Board | Test set | Result | TradingView trades evaluated |
 |---|---|---|---|
 | **Public** — [open corpus](https://github.com/pineforge-4pass/pineforge-corpus) | 312 reference strategies, Apache-2.0, reproducible by anyone | **309/309 graded excellent** (ETH/USDT-perp 15m; the corpus' declared engine-only / anomaly probes are not graded) | 429,866 |
-| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,860 excellent + 21 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
+| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,861 excellent + 20 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
 
-**2,819,967 TradingView trades** evaluated, **2,817,135 matched by the verifier** (99.90%), from the round 26 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
+**2,819,967 TradingView trades** evaluated, **2,817,198 matched by the verifier** (99.90%), from the round 27 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
 
-Round 26 improves the BTC/USDT 15m **Win The Trade EMA 9 + VWAP** strategy from strong to excellent, with **100% trade matching and zero count gap**. The engine settles carried-short margin liquidation before the close-time script runs and applies rounded signal-cost admission to new orders filled at that close. Some margin-split quantities still differ from TradingView. The fixes use shared broker state and order ownership; they contain no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
+Round 27 improves the EUR/USD 15m **Market Adaptive Trend [Interakktive]** strategy from strong to excellent, with **100% trade matching and zero count gap**. The engine tracks realized-profit summation error separately so a real small margin deficit is no longer swallowed by a fixed numerical guard. Financial PnL and equity formulas remain unchanged; uncertain histories retain the previous comparison. The fix uses shared broker data and numerical history, with no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
 
 ### The closed test, lane by lane
 
@@ -135,10 +135,10 @@ Round 26 improves the BTC/USDT 15m **Win The Trade EMA 9 + VWAP** strategy from 
 | NSE:NIFTY · 1D | 145 | 145 | — | — |
 | NYSE:F · 15m | 340 | 335 | 5 | — |
 | NYSE:F · 1D | 263 | 263 | — | — |
-| OANDA:EURUSD · 15m | 373 | 365 | 8 | — |
+| OANDA:EURUSD · 15m | 373 | 366 | 7 | — |
 | OANDA:XAUUSD · 15m | 376 | 374 | 2 | — |
 | OANDA:XAUUSD · 1D | 248 | 248 | — | — |
-| **Total** | **3,881** | **3,860** | **21** | **0** |
+| **Total** | **3,881** | **3,861** | **20** | **0** |
 
 ### How a probe is graded
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Prefer zero install? The hosted server at **[mcp.pineforge.dev/mcp](https://mcp.
 git clone https://github.com/pineforge-4pass/pineforge-engine.git && cd pineforge-engine
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
-ctest --test-dir build --output-on-failure     # 219 tests
+ctest --test-dir build --output-on-failure     # 220 tests
 bash tutorial/run.sh                            # MACD on BTC/USDT, end to end
 python3 tutorial/run_stream.py                  # OHLCV warm-up → realtime trades
 ```
@@ -190,7 +190,7 @@ PyneCore's 15 non-excellent strategies involve `strategy.exit(stop=…, limit=�
 - `libpineforge.a` — the static runtime: order matching and fills, sizing and margin, the bar magnifier, 66 indicator classes, `request.security()`, time and session math.
 - `<pineforge/pineforge.h>` — the public C ABI, the stability-pinned consumer surface.
 - `<pineforge/*.hpp>` — internal C++ headers the transpiler emits against (not part of the stability guarantee).
-- 219 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
+- 220 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
 - `corpus/` — the 312-strategy public validation corpus (submodule).
 - `benchmarks/` — the three-way comparison harness and the throughput package.
 - `scripts/` — `run_corpus.sh`, `verify_corpus.py`, `run_strategy.py` (load any `.so` via ctypes), `regen_corpus_cpp.sh`, `coverage.sh`.
@@ -244,7 +244,7 @@ src/                    26 .cpp files split by concern
   ├── ta_*.cpp                        66 indicator classes (moving averages, oscillators,
   │                                   volatility/trend, extremes/volume, misc)
   └── magnifier / matrix / session_time / timeframe / timezone / math / str_utils
-tests/                  219 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
+tests/                  220 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
 corpus/                 public submodule: 312 strategies + the 1-minute feed and derived 15m bars
 benchmarks/             three-way comparison harness, throughput package, results/
 scripts/                run_corpus.sh, verify_corpus.py, run_strategy.py, regen_corpus_cpp.sh, coverage.sh

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1738,6 +1738,15 @@ protected:
 
     // --- Cached trade metrics (updated incrementally in execute_market_exit) ---
     double net_profit_sum_ = 0.0;
+    // Conservative absolute roundoff accumulated by additions to the cached
+    // net-profit sum. This is numerical provenance only: reported PnL and
+    // equity continue to use the unchanged sum above. Infinity means a
+    // narrower margin comparison cannot be justified from this history.
+    double net_profit_roundoff_bound_ = 0.0;
+    // The net value whose additions this bound tracked. Direct/synthetic or
+    // future restore writes without matching provenance cannot narrow the
+    // established margin comparison; the next trade makes them unbounded.
+    double net_profit_roundoff_value_ = 0.0;
     double gross_profit_sum_ = 0.0;
     double gross_loss_sum_ = 0.0;
     int win_trades_count_ = 0;

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -1785,11 +1785,38 @@ bool BacktestEngine::tv_money_long_margin_call(const Bar& bar,
         // Only a ROUNDING deficit is this trigger's: the exact ledger must
         // still cover the position (a real shortfall — a fee, an adverse
         // mark — belongs to the established paths and their tolerances).
-        // Strict, with a float guard far below the pinned margins (the
-        // closest fire is 3.4e-6 under, revL L23): flat p0000 (C == cost, so
-        // equity == value == its rounding at the fill bar's low, up to the
-        // ulp of 925000 x 1.08094) is not called.
-        if (equity + 1e-7 >= value && equity + 1e-7 < rounded_value) {
+        // A real 1e-7 rounding deficit is observable in TV: Q = 891538.56
+        // at 1.15798, capital = 1032383.8221439, marked at 1.15808 has
+        // equity 1032472.9759999 against required money 1032472.976.
+        // The exact tie (+1e-7 capital) and funded controls do not fire.
+        // Only narrow the established guard when both current evaluation
+        // and accumulated realized-PnL roundoff support the decision. Fees
+        // and multiple live lots retain their existing numerical behavior.
+        double arithmetic_guard = 1e-7;
+        if (commission_value_ == 0.0 && position_entry_count_ == 1
+            && pyramid_entries_.size() == 1
+            && net_profit_sum_ == net_profit_roundoff_value_
+            && std::isfinite(net_profit_roundoff_bound_)) {
+            // A large prior loss must not inflate the scale of an identical
+            // current book. Its vanished intermediate summation residuals
+            // are represented separately by net_profit_roundoff_bound_.
+            const double entry_value = qty * position_entry_price_ * pv * fx;
+            const double money_scale = std::max({
+                std::abs(current_equity()), std::abs(open_profit(p)),
+                std::abs(entry_value), std::abs(value), std::abs(equity),
+                std::abs(rounded_value)});
+            const double evaluation_guard = 8.0
+                * std::numeric_limits<double>::epsilon() * money_scale;
+            const double supported_guard = std::nextafter(
+                evaluation_guard + net_profit_roundoff_bound_,
+                std::numeric_limits<double>::infinity());
+            // Never widen the prior boundary for a large account or an
+            // uncertain history; those books keep the established guard.
+            if (std::isfinite(supported_guard))
+                arithmetic_guard = std::min(arithmetic_guard, supported_guard);
+        }
+        if (equity + arithmetic_guard >= value
+            && equity + arithmetic_guard < rounded_value) {
             fire_price = p;
             deficit = rounded_value - equity;
             fire_path_point = i;

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -688,7 +688,33 @@ void BacktestEngine::emit_close_trade(const PyramidEntry& pe, double close_qty,
     const double pnl = trade.pnl;
     const double trade_pnl = trade.pnl;
     trades_.push_back(std::move(trade));
+    const double previous_net_profit = net_profit_sum_;
     net_profit_sum_ += trade_pnl;
+    // Knuth TwoSum recovers this addition's exact binary64 residual without
+    // changing the authoritative cached sum. Accumulate absolute residuals
+    // upward so vanished intermediate profits cannot disappear from the
+    // uncertainty used by a later rounded-money margin comparison.
+    if (previous_net_profit == net_profit_roundoff_value_
+        && std::isfinite(previous_net_profit) && std::isfinite(trade_pnl)
+        && std::isfinite(net_profit_sum_)
+        && std::isfinite(net_profit_roundoff_bound_)) {
+        const double virtual_pnl = net_profit_sum_ - previous_net_profit;
+        const double residual =
+            (previous_net_profit - (net_profit_sum_ - virtual_pnl))
+            + (trade_pnl - virtual_pnl);
+        if (std::isfinite(residual)) {
+            if (residual != 0.0) {
+                net_profit_roundoff_bound_ = std::nextafter(
+                    net_profit_roundoff_bound_ + std::abs(residual),
+                    std::numeric_limits<double>::infinity());
+            }
+        } else {
+            net_profit_roundoff_bound_ = std::numeric_limits<double>::infinity();
+        }
+    } else {
+        net_profit_roundoff_bound_ = std::numeric_limits<double>::infinity();
+    }
+    net_profit_roundoff_value_ = net_profit_sum_;
     if (trade_pnl > 0) { gross_profit_sum_ += trade_pnl; win_trades_count_++; }
     else if (trade_pnl < 0) { gross_loss_sum_ += trade_pnl; loss_trades_count_++; }
     else { ++eventrades_count_; }  // strategy.eventrades: exact zero P&L (TV uses == 0)

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -650,6 +650,8 @@ void BacktestEngine::reset_run_state() {
     trades_.reserve(256);
     range_end_trades_.clear();
     net_profit_sum_ = 0.0;
+    net_profit_roundoff_bound_ = 0.0;
+    net_profit_roundoff_value_ = 0.0;
     gross_profit_sum_ = 0.0;
     gross_loss_sum_ = 0.0;
     win_trades_count_ = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_SOURCES
     test_stop_open_margin_script_state
     test_carried_pooc_short_margin_state
     test_pooc_flat_signal_cost
+    test_small_money_margin_residual
     test_high_value_signal_cost
     test_short_margin_script_state
     test_ringbuffer

--- a/tests/test_small_money_margin_residual.cpp
+++ b/tests/test_small_money_margin_residual.cpp
@@ -1,0 +1,270 @@
+// A margin-100 long can have a real money-rounding deficit smaller than
+// the runtime's former absolute 1e-7 representation guard. This compact
+// broker fixture uses a four-bar ordinary market entry and next-open close.
+// Oracle controls and source/CSV hashes live in the campaign discovery state.
+#include <pineforge/engine.hpp>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+int passed = 0;
+int failed = 0;
+#define CHECK(value) do { \
+    if (value) ++passed; \
+    else { ++failed; std::printf("FAIL line %d: %s\n", __LINE__, #value); } \
+} while (false)
+
+constexpr double kQuantity = 891538.56;
+Bar bar(int i, double open, double high, double low, double close) {
+    Bar out;
+    out.timestamp = 1749754800000LL + i * 900000LL;
+    out.open = open; out.high = high; out.low = low; out.close = close;
+    out.volume = 1.0;
+    return out;
+}
+std::vector<Bar> bars() {
+    return {
+        bar(0, 1.15776, 1.15798, 1.15754, 1.15798),
+        bar(1, 1.15798, 1.15808, 1.15760, 1.15761),
+        bar(2, 1.15762, 1.15798, 1.15748, 1.15788),
+        bar(3, 1.15788, 1.15804, 1.15762, 1.15762),
+    };
+}
+class ResidualProbe : public BacktestEngine {
+public:
+    ResidualProbe(double capital, bool enabled = true, double realized = 0.0,
+                  double quantity = kQuantity, bool unbounded = false)
+        : realized_(realized), quantity_(quantity), unbounded_(unbounded) {
+        initial_capital_ = capital;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        pyramiding_ = 0;
+        commission_type_ = CommissionType::PERCENT;
+        commission_value_ = 0.0;
+        margin_long_ = margin_short_ = 100.0;
+        process_orders_on_close_ = false;
+        calc_on_order_fills_ = false;
+        slippage_ = 0;
+        syminfo_.pointvalue = 1.0;
+        set_syminfo_mintick(0.00001);
+        qty_step_ = 0.01;
+        set_margin_call_enabled(enabled);
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            // Initialize equivalent closed ledgers before any opening order.
+            // The synthetic prior PnL isolates numerical representation from
+            // the broker decisions that produced it.
+            net_profit_sum_ = realized_;
+            if (unbounded_)
+                net_profit_roundoff_bound_ = std::numeric_limits<double>::infinity();
+            const double na = std::numeric_limits<double>::quiet_NaN();
+            strategy_entry("L", true, na, na, quantity_);
+        }
+        if (bar_index_ == 1) strategy_close("L", "survivor");
+    }
+    const std::vector<Trade>& closed() const { return trades_; }
+private:
+    double realized_;
+    double quantity_;
+    bool unbounded_;
+};
+
+void check_capital(double capital, bool expects_call, bool enabled = true,
+                   double realized = 0.0, bool unbounded = false) {
+    ResidualProbe engine(capital, enabled, realized, kQuantity, unbounded);
+    const auto input = bars();
+    engine.run(input.data(), static_cast<int>(input.size()));
+    const auto& closed = engine.closed();
+    std::printf("capital %.10f enabled %d: %zu trades\n", capital, enabled, closed.size());
+    CHECK(closed.size() == (expects_call ? 2U : 1U));
+    if (closed.size() != (expects_call ? 2U : 1U)) return;
+    if (expects_call) {
+        const auto& call = closed[0];
+        CHECK(call.exit_comment == "Margin call");
+        CHECK(std::abs(call.qty - 1.0) < 1e-9);
+        CHECK(call.entry_time == input[1].timestamp);
+        CHECK(call.exit_time == input[1].timestamp);
+        CHECK(std::abs(call.entry_price - 1.15798) < 1e-12);
+        CHECK(std::abs(call.exit_price - 1.15808) < 1e-12);
+    }
+    const auto& survivor = closed.back();
+    CHECK(survivor.exit_comment == "survivor");
+    CHECK(survivor.exit_time == input[2].timestamp);
+    CHECK(std::abs(survivor.qty - (kQuantity - (expects_call ? 1.0 : 0.0))) < 1e-6);
+    CHECK(std::abs(survivor.exit_price - 1.15762) < 1e-12);
+}
+
+// Exercise the actual realized-PnL writer with three exact binary64 trade
+// profits. The small middle term is lost by the existing naive accumulator;
+// its uncertainty must still protect a later exact-money tie. The live
+// position is initialized after those trades to isolate the margin checkpoint
+// from entry admission, which is a different broker contract.
+class HistoryProbe : public BacktestEngine {
+public:
+    bool with_history = true;
+    HistoryProbe() {
+        initial_capital_ = 1024.0 - std::ldexp(1.0, -24);
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1.0;
+        commission_type_ = CommissionType::PERCENT;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        pyramiding_ = 0;
+        margin_long_ = margin_short_ = 100.0;
+        syminfo_.pointvalue = 1.0;
+        set_syminfo_mintick(std::ldexp(1.0, -24));
+        qty_step_ = std::ldexp(1.0, -16);
+    }
+    void on_bar(const Bar& current) override {
+        if (bar_index_ == 0) set_margin_call_enabled(false);
+        if (with_history) {
+            const double na = std::numeric_limits<double>::quiet_NaN();
+            if (bar_index_ == 0 || bar_index_ == 2)
+                strategy_entry("H", true, na, na, 1.0);
+            if (bar_index_ == 4)
+                strategy_entry("H", false, na, na, 1.0);
+            if (bar_index_ == 1 || bar_index_ == 3 || bar_index_ == 5)
+                strategy_close("H", "history");
+        }
+        if (bar_index_ == 6) {
+            const double price = 1024.0 - std::ldexp(1.0, -21);
+            position_side_ = PositionSide::LONG;
+            position_qty_ = 1.0;
+            position_entry_count_ = 1;
+            position_entry_price_ = price;
+            position_entry_time_ = current.timestamp;
+            position_open_bar_ = bar_index_;
+            PyramidEntry entry{};
+            entry.price = price;
+            entry.qty = 1.0;
+            entry.time = current.timestamp;
+            entry.entry_id = "current";
+            entry.entry_bar_index = bar_index_;
+            entry.entry_commission_account = 0.0;
+            pyramid_entries_.push_back(entry);
+            set_margin_call_enabled(true);
+        }
+    }
+    int margin_calls() const {
+        int count = 0;
+        for (const auto& trade : trades_)
+            count += trade.exit_comment == "Margin call";
+        return count;
+    }
+    double position() const { return signed_position_size(); }
+    using BacktestEngine::net_profit;
+};
+void check_history_tie_and_reset() {
+    const double big = std::ldexp(1.0, 30);
+    const double small = std::ldexp(1.0, -24);
+    const double price = 1024.0 - std::ldexp(1.0, -21);
+    std::vector<Bar> input;
+    for (double p : {1.0, 1.0, 1.0 + big, 1.0, 1.0 + small,
+                     1.0, 1.0 + big, price, price})
+        input.push_back(bar(static_cast<int>(input.size()), p, p, p, p));
+    HistoryProbe engine;
+    engine.run(input.data(), static_cast<int>(input.size()));
+    CHECK(engine.net_profit() == 0.0);  // preserve the existing financial sum
+    CHECK(engine.trade_count() == 3);
+    CHECK(engine.margin_calls() == 0);
+    CHECK(engine.position() == 1.0);
+
+    // A new run has no vanished positive realized term, hence this same
+    // current-capital value has a real deficit. A stale error bound would
+    // falsely hide the call; reset must clear numerical provenance too.
+    engine.with_history = false;
+    engine.run(input.data(), static_cast<int>(input.size()));
+    CHECK(engine.trade_count() == 1);
+    CHECK(engine.margin_calls() == 1);
+    CHECK(engine.position() == 0.0);
+}
+void check_high_money_preserves_previous_boundary() {
+    const auto input = bars();
+    ResidualProbe deficit(103238382.21439985, true, 0.0, kQuantity * 100.0);
+    deficit.run(input.data(), static_cast<int>(input.size()));
+    CHECK(deficit.closed().size() == 2);
+    if (deficit.closed().size() == 2) {
+        CHECK(deficit.closed()[0].exit_comment == "Margin call");
+        CHECK(deficit.closed()[0].qty == 1.0);
+        CHECK(std::abs(deficit.closed()[0].exit_price - 1.15808) < 1e-12);
+    }
+    ResidualProbe funded(103238382.2144001, true, 0.0, kQuantity * 100.0);
+    funded.run(input.data(), static_cast<int>(input.size()));
+    CHECK(funded.closed().size() == 1);
+    if (funded.closed().size() == 1)
+        CHECK(funded.closed()[0].exit_comment == "survivor");
+}
+
+class OrdinaryHistoryProbe : public ResidualProbe {
+    bool injected_;
+public:
+    explicit OrdinaryHistoryProbe(bool injected)
+        : ResidualProbe(1032383.8221439 - 0.25 - (injected ? 100.0 : 0.0)),
+          injected_(injected) {}
+    void on_bar(const Bar&) override {
+        const double na = std::numeric_limits<double>::quiet_NaN();
+        if (bar_index_ == 0) {
+            if (injected_) net_profit_sum_ = 100.0;
+            strategy_entry("H", true, na, na, 1.0);
+        }
+        if (bar_index_ == 1) strategy_close("H", "ordinary history");
+        if (bar_index_ == 2) strategy_entry("L", true, na, na, kQuantity);
+        if (bar_index_ == 3) strategy_close("L", "survivor");
+    }
+};
+void check_ordinary_and_untracked_history() {
+    const std::vector<Bar> input = {
+        bar(0, 1.0, 1.0, 1.0, 1.0),
+        bar(1, 1.0, 1.0, 1.0, 1.0),
+        bar(2, 1.25, 1.25, 1.15798, 1.15798),
+        bar(3, 1.15798, 1.15808, 1.15760, 1.15761),
+        bar(4, 1.15762, 1.15798, 1.15748, 1.15788),
+    };
+    for (bool injected : {false, true}) {
+        OrdinaryHistoryProbe engine(injected);
+        engine.run(input.data(), static_cast<int>(input.size()));
+        const auto& closed = engine.closed();
+        CHECK(closed.size() == (injected ? 2U : 3U));
+        if (closed.size() != (injected ? 2U : 3U)) continue;
+        CHECK(closed.front().pnl == 0.25);
+        CHECK(closed.front().exit_comment == "ordinary history");
+        if (!injected) {
+            CHECK(closed[1].exit_comment == "Margin call");
+            CHECK(closed[1].qty == 1.0);
+            CHECK(std::abs(closed[1].exit_price - 1.15808) < 1e-12);
+        }
+        CHECK(closed.back().exit_comment == "survivor");
+    }
+}
+}
+int main() {
+    check_capital(1032383.8221439, true);   // real 1e-7 deficit at the high
+    check_capital(1032383.8221438, true);   // 2e-7 deficit
+    check_capital(1032383.8221440, false);  // exact mathematical tie
+    check_capital(1032383.8221441, false);  // positive coverage
+    check_capital(1032383.8221449, false);  // wider positive coverage
+    check_capital(1032383.8221439, false, false);
+
+    // Equal current equity must make the same decision whether it is the
+    // initial balance or follows a large realized loss. Scaling roundoff by
+    // raw historical capital incorrectly suppressed the split-ledger call.
+    const double initial = 1e9;
+    const double loss = 1032383.8221436 - initial;
+    check_capital(initial + loss, true);
+    check_capital(initial, true, true, loss);
+    const double funded_loss = 1032383.8221445 - initial;
+    check_capital(initial + funded_loss, false);
+    check_capital(initial, false, true, funded_loss);
+    check_history_tie_and_reset();
+    check_high_money_preserves_previous_boundary();
+    check_ordinary_and_untracked_history();
+    check_capital(1032383.8221439 - 1.0, false, true, 1.0);
+    check_capital(1032383.8221439, false, true, 0.0, true);
+    std::printf("small money residual: %d passed / %d failed\n", passed, failed);
+    return failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
A fixed floating-point guard in long-margin checks could hide a real small deficit and delay TradingView's one-contract liquidation, changing subsequent trades.

Track rounding lost by additions to realized PnL in separate numerical-history fields. Use that bound to narrow the margin comparison only when the current calculation and tracked history support it. The financial ledger addition and PnL/equity formulas remain unchanged. Uncertain or mismatched histories, fees, multiple live lots and large values retain the previous comparison. Eligibility uses broker data and numerical history, with no strategy, symbol, date, or benchmark-ID conditions.

Update the README with the measured round 27 scoreboard, lane counts, verifier totals, and 220-test inventory.

Validation on final `96bababc757116841f0f4f002300e54055d1678b`:

- All **4,190 probes** measured on Cloud Run: **4,170 excellent / 20 strong / zero moderate**. Interakktive EUR becomes excellent; the other **4,189 canonical results are identical**. Zero errors, coverage gaps, or regressions.
- Target matching improves **97.7% → 100%**, count gap **7 → 0**, and PnL p90 **0.0008 → 0.0006**. The existing terminal open-position mark is handled separately by the unchanged verifier.
- Five covered TradingView controls establish the real-deficit versus exact-tie/funded boundary. Regression fixtures also cover historical cancellation, high values, tracked-value provenance, and run reuse. Earlier audit findings are corrected and retained in the evidence.
- **220/220 tests pass**, including 108 focused assertions; C ABI and build freshness pass. Independent Codex component audit and Grok 4.6 high review of the exact final commit report **P0/P1/P2 = 0**.
- Formal Cloud Run gate `pineforge-pr-gate-jm8bb`: **PASS**, target score **+1**, all **704 hard probes** unchanged with zero tolerated exceptions. Snapshot: `085183f809a0f27e1eeacb10e2e5f70215bda88d7c8437248581aba355c8b1b7`.

Codegen remains `3fd97fe28abd7b191cb376d9f5db4e056fcfae4b`. Grading metrics, verifier, harness, population, tapes, and FX policy are unchanged.
