### PR TITLE
fix: reset filled-order limits on the broker session day

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Prefer zero install? The hosted server at **[mcp.pineforge.dev/mcp](https://mcp.
 git clone https://github.com/pineforge-4pass/pineforge-engine.git && cd pineforge-engine
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
-ctest --test-dir build --output-on-failure     # 221 tests
+ctest --test-dir build --output-on-failure     # 222 tests
 bash tutorial/run.sh                            # MACD on BTC/USDT, end to end
 python3 tutorial/run_stream.py                  # OHLCV warm-up → realtime trades
 ```
@@ -190,7 +190,7 @@ PyneCore's 15 non-excellent strategies involve `strategy.exit(stop=…, limit=�
 - `libpineforge.a` — the static runtime: order matching and fills, sizing and margin, the bar magnifier, 66 indicator classes, `request.security()`, time and session math.
 - `<pineforge/pineforge.h>` — the public C ABI, the stability-pinned consumer surface.
 - `<pineforge/*.hpp>` — internal C++ headers the transpiler emits against (not part of the stability guarantee).
-- 221 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
+- 222 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
 - `corpus/` — the 312-strategy public validation corpus (submodule).
 - `benchmarks/` — the three-way comparison harness and the throughput package.
 - `scripts/` — `run_corpus.sh`, `verify_corpus.py`, `run_strategy.py` (load any `.so` via ctypes), `regen_corpus_cpp.sh`, `coverage.sh`.
@@ -244,7 +244,7 @@ src/                    26 .cpp files split by concern
   ├── ta_*.cpp                        66 indicator classes (moving averages, oscillators,
   │                                   volatility/trend, extremes/volume, misc)
   └── magnifier / matrix / session_time / timeframe / timezone / math / str_utils
-tests/                  221 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
+tests/                  222 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
 corpus/                 public submodule: 312 strategies + the 1-minute feed and derived 15m bars
 benchmarks/             three-way comparison harness, throughput package, results/
 scripts/                run_corpus.sh, verify_corpus.py, run_strategy.py, regen_corpus_cpp.sh, coverage.sh

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 TradingView's strategy tester is the reference every Pine author trusts, and nothing outside TradingView reproduced it — until now. PineForge is a C++17 runtime with a stable C ABI that runs PineScript v6 strategies exactly the way TradingView's broker emulator does: same fills, same sizing, same margin calls, same trailing stops, same `request.security()` buckets, on any OHLCV you give it, in microseconds per bar.
 
-- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,171 excellent, 19 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,219 matched by the verifier.
+- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,172 excellent, 18 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,239 matched by the verifier.
 - **Open.** Engine, transpiler, corpus, benchmarks and the validation tooling are all public and Apache-2.0. The only thing you cannot download is the closed test set, because TradingView's Terms of Service forbid redistributing community scripts.
 - **Fast.** In-process, no interpreter: median **162× faster than PyneCore** on 99 timed strategies. Parameter sweeps re-run a loaded `.so` with new inputs — no recompile, no fork.
 - **Deterministic to the bit.** Two runs with the same inputs produce identical trade lists. Same on Linux and macOS.
@@ -108,16 +108,16 @@ Every PineForge-compiled strategy `.so` exports this same ABI — write the harn
 
 ## Validation scoreboard
 
-**Round 28 · 2026-09-07:** **4,171 excellent / 19 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
+**Round 29 · 2026-09-07:** **4,172 excellent / 18 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
 
 | Board | Test set | Result | TradingView trades evaluated |
 |---|---|---|---|
 | **Public** — [open corpus](https://github.com/pineforge-4pass/pineforge-corpus) | 312 reference strategies, Apache-2.0, reproducible by anyone | **309/309 graded excellent** (ETH/USDT-perp 15m; the corpus' declared engine-only / anomaly probes are not graded) | 429,866 |
-| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,862 excellent + 19 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
+| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,863 excellent + 18 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
 
-**2,819,967 TradingView trades** evaluated, **2,817,219 matched by the verifier** (99.90%), from the round 28 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
+**2,819,967 TradingView trades** evaluated, **2,817,239 matched by the verifier** (99.90%), from the round 29 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
 
-Round 28 improves the Ford (NYSE:F) 15m **Trendline and Horizontal Breakout [Rhyme17]** strategy from strong to excellent, with **100% trade matching and zero count gap**. The engine settles completed integer short margin events and their revived exits before the script evaluates replacement orders, so those orders read the current position state. Existing margin arithmetic and fill prices are unchanged. The fix uses broker position and order ownership, with no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
+Round 29 improves the EUR/USD 15m **Regime Execution Strategy [JOAT]** from strong to excellent, with **100% trade matching and zero count gap**. The filled-order limit now resets on the supplied symbol session clock across order placement, fills, and direct closes. Its broker day remains independent of holiday bars combined by the indicator calendar; continuous-session behavior and other risk-day rules are unchanged. The fix uses the existing symbol configuration, with no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
 
 ### The closed test, lane by lane
 
@@ -135,10 +135,10 @@ Round 28 improves the Ford (NYSE:F) 15m **Trendline and Horizontal Breakout [Rhy
 | NSE:NIFTY · 1D | 145 | 145 | — | — |
 | NYSE:F · 15m | 340 | 336 | 4 | — |
 | NYSE:F · 1D | 263 | 263 | — | — |
-| OANDA:EURUSD · 15m | 373 | 366 | 7 | — |
+| OANDA:EURUSD · 15m | 373 | 367 | 6 | — |
 | OANDA:XAUUSD · 15m | 376 | 374 | 2 | — |
 | OANDA:XAUUSD · 1D | 248 | 248 | — | — |
-| **Total** | **3,881** | **3,862** | **19** | **0** |
+| **Total** | **3,881** | **3,863** | **18** | **0** |
 
 ### How a probe is graded
 

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1698,8 +1698,8 @@ protected:
     // skipped fills past the cap, leaving the position carried open
     // across day boundaries.
     int intraday_fill_count_ = 0;
-    int intraday_day_ = -1;       // day key (dayofmonth*100+month) for reset
-    bool intraday_cap_hit_ = false;  // latched once per chart-day; reset on day rollover
+    int64_t intraday_day_ = -1;   // session day, or legacy chart-date key
+    bool intraday_cap_hit_ = false;  // latched once per broker day
     // State, not configuration: a POOC MARKET fill reached the cap at the
     // signal close and its risk-generated flatten is due at the next broker
     // boundary (the next ordinary bar open).
@@ -1710,8 +1710,23 @@ protected:
     // may inherit that already-spent slot if it survives every fill-time gate.
     uint64_t intraday_cap_pooc_close_inheritor_incarnation_ = 0;
 
+    // An explicitly timed symbol session defines the broker's trading day.
+    // Its existing clock includes DST and a supplied native daily calendar.
+    // Continuous/unconfigured sessions retain the validated chart-date clock.
+    int64_t intraday_order_day_key() const {
+        const auto& session = syminfo_.session;
+        if (session.size() >= 9 && session[4] == '-'
+            && hhmm_to_minutes(session.substr(0, 4)) >= 0
+            && hhmm_to_minutes(session.substr(5, 4)) >= 0) {
+            return session_day_index(current_bar_.timestamp,
+                                     syminfo_.timezone, session);
+        }
+        const BarTime bt = _decompose_bar_time_chart_tz();
+        return bt.dayofmonth * 100 + bt.month;
+    }
+
     // True iff the intraday cap is currently latched on the CURRENT bar's
-    // chart-day. Performs a lazy day-rollover reset so callers outside the
+    // broker day. Performs a lazy day-rollover reset so callers outside the
     // fill path (notably ``strategy_entry`` / ``strategy_order``) see a
     // consistent view: TV silently drops *order placement* during the
     // latched window in addition to dropping fills (Pine docs: "all
@@ -1726,8 +1741,7 @@ protected:
     // entries followed by mismatched cap-close exit prices below.
     bool _intraday_cap_currently_latched() {
         if (max_intraday_filled_orders_ <= 0) return false;
-        BarTime bt = _decompose_bar_time_chart_tz();
-        int cur_day = bt.dayofmonth * 100 + bt.month;
+        const int64_t cur_day = intraday_order_day_key();
         if (cur_day != intraday_day_) {
             intraday_day_ = cur_day;
             intraday_fill_count_ = 0;
@@ -2973,11 +2987,10 @@ protected:
         return bt;
     }
 
-    // Chart-timezone-aware decomposition. ONLY for intraday-day rollover
-    // gates (max_intraday_filled_orders, max_intraday_loss, consecutive
-    // loss-day tracking) — those must roll over at the chart's wall-clock
-    // 00:00, matching TV's broker emulator (which keys off the chart's
-    // display TZ, not the exchange TZ).
+    // Chart-timezone-aware decomposition for the existing loss-day clocks
+    // and the continuous/unconfigured-session order-counter fallback. The
+    // order counter on an explicitly timed session instead consumes
+    // intraday_order_day_key(), which follows the symbol's trading day.
     //
     // Falls back to plain ``_decompose_bar_time()`` (UTC) when no chart
     // timezone has been set, preserving the legacy fast path for
@@ -4390,15 +4403,10 @@ public:
     // predicates. They default to UTC / 24x7 (crypto); a data feed pushes
     // the real values via these setters before run().
     //
-    // NOTE on intraday-day rollover gates (max_intraday_filled_orders,
-    // max_intraday_loss, consecutive-loss day): these intentionally key off
-    // ``chart_timezone_`` (see ``_decompose_bar_time_chart_tz``), which is
-    // what TV's broker emulator matched on the only validated case (probe-97,
-    // crypto on a UTC+8 chart). For real-session instruments (e.g. US
-    // equities), the serving layer should set ``set_chart_timezone`` to the
-    // exchange timezone so the gate rolls over on the exchange trading day —
-    // we deliberately do NOT switch the gates to ``syminfo_.timezone`` (that
-    // would regress the crypto-on-shifted-chart case).
+    // max_intraday_filled_orders consumes a valid explicit session and this
+    // timezone through intraday_order_day_key(). Other risk-day rules keep
+    // chart_timezone_, as do continuous/unconfigured order-counter clocks;
+    // the existing crypto-on-shifted-chart contract therefore remains intact.
     void set_syminfo_timezone(const std::string& tz) { syminfo_.timezone = tz; }
     void set_syminfo_session(const std::string& s) { syminfo_.session = s; }
     // ``syminfo.type`` ("crypto" default; "forex" / "stock" / "futures" /

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1711,15 +1711,16 @@ protected:
     uint64_t intraday_cap_pooc_close_inheritor_incarnation_ = 0;
 
     // An explicitly timed symbol session defines the broker's trading day.
-    // Its existing clock includes DST and a supplied native daily calendar.
+    // Use its unmerged clock: a futures holiday D bar may span two sessions,
+    // while TradingView renews the order budget at each session's reopen.
     // Continuous/unconfigured sessions retain the validated chart-date clock.
     int64_t intraday_order_day_key() const {
         const auto& session = syminfo_.session;
         if (session.size() >= 9 && session[4] == '-'
             && hhmm_to_minutes(session.substr(0, 4)) >= 0
             && hhmm_to_minutes(session.substr(5, 4)) >= 0) {
-            return session_day_index(current_bar_.timestamp,
-                                     syminfo_.timezone, session);
+            return session_trading_day_index(current_bar_.timestamp,
+                                             syminfo_.timezone, session);
         }
         const BarTime bt = _decompose_bar_time_chart_tz();
         return bt.dayofmonth * 100 + bt.month;

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1684,14 +1684,14 @@ protected:
 
     // --- Intraday fill counter ---
     // Counts every fill processed by ``apply_filled_order_to_state`` on
-    // the current chart-day. When the count reaches
+    // the current broker day. When the count reaches
     // ``max_intraday_filled_orders_`` the engine emits TV's synthetic
     // "Close Position (Max number of filled orders in one day)" exit at
     // the cap-triggering fill's price and LATCHES (intraday_cap_hit_)
-    // until the chart-day rolls over. Once latched, ALL further fills
-    // on that chart-day are silently rejected — TV's broker emulator
-    // emits at most one cap-close per chart-day (probe 97b: 382
-    // cap-closes across 13 months of data, ~one per chart-day where
+    // until the broker day rolls over. Once latched, ALL further fills
+    // on that broker day are silently rejected — TV's broker emulator
+    // emits at most one cap-close per broker day (probe 97b: 382
+    // cap-closes across 13 months of data, ~one per day where
     // the cap fires). Pre-latch the engine recharged the counter
     // after each cap-cycle, which over-fired cap-closes (3459 engine
     // vs 1957 TV trades on probe 97b). Pre-fix-fix the engine just
@@ -1719,8 +1719,8 @@ protected:
         if (session.size() >= 9 && session[4] == '-'
             && hhmm_to_minutes(session.substr(0, 4)) >= 0
             && hhmm_to_minutes(session.substr(5, 4)) >= 0) {
-            return session_trading_day_index(current_bar_.timestamp,
-                                             syminfo_.timezone, session);
+            return internal::session_trading_day_index(current_bar_.timestamp,
+                                                       syminfo_.timezone, session);
         }
         const BarTime bt = _decompose_bar_time_chart_tz();
         return bt.dayofmonth * 100 + bt.month;

--- a/include/pineforge/timeframe.hpp
+++ b/include/pineforge/timeframe.hpp
@@ -141,6 +141,12 @@ bool tf_change(int64_t prev_ms, int64_t curr_ms, const std::string& tf,
 int64_t session_day_index(int64_t ms, const std::string& tz,
                           const std::string& session);
 
+/// Broker trading-day ordinal on the unmerged symbol session clock. A native
+/// daily bar may combine holiday sessions, but each session still renews the
+/// intraday order budget. This function never reads the native D partition.
+int64_t session_trading_day_index(int64_t ms, const std::string& tz,
+                                  const std::string& session);
+
 /// Open (Unix ms) of the symbol's D/W/M bar that contains `ms`: the day
 /// stamp of the period's first session-day (17:00 ET on OANDA 1800-1700,
 /// the session open elsewhere). CalendarPeriod::NONE returns `ms` unchanged.

--- a/include/pineforge/timeframe.hpp
+++ b/include/pineforge/timeframe.hpp
@@ -141,11 +141,13 @@ bool tf_change(int64_t prev_ms, int64_t curr_ms, const std::string& tf,
 int64_t session_day_index(int64_t ms, const std::string& tz,
                           const std::string& session);
 
+namespace internal {
 /// Broker trading-day ordinal on the unmerged symbol session clock. A native
 /// daily bar may combine holiday sessions, but each session still renews the
 /// intraday order budget. This function never reads the native D partition.
 int64_t session_trading_day_index(int64_t ms, const std::string& tz,
                                   const std::string& session);
+} // namespace internal
 
 /// Open (Unix ms) of the symbol's D/W/M bar that contains `ms`: the day
 /// stamp of the period's first session-day (17:00 ET on OANDA 1800-1700,

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -5742,8 +5742,7 @@ void BacktestEngine::apply_filled_order_to_state(
     //     1957 TV trades on 97b — 43% over-count).
     bool will_trigger_cap = false;
     if (max_intraday_filled_orders_ > 0) {
-        BarTime bt = _decompose_bar_time_chart_tz();
-        int cur_day = bt.dayofmonth * 100 + bt.month;
+        const int64_t cur_day = intraday_order_day_key();
         if (cur_day != intraday_day_) {
             intraday_day_ = cur_day;
             intraday_fill_count_ = 0;

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -5747,7 +5747,7 @@ void BacktestEngine::apply_filled_order_to_state(
         if (cur_day != intraday_day_) {
             intraday_day_ = cur_day;
             intraday_fill_count_ = 0;
-            intraday_cap_hit_ = false;  // RESET LATCH on chart-day rollover
+            intraday_cap_hit_ = false;  // Reset latch on broker-day rollover.
         }
         // A POOC close+opposite-entry reversal is split by the engine into a
         // close operation followed by a MARKET operation. Factor C counted
@@ -6422,10 +6422,10 @@ void BacktestEngine::apply_filled_order_to_state(
     // already need no synthetic close), emit TV's synthetic
     // "Close Position (Max number of filled orders in one day)" exit at
     // the same fill price, then LATCH so all subsequent fills on this
-    // chart-day are silently rejected. TV emits at most one cap-close
-    // per chart-day (probe 97b: 382 cap-closes across 13 months,
-    // ~one per chart-day where the cap fires). The latch is reset
-    // only on chart-day rollover (see top of this function).
+    // broker day are silently rejected. TV emits at most one cap-close
+    // per broker day (probe 97b: 382 cap-closes across 13 months,
+    // ~one per day where the cap fires). The latch is reset
+    // only on broker-day rollover (see top of this function).
     if (will_trigger_cap) {
         if (position_side_ != PositionSide::FLAT) {
             // Opt-in factor B is deliberately narrow: an ordinary historical

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -5717,17 +5717,18 @@ void BacktestEngine::apply_filled_order_to_state(
     // Check max_intraday_filled_orders limit.
     //
     // TV's broker emulator (LATCH-TILL-DAY-ROLLOVER semantics):
-    //   1. Track fills on the current chart-day. When the Nth fill
+    //   1. Track fills on the current broker day. When the Nth fill
     //      (== max_intraday_filled_orders) lands and the resulting
     //      position is non-flat, TV synthesises a full close at the
     //      SAME BAR / SAME FILL PRICE tagged
     //      "Close Position (Max number of filled orders in one day)".
     //   2. After the synthetic close fires, a LATCH (intraday_cap_hit_)
-    //      is set. ALL subsequent fills on that chart-day are silently
-    //      rejected — TV emits at most one cap-close per chart-day.
-    //   3. The latch (and the counter) reset only at chart-day rollover.
+    //      is set. ALL subsequent fills on that broker day are silently
+    //      rejected — TV emits at most one cap-close per broker day.
+    //   3. The latch/counter reset on the unmerged symbol session clock,
+    //      or the existing chart-date fallback for continuous sessions.
     //
-    // Verified empirically against validation probe 97b's tv_trades.csv:
+    // Verified on continuous-session probe97b's chart-day tv_trades.csv:
     //   - 382 cap-close exits across 13 months of data (~one per
     //     chart-day where the cap fires). NOT multiple per day.
     //   - cap-trigger entry + synthetic close share the same timestamp

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -1732,8 +1732,7 @@ void BacktestEngine::flush_active_same_bar_close(
             intraday_cap_pooc_close_inheritor_incarnation_ =
                 inheritor == nullptr ? 0 : inheritor->incarnation;
 
-            BarTime bt = _decompose_bar_time_chart_tz();
-            const int cur_day = bt.dayofmonth * 100 + bt.month;
+            const int64_t cur_day = intraday_order_day_key();
             if (cur_day != intraday_day_) {
                 intraday_day_ = cur_day;
                 intraday_fill_count_ = 0;

--- a/src/timeframe.cpp
+++ b/src/timeframe.cpp
@@ -467,10 +467,12 @@ const NativeDayPartition* active_native_day_partition() {
     return g_active_day_partition;
 }
 
+namespace internal {
 int64_t session_trading_day_index(int64_t ms, const std::string& tz,
                                   const std::string& session) {
     return session_day_index_nominal(ms, tz, session);
 }
+} // namespace internal
 
 int64_t session_day_index(int64_t ms, const std::string& tz,
                           const std::string& session) {

--- a/src/timeframe.cpp
+++ b/src/timeframe.cpp
@@ -467,6 +467,11 @@ const NativeDayPartition* active_native_day_partition() {
     return g_active_day_partition;
 }
 
+int64_t session_trading_day_index(int64_t ms, const std::string& tz,
+                                  const std::string& session) {
+    return session_day_index_nominal(ms, tz, session);
+}
+
 int64_t session_day_index(int64_t ms, const std::string& tz,
                           const std::string& session) {
     // Under the chart's native daily partition the ordinal is the period's

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     test_integer_short_margin_state
+    test_intraday_order_session_day
     test_stop_open_margin_script_state
     test_carried_pooc_short_margin_state
     test_pooc_flat_signal_cost

--- a/tests/test_intraday_order_session_day.cpp
+++ b/tests/test_intraday_order_session_day.cpp
@@ -113,11 +113,73 @@ void test_continuous_and_unconfigured_sessions_keep_chart_clock() {
         CHECK(!shifted.latched_at(1744243200000LL+16*hour));
     }
 }
+
+// Covered ES holiday oracle: the May26 17:00 Chicago reopen accepts a fresh
+// six-fill budget although time("D") still returns the May25 daily stamp.
+// A broker counter must not inherit the optional merged indicator calendar.
+void test_native_holiday_merge_does_not_hold_broker_limit() {
+    constexpr int64_t sunday_open = 1748210400000LL;
+    constexpr int64_t monday_open = sunday_open + 24*hour;
+    constexpr int64_t tuesday_open = sunday_open + 48*hour;
+    constexpr int64_t wednesday_open = sunday_open + 72*hour;
+    NativeDayPartition partition;
+    partition.tz = "America/Chicago";
+    partition.session = "1700-1600";
+    partition.stamps = {sunday_open, tuesday_open};
+    partition.trade_day = {
+        session_day_index(tuesday_open-hour, partition.tz, partition.session),
+        session_day_index(wednesday_open-hour, partition.tz, partition.session),
+    };
+    partition.last_bound = wednesday_open-hour;
+    NativeDayPartitionScope scope(&partition);
+    const auto indicator_day = session_day_index(sunday_open, partition.tz, partition.session);
+    CHECK(session_day_index(monday_open, partition.tz, partition.session) == indicator_day);
+    for (const char* display_zone : {"UTC", "Asia/Taipei"}) {
+        LegacyClock engine;
+        engine.set_syminfo_timezone(partition.tz);
+        engine.set_syminfo_session(partition.session);
+        engine.set_chart_timezone(display_zone);
+        engine.exhaust_at(sunday_open+hour);
+        CHECK(engine.latched_at(monday_open-minute));
+        CHECK(!engine.latched_at(monday_open));
+        engine.exhaust_at(monday_open+hour);
+        CHECK(engine.latched_at(tuesday_open-minute));
+        CHECK(!engine.latched_at(tuesday_open));
+    }
+    CHECK(active_native_day_partition() == &partition);
+    CHECK(session_day_index(monday_open, partition.tz, partition.session) == indicator_day);
+}
+
+void test_other_timed_sessions_resume_on_the_next_open() {
+    struct Market {
+        const char* timezone;
+        const char* session;
+        int64_t open;
+        int64_t before_reopen;
+    };
+    constexpr int64_t day = 1748304000000LL; // May27 UTC
+    for (const Market market : {
+            Market{"America/New_York", "0930-1600", day+13*hour+30*minute, minute},
+            Market{"America/Chicago", "1700-1600", day+22*hour, minute},
+            // The metal market's daily stamp is17:00, in its closed hour;
+            // inspect its last trading hour and its actual18:00 reopen.
+            Market{"America/New_York", "1800-1700", day+22*hour, 2*hour}}) {
+        LegacyClock engine;
+        engine.set_syminfo_timezone(market.timezone);
+        engine.set_syminfo_session(market.session);
+        engine.set_chart_timezone("Asia/Taipei");
+        engine.exhaust_at(market.open+hour);
+        CHECK(engine.latched_at(market.open+24*hour-market.before_reopen));
+        CHECK(!engine.latched_at(market.open+24*hour));
+    }
+}
 }
 
 int main() {
     test_session_boundary_uses_exchange_clock_and_dst();
     test_continuous_and_unconfigured_sessions_keep_chart_clock();
+    test_native_holiday_merge_does_not_hold_broker_limit();
+    test_other_timed_sessions_resume_on_the_next_open();
     std::printf("%d passed, %d failed\n", passed, failed);
     return failed ? 1 : 0;
 }

--- a/tests/test_intraday_order_session_day.cpp
+++ b/tests/test_intraday_order_session_day.cpp
@@ -1,0 +1,123 @@
+// Covered TV controls exhaust six broker fills, then resume exactly at the
+// declared trading-session day boundary (17:00 New York, with DST). Constant
+// synthetic prices isolate the risk clock from strategy signals and PnL.
+#include <pineforge/engine.hpp>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+int passed = 0, failed = 0;
+#define CHECK(x) do { if (x) ++passed; else { ++failed; std::printf("FAIL %d %s\n", __LINE__, #x); } } while (0)
+constexpr int64_t hour = 3600000;
+constexpr int64_t minute = 60000;
+
+class SessionOrders : public BacktestEngine {
+public:
+    bool market_close;
+    explicit SessionOrders(const std::string& display_zone, bool close_command = false)
+        : market_close(close_command) {
+        initial_capital_ = 1000000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1;
+        max_intraday_filled_orders_ = 6;
+        process_orders_on_close_ = true;
+        commission_value_ = 0;
+        slippage_ = 0;
+        syminfo_mintick_ = 0.01;
+        syminfo_.pointvalue = 1;
+        set_syminfo_timezone("America/New_York");
+        set_syminfo_session("1700-1700");
+        set_chart_timezone(display_zone);
+        intraday_cap_count_pooc_full_close_fills_ = true;
+    }
+    void on_bar(const Bar&) override {
+        if (market_close && signed_position_size() > 0) strategy_close("L");
+        const bool request = bar_index_ == 0 || bar_index_ == 2 || bar_index_ == 4
+            || (bar_index_ >= 6 && bar_index_ <= 10)
+            || bar_index_ == 12 || bar_index_ == 14 || bar_index_ == 16;
+        if (request && signed_position_size() == 0) {
+            strategy_entry("L", true);
+            if (!market_close)
+                strategy_exit("X", "L", 101.0, std::numeric_limits<double>::quiet_NaN());
+        }
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+};
+
+std::vector<Bar> session_bars(int64_t day, int reset_hour) {
+    const int64_t offsets[] = {
+        6*hour, 6*hour+15*minute, 8*hour, 8*hour+15*minute,
+        10*hour, 10*hour+15*minute, 11*hour, 15*hour+45*minute,
+        16*hour, reset_hour*hour-15*minute, reset_hour*hour,
+        reset_hour*hour+15*minute, reset_hour*hour+30*minute,
+        reset_hour*hour+45*minute, reset_hour*hour+60*minute,
+        reset_hour*hour+75*minute, 24*hour, 24*hour+15*minute,
+    };
+    std::vector<Bar> bars;
+    for (int64_t offset : offsets) bars.push_back({100, 101, 100, 100, 1, day+offset});
+    return bars;
+}
+
+void test_session_boundary_uses_exchange_clock_and_dst() {
+    struct Date { int64_t day; int reset_hour; };
+    for (const Date date : {Date{1744243200000LL,21}, Date{1762128000000LL,22},
+                            Date{1741305600000LL,22}, Date{1741564800000LL,21}}) {
+        const auto bars = session_bars(date.day, date.reset_hour);
+        for (const char* chart_zone : {"", "UTC", "Asia/Taipei", "America/New_York"}) {
+          for (bool market_close : {false, true}) {
+            SessionOrders engine(chart_zone, market_close);
+            engine.run(bars.data(), static_cast<int>(bars.size()));
+            CHECK(engine.rows().size() == 6);
+            if (engine.rows().size() != 6) continue;
+            CHECK(engine.rows()[0].entry_time == date.day+6*hour);
+            CHECK(engine.rows()[1].entry_time == date.day+8*hour);
+            CHECK(engine.rows()[2].entry_time == date.day+10*hour);
+            CHECK(engine.rows()[3].entry_time == date.day+date.reset_hour*hour);
+            CHECK(engine.rows()[4].entry_time == date.day+date.reset_hour*hour+30*minute);
+            CHECK(engine.rows()[5].entry_time == date.day+date.reset_hour*hour+60*minute);
+          }
+        }
+    }
+}
+
+class LegacyClock : public BacktestEngine {
+public:
+    void on_bar(const Bar&) override {}
+    void exhaust_at(int64_t time) {
+        max_intraday_filled_orders_ = 6;
+        current_bar_.timestamp = time;
+        _intraday_cap_currently_latched();
+        intraday_fill_count_ = 6;
+        intraday_cap_hit_ = true;
+    }
+    bool latched_at(int64_t time) {
+        current_bar_.timestamp = time;
+        return _intraday_cap_currently_latched();
+    }
+};
+
+void test_continuous_and_unconfigured_sessions_keep_chart_clock() {
+    for (const char* session : {"", "24x7", "regular"}) {
+        LegacyClock utc;
+        utc.set_syminfo_session(session);
+        utc.exhaust_at(1744243200000LL+15*hour);
+        CHECK(utc.latched_at(1744243200000LL+21*hour));
+        CHECK(!utc.latched_at(1744243200000LL+24*hour));
+        LegacyClock shifted;
+        shifted.set_syminfo_session(session);
+        shifted.set_chart_timezone("Asia/Taipei");
+        shifted.exhaust_at(1744243200000LL+15*hour);
+        CHECK(shifted.latched_at(1744243200000LL+15*hour+45*minute));
+        CHECK(!shifted.latched_at(1744243200000LL+16*hour));
+    }
+}
+}
+
+int main() {
+    test_session_boundary_uses_exchange_clock_and_dst();
+    test_continuous_and_unconfigured_sessions_keep_chart_clock();
+    std::printf("%d passed, %d failed\n", passed, failed);
+    return failed ? 1 : 0;
+}

--- a/tests/test_intraday_rollover_chart_tz.cpp
+++ b/tests/test_intraday_rollover_chart_tz.cpp
@@ -1,12 +1,10 @@
 // test_intraday_rollover_chart_tz.cpp — pin down the chart-timezone
 // rollover semantics of ``BacktestEngine::_decompose_bar_time_chart_tz()``.
 //
-// This is the helper consumed by the three intraday-day rollover gates
-// (``max_intraday_filled_orders`` in engine_fills.cpp, the loss-day
-// counter in engine_orders.cpp, and ``max_intraday_loss`` in
-// engine_risk.cpp). Pre-fix the gates rolled at UTC 00:00; post-fix
-// they roll at chart 00:00 — which is what TradingView's broker
-// emulator does, keyed off the chart's display TZ.
+// The loss-day rules and the continuous/unconfigured-session order counter
+// consume this helper. They retain the validated chart-midnight boundary.
+// A timed-session order counter instead uses the unmerged symbol session
+// clock, covered separately by test_intraday_order_session_day.cpp.
 //
 // Surfaced by the validation probe
 // ``corpus/validation/97-tp-sl-gap-reversal-oca`` (UTC+8 chart): 234


### PR DESCRIPTION
A filled-order limit could remain latched past the symbol's session reset, rejecting valid evening orders even when the correct exchange timezone and session were supplied.

Use one broker-day key across order placement, filled orders, and direct market closes. The key follows the unmerged symbol session clock, so a futures holiday daily bar can stay combined while the broker renews its order budget. Continuous-session fallback, other risk-day rules, and the indicator/security calendar remain unchanged. The shared helper is internal C++; the C ABI is unchanged. Update the README with the measured round 29 scoreboard.

Validation on final `a752fef5b529ce3ff942717e8c6cda322fd9ccba`:

- Cloud Run measures all **4,190 probes**: **4,172 excellent / 18 strong / zero moderate**. EURUSD JOAT improves to **100% matching and zero count gap**; the other **4,189 canonical results are unchanged**.
- Final and preceding corrected full sweeps have identical trade CSVs, grades, input hashes, and lane settings for all 4,190 probes. README totals: **2,817,239 matched / 2,819,967 TradingView trades**; EURUSD 15m: **367 excellent / 6 strong**.
- Covered TradingView controls verify summer/winter session boundaries, continuous sessions, equities, and the futures holiday reset while `time("D")` stays unchanged. **222/222 tests pass**, including 253 focused assertions; C ABI and build freshness pass.
- Exact-final Grok 4.6 high review: **P0/P1/P2 = 0**. Formal gate `pineforge-pr-gate-jqrjn`: **PASS**, target score **+1**, all **704 hard probes unchanged**, zero tolerated exceptions. Snapshot: `a75857788f0ed079e946893e5882fde4fe9dd58346a04ffd08562a0c5a4958ed`.

Codegen remains `3fd97fe28abd7b191cb376d9f5db4e056fcfae4b`. Grading metrics, verifier, harness, population, tapes, symbol inputs, and FX policy are unchanged. Runtime eligibility has no strategy, symbol, date, or benchmark-ID conditions.
