### PR TITLE
fix: settle integer short margin events before script evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 TradingView's strategy tester is the reference every Pine author trusts, and nothing outside TradingView reproduced it — until now. PineForge is a C++17 runtime with a stable C ABI that runs PineScript v6 strategies exactly the way TradingView's broker emulator does: same fills, same sizing, same margin calls, same trailing stops, same `request.security()` buckets, on any OHLCV you give it, in microseconds per bar.
 
-- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,170 excellent, 20 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,198 matched by the verifier.
+- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,171 excellent, 19 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,219 matched by the verifier.
 - **Open.** Engine, transpiler, corpus, benchmarks and the validation tooling are all public and Apache-2.0. The only thing you cannot download is the closed test set, because TradingView's Terms of Service forbid redistributing community scripts.
 - **Fast.** In-process, no interpreter: median **162× faster than PyneCore** on 99 timed strategies. Parameter sweeps re-run a loaded `.so` with new inputs — no recompile, no fork.
 - **Deterministic to the bit.** Two runs with the same inputs produce identical trade lists. Same on Linux and macOS.
@@ -108,16 +108,16 @@ Every PineForge-compiled strategy `.so` exports this same ABI — write the harn
 
 ## Validation scoreboard
 
-**Round 27 · 2026-09-07:** **4,170 excellent / 20 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
+**Round 28 · 2026-09-07:** **4,171 excellent / 19 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
 
 | Board | Test set | Result | TradingView trades evaluated |
 |---|---|---|---|
 | **Public** — [open corpus](https://github.com/pineforge-4pass/pineforge-corpus) | 312 reference strategies, Apache-2.0, reproducible by anyone | **309/309 graded excellent** (ETH/USDT-perp 15m; the corpus' declared engine-only / anomaly probes are not graded) | 429,866 |
-| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,861 excellent + 20 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
+| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,862 excellent + 19 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
 
-**2,819,967 TradingView trades** evaluated, **2,817,198 matched by the verifier** (99.90%), from the round 27 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
+**2,819,967 TradingView trades** evaluated, **2,817,219 matched by the verifier** (99.90%), from the round 28 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
 
-Round 27 improves the EUR/USD 15m **Market Adaptive Trend [Interakktive]** strategy from strong to excellent, with **100% trade matching and zero count gap**. The engine tracks realized-profit summation error separately so a real small margin deficit is no longer swallowed by a fixed numerical guard. Financial PnL and equity formulas remain unchanged; uncertain histories retain the previous comparison. The fix uses shared broker data and numerical history, with no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
+Round 28 improves the Ford (NYSE:F) 15m **Trendline and Horizontal Breakout [Rhyme17]** strategy from strong to excellent, with **100% trade matching and zero count gap**. The engine settles completed integer short margin events and their revived exits before the script evaluates replacement orders, so those orders read the current position state. Existing margin arithmetic and fill prices are unchanged. The fix uses broker position and order ownership, with no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
 
 ### The closed test, lane by lane
 
@@ -133,12 +133,12 @@ Round 27 improves the EUR/USD 15m **Market Adaptive Trend [Interakktive]** strat
 | NASDAQ:AAPL · 15m | 356 | 354 | 2 | — |
 | NSE:NIFTY · 15m | 191 | 190 | 1 | — |
 | NSE:NIFTY · 1D | 145 | 145 | — | — |
-| NYSE:F · 15m | 340 | 335 | 5 | — |
+| NYSE:F · 15m | 340 | 336 | 4 | — |
 | NYSE:F · 1D | 263 | 263 | — | — |
 | OANDA:EURUSD · 15m | 373 | 366 | 7 | — |
 | OANDA:XAUUSD · 15m | 376 | 374 | 2 | — |
 | OANDA:XAUUSD · 1D | 248 | 248 | — | — |
-| **Total** | **3,881** | **3,861** | **20** | **0** |
+| **Total** | **3,881** | **3,862** | **19** | **0** |
 
 ### How a probe is graded
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Prefer zero install? The hosted server at **[mcp.pineforge.dev/mcp](https://mcp.
 git clone https://github.com/pineforge-4pass/pineforge-engine.git && cd pineforge-engine
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
-ctest --test-dir build --output-on-failure     # 220 tests
+ctest --test-dir build --output-on-failure     # 221 tests
 bash tutorial/run.sh                            # MACD on BTC/USDT, end to end
 python3 tutorial/run_stream.py                  # OHLCV warm-up → realtime trades
 ```
@@ -190,7 +190,7 @@ PyneCore's 15 non-excellent strategies involve `strategy.exit(stop=…, limit=�
 - `libpineforge.a` — the static runtime: order matching and fills, sizing and margin, the bar magnifier, 66 indicator classes, `request.security()`, time and session math.
 - `<pineforge/pineforge.h>` — the public C ABI, the stability-pinned consumer surface.
 - `<pineforge/*.hpp>` — internal C++ headers the transpiler emits against (not part of the stability guarantee).
-- 220 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
+- 221 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
 - `corpus/` — the 312-strategy public validation corpus (submodule).
 - `benchmarks/` — the three-way comparison harness and the throughput package.
 - `scripts/` — `run_corpus.sh`, `verify_corpus.py`, `run_strategy.py` (load any `.so` via ctypes), `regen_corpus_cpp.sh`, `coverage.sh`.
@@ -244,7 +244,7 @@ src/                    26 .cpp files split by concern
   ├── ta_*.cpp                        66 indicator classes (moving averages, oscillators,
   │                                   volatility/trend, extremes/volume, misc)
   └── magnifier / matrix / session_time / timeframe / timezone / math / str_utils
-tests/                  220 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
+tests/                  221 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
 corpus/                 public submodule: 312 strategies + the 1-minute feed and derived 15m bars
 benchmarks/             three-way comparison harness, throughput package, results/
 scripts/                run_corpus.sh, verify_corpus.py, run_strategy.py, regen_corpus_cpp.sh, coverage.sh

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1905,8 +1905,8 @@ protected:
     // adverse-price liquidation; only an eligible one-shot post-fill
     // affordability event can trim it.
     void process_margin_call(const Bar& bar);
-    // Ordinary sub-contract shorts expose completed liquidation to the
-    // close-time script (R23 opening and carried-position TV controls).
+    // Ordinary subcontract shorts and integer MARKET lots expose completed
+    // liquidation to the close-time script (R23/R25/R28 TV controls).
     void process_short_margin_before_script(const Bar& bar);
     // An unchanged carried POOC short finishes its adverse-path margin event
     // before the close script observes or reverses it. The caller proves no

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -1014,6 +1014,10 @@ bool BacktestEngine::entry_bar_post_fill_adverse(const Bar& bar,
 // R25 covered controls extend this ordering to a flat-born pure STOP entry
 // actually filled at the open. One other pure STOP that never touched the
 // broker's bar cannot postpone liquidation and retains its pending lifetime.
+// R28 integer MARKET controls expose both opening and carried liquidation to
+// the script too. An owned priced bracket killed by this bar's opening
+// declined reversal may revive at that margin event; settle that existing
+// broker path before the script can build a replacement from the dead average.
 void BacktestEngine::process_short_margin_before_script(const Bar& bar) {
     if (!margin_call_enabled_ || position_side_ != PositionSide::SHORT
         || process_orders_on_close_ || calc_on_order_fills_
@@ -1022,8 +1026,8 @@ void BacktestEngine::process_short_margin_before_script(const Bar& bar) {
         || position_open_bar_ < 0 || position_open_bar_ > bar_index_
         || bar.timestamp != current_bar_.timestamp
         || pending_orders_.size() > 1
-        || !(position_qty_ > 0.0 && position_qty_ <= 1.0)
-        || !(qty_step_ > 0.0 && qty_step_ < 1.0)
+        || !(position_qty_ > 0.0) || !std::isfinite(position_qty_)
+        || !(qty_step_ > 0.0) || !std::isfinite(qty_step_)
         || pyramiding_ < 0 || pyramiding_ > 1
         || position_entry_count_ != 1 || pyramid_entries_.size() != 1
         || !(pyramid_entries_.front().ordinary_market_open
@@ -1039,6 +1043,15 @@ void BacktestEngine::process_short_margin_before_script(const Bar& bar) {
         || last_margin_call_event_bar_ == bar_index_) {
         return;
     }
+    const bool fractional_subcontract = qty_step_ < 1.0 && position_qty_ <= 1.0;
+    // Keep STOP-origin coverage at its R25 subcontract scope. The new
+    // integer path requires an ordinary MARKET lot on the instrument grid.
+    const bool integer_market = qty_step_ >= 1.0
+        && pyramid_entries_.front().ordinary_market_open
+        && qty_step_ == std::floor(qty_step_)
+        && position_qty_ == std::floor(position_qty_)
+        && position_qty_ == std::round(position_qty_ / qty_step_) * qty_step_;
+    if (!fractional_subcontract && !integer_market) return;
     for (const auto& order : pending_orders_) {
         if (order.type == OrderType::ENTRY
             && pyramid_entries_.front().ordinary_stop_open) {
@@ -1070,13 +1083,26 @@ void BacktestEngine::process_short_margin_before_script(const Bar& bar) {
             }
             continue;
         }
-        // Other entries/closes, foreign/global brackets, and dormant or
-        // trailing lifecycles keep their scheduling. The order kernel has
-        // already evaluated this ordinary own priced bracket over the bar;
-        // if it filled, the resulting position is what we see here.
+        // Only the current opening-decline stamp establishes that this
+        // dormant bracket predates the script. Unknown/old dormancy and
+        // close-time holds/reissues retain their existing scheduler.
+        const bool opening_decline_bracket = integer_market
+            && order.dormant_reversal_kill_bar == bar_index_
+            && order.dormant_hold_bar == -1
+            && !order.dormant_reissue_pending
+            && std::isnan(order.trail_offset)
+            && std::isfinite(order.stop_price)
+            && (std::isnan(order.qty)
+                ? order.qty_percent >= 100.0 - internal::kFullPercentEps
+                : std::isfinite(order.qty) && order.qty >= position_qty_);
+        // Other entries/closes, foreign/global and trailing brackets retain
+        // their scheduling. A live own priced bracket already had its order
+        // pass; a dormant opening-decline bracket may revive only if the
+        // unchanged margin machinery actually records a liquidation.
         if (order.type != OrderType::EXIT
             || order.from_entry != pyramid_entries_.front().entry_id
-            || order.dormant_bracket || order.dormant_reissue_pending
+            || (order.dormant_bracket && !opening_decline_bracket)
+            || order.dormant_reissue_pending
             || !std::isnan(order.trail_points)
             || !std::isnan(order.trail_price)
             || (!std::isfinite(order.limit_price)

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -1093,7 +1093,8 @@ void BacktestEngine::process_short_margin_before_script(const Bar& bar) {
             && std::isnan(order.trail_offset)
             && std::isfinite(order.stop_price)
             && (std::isnan(order.qty)
-                ? order.qty_percent >= 100.0 - internal::kFullPercentEps
+                ? std::isfinite(order.qty_percent)
+                    && order.qty_percent >= 100.0 - internal::kFullPercentEps
                 : std::isfinite(order.qty) && order.qty >= position_qty_);
         // Other entries/closes, foreign/global and trailing brackets retain
         // their scheduling. A live own priced bracket already had its order

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    test_integer_short_margin_state
     test_stop_open_margin_script_state
     test_carried_pooc_short_margin_state
     test_pooc_flat_signal_cost

--- a/tests/test_integer_short_margin_state.cpp
+++ b/tests/test_integer_short_margin_state.cpp
@@ -1,0 +1,299 @@
+// R28 covered TV controls: integer short margin events, including a bracket
+// revived after an opening declined reversal, precede close-time script state.
+// Evidence: r28-killed-dynamic, r28-killed-explicit-child, r28-killed-funded,
+// carried-half, opening-half and r28-unit-carried-high-state campaign tapes.
+// The last one's TV CSV SHA is
+// eb3a2e2fd74a9a56560b0525ff56126aa085d6117798fc49dfe0b8247cd14db1.
+// These compact command fixtures use synthetic timestamps, fixed distances,
+// and a short bar sequence; they do not run a corpus strategy or a verifier.
+#include <pineforge/engine.hpp>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+constexpr double qnan = std::numeric_limits<double>::quiet_NaN();
+int passed = 0, failed = 0;
+#define CHECK(x) do { if (x) ++passed; else { ++failed; std::printf("FAIL %d %s\n", __LINE__, #x); } } while (0)
+bool near(double a, double b) { return std::abs(a - b) < 1e-7; }
+
+enum class Mode { OPENING_HALF, CARRIED_HALF, DYNAMIC, EXPLICIT, UNIT };
+class IntegerScript : public BacktestEngine {
+public:
+    Mode mode;
+    double opening_view = qnan, carried_view = qnan, carried_average = qnan;
+    double carried_balance = qnan;
+    std::size_t carried_closed = 0;
+    explicit IntegerScript(Mode value, double capital = 10315.59)
+        : mode(value) {
+        initial_capital_ = capital;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100.0;
+        qty_step_ = 1.0;
+        syminfo_mintick_ = 0.01;
+        syminfo_.pointvalue = 1.0;
+        margin_short_ = 100.0;
+        margin_long_ = mode == Mode::UNIT ? 50.0 : 100.0;
+        pyramiding_ = 0;
+    }
+    void reverse(double distance) {
+        const double average = signed_position_size() == 0.0
+            ? qnan : position_entry_price_;
+        strategy_entry("L", true);
+        if (mode == Mode::EXPLICIT && bar_index_ == 2) {
+            strategy_exit("XL", "L", 10.63, 10.49);
+        } else {
+            strategy_exit("XL", "L", average + 2.0 * distance, average - distance);
+        }
+        strategy_exit("XS", "S", average - 2.0 * distance, average + distance);
+        strategy_close("S");
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) strategy_entry("S", false, qnan, qnan, mode == Mode::UNIT ? 1.0 : 991.0);
+        if (bar_index_ == 1) {
+            opening_view = signed_position_size();
+            if (mode == Mode::OPENING_HALF) strategy_close("S", "half", std::floor(-opening_view / 2.0));
+            if (mode == Mode::DYNAMIC || mode == Mode::EXPLICIT) reverse(0.034233333969624);
+        }
+        if (bar_index_ == 2) {
+            carried_view = signed_position_size();
+            carried_average = carried_view == 0.0 ? qnan : position_entry_price_;
+            carried_balance = current_equity();
+            carried_closed = trades_.size();
+            if (mode == Mode::CARRIED_HALF) strategy_close("S", "half", std::floor(-carried_view / 2.0));
+            if (mode == Mode::DYNAMIC || mode == Mode::EXPLICIT) reverse(0.040359524400365);
+            if (mode == Mode::UNIT) strategy_entry("Observer", true, qnan, qnan, 1.0);
+        }
+        if (signed_position_size() > 0.0 && bar_index_ >= 3 && mode != Mode::UNIT) {
+            strategy_exit("XL", "L", 10.63, 10.49);
+        }
+        if (bar_index_ == 5) strategy_close_all();
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+};
+
+const std::vector<Bar> bars = {
+    {10.415, 10.415, 10.39, 10.395, 1, 1000},
+    {10.395, 10.44, 10.38, 10.44, 1, 2000},
+    {10.50, 10.56, 10.49, 10.54, 1, 3000},
+    {10.535, 10.60, 10.535, 10.56, 1, 4000},
+    {10.565, 10.61, 10.56, 10.605, 1, 5000},
+    {10.605, 10.66, 10.605, 10.645, 1, 6000},
+    {10.61, 10.61, 10.61, 10.61, 1, 7000},
+};
+
+void test_revival_precedes_replacement_script() {
+    for (Mode mode : {Mode::DYNAMIC, Mode::EXPLICIT}) {
+        IntegerScript engine(mode);
+        engine.run(bars.data(), static_cast<int>(bars.size()));
+        CHECK(near(engine.opening_view, -967.0));
+        CHECK(near(engine.carried_view, 0.0));
+        CHECK(std::isnan(engine.carried_average));
+        CHECK(near(engine.carried_balance, 10159.91));
+        CHECK(engine.carried_closed == 3);
+        CHECK(engine.rows().size() == 4);
+        if (engine.rows().size() != 4) continue;
+        CHECK(engine.rows()[0].exit_id == "__margin_call__");
+        CHECK(near(engine.rows()[0].qty, 24.0));
+        CHECK(near(engine.rows()[0].exit_price, 10.44));
+        CHECK(engine.rows()[1].exit_id == "__margin_call__");
+        CHECK(near(engine.rows()[1].qty, 16.0));
+        CHECK(engine.rows()[1].exit_time == 3000);
+        CHECK(near(engine.rows()[1].exit_price, 10.56));
+        CHECK(engine.rows()[2].exit_id == "XS");
+        CHECK(near(engine.rows()[2].qty, 951.0));
+        CHECK(engine.rows()[2].exit_time == 3000);
+        CHECK(near(engine.rows()[2].exit_price, 10.56));
+        CHECK(engine.rows()[3].entry_time == 4000);
+        CHECK(near(engine.rows()[3].qty, 963.0));
+        CHECK(near(engine.rows()[3].entry_price, 10.54));
+        CHECK(engine.rows()[3].exit_id == "XL");
+        CHECK(engine.rows()[3].exit_time == 6000);
+        CHECK(near(engine.rows()[3].exit_price, 10.63));
+    }
+}
+
+void test_partial_state_and_funded_control() {
+    for (Mode mode : {Mode::OPENING_HALF, Mode::CARRIED_HALF}) {
+        IntegerScript engine(mode);
+        engine.run(bars.data(), static_cast<int>(bars.size()));
+        CHECK(near(engine.opening_view, -967.0));
+        CHECK(engine.rows().size() == (mode == Mode::OPENING_HALF ? 3 : 4));
+        if (mode == Mode::CARRIED_HALF) CHECK(near(engine.carried_view, -951.0));
+        bool found_half = false;
+        for (const auto& trade : engine.rows()) {
+            if (trade.exit_comment != "half") continue;
+            found_half = true;
+            CHECK(near(trade.qty, mode == Mode::OPENING_HALF ? 483.0 : 475.0));
+        }
+        CHECK(found_half);
+    }
+    IntegerScript funded(Mode::DYNAMIC, 11315.59);
+    funded.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(near(funded.opening_view, -991.0));
+    CHECK(near(funded.carried_view, -991.0));
+    CHECK(funded.carried_closed == 0);
+    CHECK(funded.rows().size() == 2);
+    if (funded.rows().size() != 2) return;
+    CHECK(funded.rows()[0].exit_time == 4000);
+    CHECK(near(funded.rows()[0].qty, 991.0));
+    CHECK(funded.rows()[1].entry_time == 4000);
+    CHECK(funded.rows()[1].exit_time == 4000);
+    CHECK(funded.rows()[1].exit_id == "XL");
+    CHECK(near(funded.rows()[1].qty, 1060.0));
+}
+
+void test_one_unit_adverse_high() {
+    for (double capital : {10.4, 10.5, 10.6}) {
+        IntegerScript engine(Mode::UNIT, capital);
+        engine.run(bars.data(), static_cast<int>(bars.size()));
+        CHECK(near(engine.opening_view, capital == 10.4 ? 0.0 : -1.0));
+        CHECK(near(engine.carried_view, 0.0));
+        CHECK(engine.carried_closed == 1);
+        CHECK(engine.rows().size() == 2);
+        if (engine.rows().size() != 2) continue;
+        CHECK(engine.rows()[0].exit_id == "__margin_call__");
+        CHECK(near(engine.rows()[0].qty, 1.0));
+        CHECK(engine.rows()[0].exit_time == (capital == 10.4 ? 2000 : 3000));
+        CHECK(near(engine.rows()[0].exit_price,
+                   capital == 10.4 ? 10.44 : (capital == 10.5 ? 10.50 : 10.56)));
+    }
+}
+
+// Broker snapshots exercise the lifetime boundary independently of the
+// strategy command sequence: an unknown/old/held/reissued/trailing dormant
+// bracket must keep its old scheduler, as must integer STOP-origin books.
+enum class Shape { CURRENT, UNKNOWN, OLD, FUTURE, HELD, OLD_HOLD, REISSUED, TRAIL,
+                   FOREIGN, GLOBAL, UNPRICED, STOP_ORIGIN, OFF_GRID, BIG_STEP,
+                   LIMIT_ONLY, PARTIAL, COARSE_FRACTIONAL, TRAIL_OFFSET, NAKED,
+                   PENDING_ENTRY };
+class DormantCheckpoint : public BacktestEngine {
+public:
+    explicit DormantCheckpoint(Shape shape) {
+        initial_capital_ = 10000.0;
+        current_bar_ = {100.0, 102.0, 99.0, 100.0, 1, 2000};
+        bar_index_ = 1;
+        position_open_bar_ = 0;
+        position_side_ = PositionSide::SHORT;
+        position_qty_ = 100.0;
+        position_entry_price_ = 100.0;
+        position_entry_time_ = 1000;
+        position_entry_count_ = 1;
+        position_cycle_seq_ = 1;
+        qty_step_ = shape == Shape::BIG_STEP ? 2.0 : 1.0;
+        syminfo_mintick_ = 0.01;
+        syminfo_.pointvalue = 1.0;
+        PyramidEntry entry{};
+        entry.price = 100.0;
+        entry.qty = position_qty_;
+        entry.time = 1000;
+        entry.entry_id = "S";
+        entry.entry_bar_index = 0;
+        entry.entry_incarnation = 7;
+        entry.ordinary_market_open = true;
+        pyramid_entries_.push_back(entry);
+        cycle_filled_entry_ids_.insert("S");
+        PendingOrder order{};
+        order.id = "XS";
+        order.type = OrderType::EXIT;
+        order.from_entry = "S";
+        order.limit_price = order.trail_points = order.trail_offset = order.qty = qnan;
+        order.qty_percent = 100.0;
+        order.stop_price = 101.0;
+        // Snapshot of the private opening-decline producer. The command
+        // fixture above separately exercises that producer through orders.
+        order.dormant_bracket = true;
+        order.dormant_reversal_kill_bar = bar_index_;
+        order.dormant_hold_bar = -1;
+        order.dormant_reissue_pending = false;
+        pending_orders_.push_back(order);
+        auto& owned = pending_orders_.front();
+        switch (shape) {
+        case Shape::UNKNOWN: owned.dormant_reversal_kill_bar = -1; break;
+        case Shape::OLD: owned.dormant_reversal_kill_bar = 0; break;
+        case Shape::FUTURE: owned.dormant_reversal_kill_bar = 2; break;
+        case Shape::HELD: owned.dormant_hold_bar = 1; break;
+        case Shape::OLD_HOLD: owned.dormant_hold_bar = 0; break;
+        case Shape::REISSUED: owned.dormant_reissue_pending = true; break;
+        case Shape::TRAIL: owned.trail_price = 100.5; break;
+        case Shape::FOREIGN: owned.from_entry = "Other"; break;
+        case Shape::GLOBAL: owned.from_entry.clear(); break;
+        case Shape::UNPRICED: owned.stop_price = qnan; break;
+        case Shape::STOP_ORIGIN:
+            pyramid_entries_[0].ordinary_market_open = false;
+            pyramid_entries_[0].ordinary_stop_open = true;
+            break;
+        case Shape::OFF_GRID: position_qty_ = pyramid_entries_[0].qty = 100.5; break;
+        case Shape::LIMIT_ONLY: owned.stop_price = qnan; owned.limit_price = 98.0; break;
+        case Shape::PARTIAL: owned.qty = 50.0; owned.requested_partial = true; break;
+        case Shape::COARSE_FRACTIONAL:
+            qty_step_ = 1.5;
+            position_qty_ = pyramid_entries_[0].qty = 100.5;
+            break;
+        case Shape::TRAIL_OFFSET: owned.trail_offset = 1.0; break;
+        case Shape::PENDING_ENTRY:
+            owned.type = OrderType::ENTRY;
+            owned.stop_price = 110.0;
+            owned.dormant_bracket = false;
+            break;
+        case Shape::NAKED: pending_orders_.clear(); break;
+        default: break;
+        }
+    }
+    void on_bar(const Bar&) override {}
+    void checkpoint() { process_short_margin_before_script(current_bar_); }
+    void late_margin() { process_margin_call(current_bar_); }
+    const std::vector<Trade>& rows() const { return trades_; }
+    double quantity() const { return position_qty_; }
+    std::size_t pending() const { return pending_orders_.size(); }
+};
+
+void test_dormant_lifetime_boundary() {
+    for (Shape shape : {Shape::CURRENT, Shape::BIG_STEP}) {
+        DormantCheckpoint owned(shape);
+        owned.checkpoint();
+        CHECK(owned.rows().size() == 2);
+        CHECK(owned.quantity() == 0.0);
+        CHECK(owned.pending() == 0);
+        if (owned.rows().size() != 2) continue;
+        CHECK(owned.rows()[0].exit_id == "__margin_call__");
+        CHECK(near(owned.rows()[0].qty, shape == Shape::CURRENT ? 12.0 : 8.0));
+        CHECK(owned.rows()[1].exit_id == "XS");
+        CHECK(near(owned.rows()[0].exit_price, 102.0));
+        CHECK(near(owned.rows()[1].exit_price, 102.0));
+        owned.late_margin();
+        CHECK(owned.rows().size() == 2);
+    }
+    for (Shape shape : {Shape::UNKNOWN, Shape::OLD, Shape::FUTURE, Shape::HELD,
+                        Shape::OLD_HOLD, Shape::REISSUED, Shape::TRAIL,
+                        Shape::FOREIGN, Shape::GLOBAL, Shape::UNPRICED,
+                        Shape::STOP_ORIGIN, Shape::OFF_GRID, Shape::LIMIT_ONLY,
+                        Shape::PARTIAL, Shape::COARSE_FRACTIONAL,
+                        Shape::TRAIL_OFFSET, Shape::PENDING_ENTRY}) {
+        DormantCheckpoint other(shape);
+        const double before = other.quantity();
+        other.checkpoint();
+        CHECK(other.rows().empty());
+        CHECK(other.quantity() == before);
+        CHECK(other.pending() == 1);
+    }
+    DormantCheckpoint naked(Shape::NAKED);
+    naked.checkpoint();
+    CHECK(naked.rows().size() == 1);
+    CHECK(near(naked.quantity(), 88.0));
+    naked.late_margin();
+    CHECK(naked.rows().size() == 1);
+    CHECK(near(naked.quantity(), 88.0));
+}
+}
+
+int main() {
+    test_revival_precedes_replacement_script();
+    test_partial_state_and_funded_control();
+    test_one_unit_adverse_high();
+    test_dormant_lifetime_boundary();
+    std::printf("%d passed, %d failed\n", passed, failed);
+    return failed ? 1 : 0;
+}

--- a/tests/test_integer_short_margin_state.cpp
+++ b/tests/test_integer_short_margin_state.cpp
@@ -26,6 +26,7 @@ public:
     double opening_view = qnan, carried_view = qnan, carried_average = qnan;
     double carried_balance = qnan;
     std::size_t carried_closed = 0;
+    uint64_t explicit_child_incarnation = 0, filled_parent_child_incarnation = 0;
     explicit IntegerScript(Mode value, double capital = 10315.59)
         : mode(value) {
         initial_capital_ = capital;
@@ -63,10 +64,24 @@ public:
             carried_balance = current_equity();
             carried_closed = trades_.size();
             if (mode == Mode::CARRIED_HALF) strategy_close("S", "half", std::floor(-carried_view / 2.0));
-            if (mode == Mode::DYNAMIC || mode == Mode::EXPLICIT) reverse(0.040359524400365);
+            if (mode == Mode::DYNAMIC || mode == Mode::EXPLICIT) {
+                reverse(0.040359524400365);
+                if (mode == Mode::EXPLICIT) {
+                    for (const auto& order : pending_orders_) {
+                        if (order.id == "XL") explicit_child_incarnation = order.incarnation;
+                    }
+                }
+            }
             if (mode == Mode::UNIT) strategy_entry("Observer", true, qnan, qnan, 1.0);
         }
-        if (signed_position_size() > 0.0 && bar_index_ >= 3 && mode != Mode::UNIT) {
+        if (mode == Mode::EXPLICIT && bar_index_ == 3) {
+            for (const auto& order : pending_orders_) {
+                if (order.id == "XL") filled_parent_child_incarnation = order.incarnation;
+            }
+        }
+        // The EXPLICIT child must survive on its original incarnation;
+        // reissuing it here would mask a lost pending-parent bracket.
+        if (signed_position_size() > 0.0 && bar_index_ >= 3 && mode == Mode::DYNAMIC) {
             strategy_exit("XL", "L", 10.63, 10.49);
         }
         if (bar_index_ == 5) strategy_close_all();
@@ -93,6 +108,10 @@ void test_revival_precedes_replacement_script() {
         CHECK(std::isnan(engine.carried_average));
         CHECK(near(engine.carried_balance, 10159.91));
         CHECK(engine.carried_closed == 3);
+        if (mode == Mode::EXPLICIT) {
+            CHECK(engine.explicit_child_incarnation != 0);
+            CHECK(engine.filled_parent_child_incarnation == engine.explicit_child_incarnation);
+        }
         CHECK(engine.rows().size() == 4);
         if (engine.rows().size() != 4) continue;
         CHECK(engine.rows()[0].exit_id == "__margin_call__");
@@ -168,7 +187,7 @@ void test_one_unit_adverse_high() {
 enum class Shape { CURRENT, UNKNOWN, OLD, FUTURE, HELD, OLD_HOLD, REISSUED, TRAIL,
                    FOREIGN, GLOBAL, UNPRICED, STOP_ORIGIN, OFF_GRID, BIG_STEP,
                    LIMIT_ONLY, PARTIAL, COARSE_FRACTIONAL, TRAIL_OFFSET, NAKED,
-                   PENDING_ENTRY };
+                   PENDING_ENTRY, INFINITE_PERCENT };
 class DormantCheckpoint : public BacktestEngine {
 public:
     explicit DormantCheckpoint(Shape shape) {
@@ -238,6 +257,7 @@ public:
             owned.stop_price = 110.0;
             owned.dormant_bracket = false;
             break;
+        case Shape::INFINITE_PERCENT: owned.qty_percent = INFINITY; break;
         case Shape::NAKED: pending_orders_.clear(); break;
         default: break;
         }
@@ -271,7 +291,7 @@ void test_dormant_lifetime_boundary() {
                         Shape::FOREIGN, Shape::GLOBAL, Shape::UNPRICED,
                         Shape::STOP_ORIGIN, Shape::OFF_GRID, Shape::LIMIT_ONLY,
                         Shape::PARTIAL, Shape::COARSE_FRACTIONAL,
-                        Shape::TRAIL_OFFSET, Shape::PENDING_ENTRY}) {
+                        Shape::TRAIL_OFFSET, Shape::PENDING_ENTRY, Shape::INFINITE_PERCENT}) {
         DormantCheckpoint other(shape);
         const double before = other.quantity();
         other.checkpoint();

--- a/tests/test_short_margin_script_state.cpp
+++ b/tests/test_short_margin_script_state.cpp
@@ -280,7 +280,8 @@ public:
         default: break;
         }
         if (scenario >= 11) {
-            PendingOrder order;
+            PendingOrder order{};
+            order.trail_points = order.trail_offset = qnan;
             order.id = "Exit";
             order.type = OrderType::EXIT;
             order.from_entry = "Short";
@@ -304,11 +305,17 @@ public:
 };
 
 void test_other_checkpoint_owners_are_untouched() {
-    CheckpointOwnership owned(0);
-    owned.checkpoint();
-    CHECK(owned.trades_count() == 1);
-    CHECK(owned.quantity() == 0.0);
+    // R28's covered one-unit opening/carried TV controls supersede the old
+    // synthetic integer exclusion: an ordinary integer MARKET book also
+    // exposes its completed margin event before the script.
+    for (int scenario : {0, 7}) {
+        CheckpointOwnership owned(scenario);
+        owned.checkpoint();
+        CHECK(owned.trades_count() == 1);
+        CHECK(owned.quantity() == 0.0);
+    }
     for (int scenario = 1; scenario <= 16; ++scenario) {
+        if (scenario == 7) continue;
         CheckpointOwnership other(scenario);
         const double quantity_before = other.quantity();
         const auto orders_before = other.pending_count();


### PR DESCRIPTION
Integer short liquidations could settle after script evaluation, leaving replacement orders priced from a position that TradingView had already closed. A declined opening reversal followed by margin liquidation and bracket revival could therefore close the replacement immediately.

Extend the existing pre-script margin checkpoint to ordinary integer MARKET positions and a narrowly proven dormant, owned stop bracket. Preserve the margin arithmetic, fill prices, fractional/STOP behavior, and order ownership guards. Add regression coverage for partial/full liquidation, funded controls, the original replacement-bracket incarnation, and dormant-order exclusions. Update the README with the measured round 28 scoreboard.

Validation on final `2a593142469070d5aa8835234b3851c9109c9c5f`:

- Cloud Run measures all **4,190 probes**: **4,171 excellent / 19 strong / zero moderate**. Ford Rhyme17 becomes excellent with **100% matching and zero count gap**; the other **4,189 canonical results are unchanged**.
- Final and preceding full sweeps have identical trade CSVs, grades, input hashes, and lane settings for all 4,190 probes. README totals: **2,817,219 matched / 2,819,967 TradingView trades**.
- **221/221 tests pass**, including 167 focused assertions; C ABI and build freshness pass. Covered TradingView controls, independent Codex audit, and exact-final Grok 4.6 high review support the change. Final Grok findings: **P0/P1/P2 = 0**.
- Formal gate `pineforge-pr-gate-r4lth`: **PASS**, target score **+1**, all **704 hard probes unchanged**, zero tolerated exceptions. Snapshot: `db73737250d1429b90e9772d20b4508b17c576b2b9b54ec257bad218d1c54636`.

Codegen remains `3fd97fe28abd7b191cb376d9f5db4e056fcfae4b`. Grading metrics, verifier, harness, population, tapes, and FX policy are unchanged. Runtime eligibility has no strategy, symbol, date, or benchmark-ID conditions.
