### PR TITLE
fix: settle opening money margin before later priced exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 TradingView's strategy tester is the reference every Pine author trusts, and nothing outside TradingView reproduced it — until now. PineForge is a C++17 runtime with a stable C ABI that runs PineScript v6 strategies exactly the way TradingView's broker emulator does: same fills, same sizing, same margin calls, same trailing stops, same `request.security()` buckets, on any OHLCV you give it, in microseconds per bar.
 
-- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,172 excellent, 18 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,239 matched by the verifier.
+- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,173 excellent, 17 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,243 matched by the verifier.
 - **Open.** Engine, transpiler, corpus, benchmarks and the validation tooling are all public and Apache-2.0. The only thing you cannot download is the closed test set, because TradingView's Terms of Service forbid redistributing community scripts.
 - **Fast.** In-process, no interpreter: median **162× faster than PyneCore** on 99 timed strategies. Parameter sweeps re-run a loaded `.so` with new inputs — no recompile, no fork.
 - **Deterministic to the bit.** Two runs with the same inputs produce identical trade lists. Same on Linux and macOS.
@@ -108,16 +108,16 @@ Every PineForge-compiled strategy `.so` exports this same ABI — write the harn
 
 ## Validation scoreboard
 
-**Round 29 · 2026-09-07:** **4,172 excellent / 18 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
+**Round 30 · 2026-09-08:** **4,173 excellent / 17 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
 
 | Board | Test set | Result | TradingView trades evaluated |
 |---|---|---|---|
 | **Public** — [open corpus](https://github.com/pineforge-4pass/pineforge-corpus) | 312 reference strategies, Apache-2.0, reproducible by anyone | **309/309 graded excellent** (ETH/USDT-perp 15m; the corpus' declared engine-only / anomaly probes are not graded) | 429,866 |
-| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,863 excellent + 18 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
+| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,864 excellent + 17 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
 
-**2,819,967 TradingView trades** evaluated, **2,817,239 matched by the verifier** (99.90%), from the round 29 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
+**2,819,967 TradingView trades** evaluated, **2,817,243 matched by the verifier** (99.90%), from the round 30 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
 
-Round 29 improves the EUR/USD 15m **Regime Execution Strategy [JOAT]** from strong to excellent, with **100% trade matching and zero count gap**. The filled-order limit now resets on the supplied symbol session clock across order placement, fills, and direct closes. Its broker day remains independent of holiday bars combined by the indicator calendar; continuous-session behavior and other risk-day rules are unchanged. The fix uses the existing symbol configuration, with no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
+Round 30 improves the EUR/USD 15m **Master Trend Strategy [Jake TheBoss]** from strong to excellent, with **100% trade matching and zero count gap**. A carried long now receives its opening money-rounding margin check before a later owned, fully reserved priced exit. Exits already marketable at the open retain priority. The engine keeps the actual chart bar for eligibility and checks only its opening point, preserving existing margin arithmetic and other execution modes. The fix uses broker state and order ownership, with no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
 
 ### The closed test, lane by lane
 
@@ -135,10 +135,10 @@ Round 29 improves the EUR/USD 15m **Regime Execution Strategy [JOAT]** from stro
 | NSE:NIFTY · 1D | 145 | 145 | — | — |
 | NYSE:F · 15m | 340 | 336 | 4 | — |
 | NYSE:F · 1D | 263 | 263 | — | — |
-| OANDA:EURUSD · 15m | 373 | 367 | 6 | — |
+| OANDA:EURUSD · 15m | 373 | 368 | 5 | — |
 | OANDA:XAUUSD · 15m | 376 | 374 | 2 | — |
 | OANDA:XAUUSD · 1D | 248 | 248 | — | — |
-| **Total** | **3,881** | **3,863** | **18** | **0** |
+| **Total** | **3,881** | **3,864** | **17** | **0** |
 
 ### How a probe is graded
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Prefer zero install? The hosted server at **[mcp.pineforge.dev/mcp](https://mcp.
 git clone https://github.com/pineforge-4pass/pineforge-engine.git && cd pineforge-engine
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
-ctest --test-dir build --output-on-failure     # 222 tests
+ctest --test-dir build --output-on-failure     # 223 tests
 bash tutorial/run.sh                            # MACD on BTC/USDT, end to end
 python3 tutorial/run_stream.py                  # OHLCV warm-up → realtime trades
 ```
@@ -190,7 +190,7 @@ PyneCore's 15 non-excellent strategies involve `strategy.exit(stop=…, limit=�
 - `libpineforge.a` — the static runtime: order matching and fills, sizing and margin, the bar magnifier, 66 indicator classes, `request.security()`, time and session math.
 - `<pineforge/pineforge.h>` — the public C ABI, the stability-pinned consumer surface.
 - `<pineforge/*.hpp>` — internal C++ headers the transpiler emits against (not part of the stability guarantee).
-- 222 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
+- 223 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
 - `corpus/` — the 312-strategy public validation corpus (submodule).
 - `benchmarks/` — the three-way comparison harness and the throughput package.
 - `scripts/` — `run_corpus.sh`, `verify_corpus.py`, `run_strategy.py` (load any `.so` via ctypes), `regen_corpus_cpp.sh`, `coverage.sh`.
@@ -244,7 +244,7 @@ src/                    26 .cpp files split by concern
   ├── ta_*.cpp                        66 indicator classes (moving averages, oscillators,
   │                                   volatility/trend, extremes/volume, misc)
   └── magnifier / matrix / session_time / timeframe / timezone / math / str_utils
-tests/                  222 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
+tests/                  223 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
 corpus/                 public submodule: 312 strategies + the 1-minute feed and derived 15m bars
 benchmarks/             three-way comparison harness, throughput package, results/
 scripts/                run_corpus.sh, verify_corpus.py, run_strategy.py, regen_corpus_cpp.sh, coverage.sh

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -3889,8 +3889,11 @@ private:
     // The POOC extension is called only before the close-time script, with
     // no pending broker orders. End-of-bar callers keep it disabled so a
     // close/add cannot make earlier prices act on the post-close position.
+    // Opening-only callers retain the actual chart bar for all eligibility
+    // checks while restricting valuation to its first path point.
     bool tv_money_long_margin_call(const Bar& bar,
-                                  bool carried_pooc_pre_close = false);
+                                  bool carried_pooc_pre_close = false,
+                                  bool opening_only = false);
     // finding-311: mark the live position's standing strategy.exit brackets
     // dormant when an in-position reversal entry is declined at fill.
     void mark_position_brackets_dormant_on_declined_reversal(const Bar& bar);

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1916,11 +1916,12 @@ protected:
                                               const Bar* chart_bar = nullptr);
 
     // TradingView forced-liquidation (margin call). Finite-price liquidation
-    // paths use the bar's adverse extreme. A 100%-margin long has no later
-    // adverse-price liquidation; only an eligible one-shot post-fill
-    // affordability event can trim it.
-    void process_carried_long_money_before_priced_orders(const Bar& bar);
+    // paths use the bar's adverse extreme. A 100%-margin long instead uses
+    // opening affordability and the separately scoped rounded-money checks.
     void process_margin_call(const Bar& bar);
+    // Settle an opening money restore before a later eligible owned exit,
+    // retaining the actual chart bar for financial-class eligibility.
+    void process_carried_long_money_before_priced_orders(const Bar& bar);
     // Ordinary subcontract shorts and integer MARKET lots expose completed
     // liquidation to the close-time script (R23/R25/R28 TV controls).
     void process_short_margin_before_script(const Bar& bar);

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1919,6 +1919,7 @@ protected:
     // paths use the bar's adverse extreme. A 100%-margin long has no later
     // adverse-price liquidation; only an eligible one-shot post-fill
     // affordability event can trim it.
+    void process_carried_long_money_before_priced_orders(const Bar& bar);
     void process_margin_call(const Bar& bar);
     // Ordinary subcontract shorts and integer MARKET lots expose completed
     // liquidation to the close-time script (R23/R25/R28 TV controls).

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -234,8 +234,10 @@ void BacktestEngine::process_carried_long_money_before_priced_orders(
     const bool has_stop = std::isfinite(order.stop_price) && order.stop_price > 0.0;
     if (!has_limit && !has_stop) return;
     const double open = broker_trigger_bar(bar).open;
-    if ((has_limit && open >= order.limit_price)
-        || (has_stop && open <= order.stop_price)) return;
+    // Every finite leg participates in opening marketability. A nonpositive
+    // limit can still be marketable; do not ignore it beside a valid stop.
+    if ((std::isfinite(order.limit_price) && open >= order.limit_price)
+        || (std::isfinite(order.stop_price) && open <= order.stop_price)) return;
 
     // Only the opening checkpoint precedes every eligible exit. The normal
     // end-of-bar call owns later waypoints; a successful trim already records

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -185,9 +185,70 @@ void BacktestEngine::finalize_same_bar_market_tx_book() {
     }
 }
 
+// A carried long can owe the broker's one-contract money-rounding trim at
+// the OPEN before its resting take-profit/stop is reached later on the path.
+// The full-bar exit pass used to erase that position first. Covered controls
+// keep an exit already marketable at O ahead of the trim, and do not borrow a
+// rounding deficit that occurs only at the final close after a TP has filled.
+void BacktestEngine::process_carried_long_money_before_priced_orders(
+        const Bar& bar) {
+    if (!margin_call_enabled_ || position_side_ != PositionSide::LONG
+        || process_orders_on_close_ || calc_on_order_fills_
+        || bar_magnifier_enabled_ || coof_scheduler_active_
+        || stream_warmup_mode_ || stream_phase_ != StreamPhase::IDLE
+        || position_open_bar_ < 0 || position_open_bar_ >= bar_index_
+        || bar.timestamp != current_bar_.timestamp
+        || pending_orders_.size() != 1 || pyramid_entries_.size() != 1
+        || position_entry_count_ != 1 || !(position_qty_ > 1.0)
+        || pyramid_entries_.front().entry_bar_index >= bar_index_
+        || commission_value_ != 0.0 || slippage_ != 0
+        || margin_long_ != 100.0 || syminfo_.pointvalue != 1.0
+        || active_account_currency_fx() != 1.0
+        || !account_currency_fx_timestamps_.empty()
+        || max_intraday_filled_orders_ > 0
+        || risk_max_intraday_loss_ != 0.0 || risk_max_drawdown_ != 0.0
+        || risk_max_cons_loss_days_ > 0
+        || !std::isfinite(bar.open) || !(bar.open > 0.0)
+        || !std::isfinite(bar.high) || !std::isfinite(bar.low)
+        || !std::isfinite(bar.close)) return;
+
+    const auto& order = pending_orders_.front();
+    const auto& entry = pyramid_entries_.front();
+    if (order.type != OrderType::EXIT || entry.entry_id.empty()
+        || order.from_entry != entry.entry_id
+        || order.created_bar >= bar_index_
+        || order.dormant_bracket || order.dormant_reissue_pending
+        || order.suppress_as_declined_reversal_close
+        || !order.oca_name.empty() || order.oca_type != 0
+        || !std::isnan(order.trail_points)
+        || !std::isnan(order.trail_offset) || !std::isnan(order.trail_price)
+        || (!std::isnan(order.limit_price) && !std::isfinite(order.limit_price))
+        || (!std::isnan(order.stop_price) && !std::isfinite(order.stop_price))) return;
+    // The covered book has one ordinary own full-position reservation. Keep
+    // partial-reservation and sibling ownership races on their existing path.
+    if (std::isnan(order.qty)) {
+        if (!std::isfinite(order.qty_percent) || order.qty_percent < 100.0) return;
+    } else if (!std::isfinite(order.qty)
+               || order.qty < position_qty_ - kQtyEpsilon) return;
+    const bool has_limit = std::isfinite(order.limit_price) && order.limit_price > 0.0;
+    const bool has_stop = std::isfinite(order.stop_price) && order.stop_price > 0.0;
+    if (!has_limit && !has_stop) return;
+    const double open = broker_trigger_bar(bar).open;
+    if ((has_limit && open >= order.limit_price)
+        || (has_stop && open <= order.stop_price)) return;
+
+    // Only the opening checkpoint precedes every eligible exit. The normal
+    // end-of-bar call owns later waypoints; a successful trim already records
+    // its consumed bar and retains the bracket on the surviving physical lot.
+    Bar opening = bar;
+    opening.high = opening.low = opening.close = opening.open;
+    tv_money_long_margin_call(opening);
+}
+
 void BacktestEngine::process_pending_orders(const Bar& bar) {
     // Update risk state
     update_risk_state();
+    process_carried_long_money_before_priced_orders(bar);
     finalize_default_flat_market_gross_admission();
     finalize_pending_flat_market_pairs(bar);
     finalize_same_bar_market_tx_book();

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -242,9 +242,8 @@ void BacktestEngine::process_carried_long_money_before_priced_orders(
     // Only the opening checkpoint precedes every eligible exit. The normal
     // end-of-bar call owns later waypoints; a successful trim already records
     // its consumed bar and retains the bracket on the surviving physical lot.
-    Bar opening = bar;
-    opening.high = opening.low = opening.close = opening.open;
-    tv_money_long_margin_call(opening);
+    tv_money_long_margin_call(bar, /*carried_pooc_pre_close=*/false,
+                              /*opening_only=*/true);
 }
 
 void BacktestEngine::process_pending_orders(const Bar& bar) {
@@ -1788,7 +1787,8 @@ void BacktestEngine::process_margin_call(const Bar& bar) {
 // on the trigger bar read PS 878944.99 before sizing their close orders
 // (log-20260906t091207z-83d4bea0), so dispatch_bar calls this BEFORE on_bar.
 bool BacktestEngine::tv_money_long_margin_call(const Bar& bar,
-                                              bool carried_pooc_pre_close) {
+                                              bool carried_pooc_pre_close,
+                                              bool opening_only) {
     if (!margin_call_enabled_) return false;
     if (position_side_ != PositionSide::LONG) return false;
     if (!std::isfinite(margin_long_)
@@ -1865,7 +1865,8 @@ bool BacktestEngine::tv_money_long_margin_call(const Bar& bar,
     double fire_price = std::numeric_limits<double>::quiet_NaN();
     double deficit = 0.0;
     int fire_path_point = -1;
-    for (int i = start; i < 4; ++i) {
+    const int path_end = opening_only ? 1 : 4;
+    for (int i = start; i < path_end; ++i) {
         const double p = path[i];
         if (!std::isfinite(p) || !(p > 0.0)) continue;
         const double value = qty * p * pv * fx;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SOURCES
     test_integer_short_margin_state
     test_intraday_order_session_day
+    test_open_money_before_priced_exit
     test_stop_open_margin_script_state
     test_carried_pooc_short_margin_state
     test_pooc_flat_signal_cost

--- a/tests/test_open_money_before_priced_exit.cpp
+++ b/tests/test_open_money_before_priced_exit.cpp
@@ -112,6 +112,53 @@ void check_script_after_open_call() {
     CHECK(near(out[2].qty, 446173.12));
     CHECK(out[2].exit_time == input[6].timestamp);
 }
+
+// The existing high-value fractional class excludes priced-origin lots.
+// A bar can cross the one-account-unit lot-value boundary; evaluating only O
+// must not change which existing class the actual chart bar belongs to.
+class BoundaryProbe : public BacktestEngine {
+public:
+    static constexpr double qty = 100001.1;
+    static constexpr double entry_price = 9.9999;
+    BoundaryProbe() {
+        initial_capital_ = qty * entry_price + 0.00001;
+        qty_step_ = 0.1;
+        set_syminfo_mintick(0.00001);
+        syminfo_.pointvalue = 1.0;
+        margin_long_ = margin_short_ = 100.0;
+        commission_value_ = 0.0;
+        pyramiding_ = 0;
+    }
+    void on_bar(const Bar& current) override {
+        if (bar_index_ != 0) return;
+        // A priced lot born at the prior close has no earlier path to mark.
+        position_side_ = PositionSide::LONG;
+        position_qty_ = qty;
+        position_entry_price_ = entry_price;
+        position_entry_time_ = current.timestamp;
+        position_entry_count_ = 1;
+        position_open_bar_ = 0;
+        PyramidEntry entry{};
+        entry.price = entry_price; entry.qty = qty;
+        entry.time = current.timestamp; entry.entry_id = "Boundary";
+        entry.entry_bar_index = 0; entry.entry_path_position = 3.0;
+        entry.entry_commission_account = 0.0;
+        pyramid_entries_.push_back(entry);
+        strategy_exit("Resting", "Boundary", 11.0, 9.0);
+    }
+    const std::vector<Trade>& closed() const { return trades_; }
+    double position() const { return signed_position_size(); }
+};
+void check_original_money_scope_is_preserved() {
+    const std::vector<Bar> input = {
+        make_bar(0, 9.9999, 9.9999, 9.9999, 9.9999),
+        make_bar(1, 9.99995, 10.0002, 9.9998, 10.0001),
+    };
+    BoundaryProbe p;
+    p.run(input.data(), static_cast<int>(input.size()));
+    CHECK(p.closed().empty());
+    CHECK(near(p.position(), BoundaryProbe::qty));
+}
 }
 int main() {
     check_priced_exit(Mode::Bracket, true, 1.12401);
@@ -125,6 +172,7 @@ int main() {
     check_priced_exit(Mode::Stop, true, 1.12365);
     check_priced_exit(Mode::Disabled, false, 1.12401);
     check_script_after_open_call();
+    check_original_money_scope_is_preserved();
     std::printf("open money before priced exit: %d passed / %d failed\n", passed, failed);
     return failed == 0 ? 0 : 1;
 }

--- a/tests/test_open_money_before_priced_exit.cpp
+++ b/tests/test_open_money_before_priced_exit.cpp
@@ -34,7 +34,7 @@ std::vector<Bar> bars() {
         make_bar(6, 1.12154, 1.12198, 1.11798, 1.11866),
     };
 }
-enum class Mode { Bracket, Funded, OpenRace, Half, Stop, Disabled };
+enum class Mode { Bracket, Funded, OpenRace, NonpositiveOpen, Half, Stop, Disabled };
 class Probe : public BacktestEngine {
     Mode mode_;
 public:
@@ -55,12 +55,15 @@ public:
     void on_bar(const Bar& b) override {
         if (bar_index_ == 0) {
             strategy_entry("Owned", true);
-            if (mode_ != Mode::OpenRace && mode_ != Mode::Stop)
+            if (mode_ != Mode::OpenRace && mode_ != Mode::NonpositiveOpen
+                && mode_ != Mode::Stop)
                 strategy_exit("Bracket", "Owned", mode_ == Mode::Half ? 1.2 : b.close * 1.003,
                               mode_ == Mode::Half ? kNa : b.close * 0.998);
         }
         if (bar_index_ == 3) {
             if (mode_ == Mode::OpenRace) strategy_exit("AtOpen", "Owned", 1.12373, kNa);
+            if (mode_ == Mode::NonpositiveOpen)
+                strategy_exit("FiniteAtOpen", "Owned", -1.0, 1.11839);
             if (mode_ == Mode::Stop) strategy_exit("Stop", "Owned", kNa, 1.12365);
         }
         if (bar_index_ == 4) {
@@ -116,6 +119,9 @@ int main() {
     // the take-profit has already filled. Do not pre-process that future point.
     check_priced_exit(Mode::Funded, false, 1.12401);
     check_priced_exit(Mode::OpenRace, false, 1.12373);
+    // A finite nonpositive limit is still marketable at this positive open;
+    // a valid stop sibling must not hide its established opening priority.
+    check_priced_exit(Mode::NonpositiveOpen, false, 1.12373);
     check_priced_exit(Mode::Stop, true, 1.12365);
     check_priced_exit(Mode::Disabled, false, 1.12401);
     check_script_after_open_call();

--- a/tests/test_open_money_before_priced_exit.cpp
+++ b/tests/test_open_money_before_priced_exit.cpp
@@ -1,0 +1,124 @@
+// Carried 100%-margin money rounding at the next open precedes a resting
+// priced exit that is not marketable there. Covered TradingView controls:
+// eur7-jake-first-fixed, funded, open-race, half, and stop. This synthetic
+// order schedule has no strategy signals; the price/quantity ownership is
+// the contract. An already-marketable exit retains its own opening priority.
+#include <pineforge/engine.hpp>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+int passed = 0;
+int failed = 0;
+#define CHECK(x) do { if (x) ++passed; else { ++failed; \
+    std::printf("FAIL line %d: %s\n", __LINE__, #x); } } while (false)
+constexpr double kQty = 892347.23;
+const double kNa = std::numeric_limits<double>::quiet_NaN();
+Bar make_bar(int i, double o, double h, double l, double c) {
+    Bar out;
+    out.timestamp = 1744306200000LL + i * 900000LL;
+    out.open = o; out.high = h; out.low = l; out.close = c; out.volume = 1.0;
+    return out;
+}
+std::vector<Bar> bars() {
+    return {
+        make_bar(0, 1.11788, 1.12110, 1.11776, 1.12064),
+        make_bar(1, 1.12064, 1.12100, 1.11990, 1.12099),
+        make_bar(2, 1.12103, 1.12169, 1.12012, 1.12160),
+        make_bar(3, 1.12160, 1.12395, 1.12152, 1.12372),
+        make_bar(4, 1.12373, 1.12418, 1.12346, 1.12362),
+        make_bar(5, 1.12362, 1.12377, 1.12090, 1.12156),
+        make_bar(6, 1.12154, 1.12198, 1.11798, 1.11866),
+    };
+}
+enum class Mode { Bracket, Funded, OpenRace, Half, Stop, Disabled };
+class Probe : public BacktestEngine {
+    Mode mode_;
+public:
+    double script_size = kNa;
+    explicit Probe(Mode mode) : mode_(mode) {
+        initial_capital_ = mode == Mode::Funded ? 1000000.0001 : 1000000.0;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100;
+        pyramiding_ = 10;
+        margin_long_ = margin_short_ = 100;
+        commission_value_ = 0;
+        slippage_ = 0;
+        qty_step_ = 0.01;
+        set_syminfo_mintick(0.00001);
+        syminfo_.pointvalue = 1;
+        set_margin_call_enabled(mode != Mode::Disabled);
+    }
+    void on_bar(const Bar& b) override {
+        if (bar_index_ == 0) {
+            strategy_entry("Owned", true);
+            if (mode_ != Mode::OpenRace && mode_ != Mode::Stop)
+                strategy_exit("Bracket", "Owned", mode_ == Mode::Half ? 1.2 : b.close * 1.003,
+                              mode_ == Mode::Half ? kNa : b.close * 0.998);
+        }
+        if (bar_index_ == 3) {
+            if (mode_ == Mode::OpenRace) strategy_exit("AtOpen", "Owned", 1.12373, kNa);
+            if (mode_ == Mode::Stop) strategy_exit("Stop", "Owned", kNa, 1.12365);
+        }
+        if (bar_index_ == 4) {
+            script_size = signed_position_size();
+            if (mode_ == Mode::Half) strategy_close("Owned", "half", kNa, 50.0);
+        }
+        if (bar_index_ == 5 && mode_ == Mode::Half) strategy_close_all();
+    }
+    const std::vector<Trade>& closed() const { return trades_; }
+};
+bool near(double a, double b, double eps = 1e-8) { return std::abs(a-b) < eps; }
+void check_priced_exit(Mode mode, bool call, double price) {
+    auto input = bars();
+    Probe p(mode);
+    p.run(input.data(), static_cast<int>(input.size()));
+    const auto& out = p.closed();
+    CHECK(out.size() == (call ? 2U : 1U));
+    if (out.size() != (call ? 2U : 1U)) return;
+    if (call) {
+        CHECK(out[0].exit_comment == "Margin call");
+        CHECK(out[0].qty == 1.0);
+        CHECK(out[0].exit_time == input[4].timestamp);
+        CHECK(near(out[0].exit_price, 1.12373));
+        CHECK(near(out[0].max_runup, 0.00331));
+        CHECK(near(out[0].max_drawdown, 0.00074));
+    }
+    CHECK(near(out.back().qty, kQty - (call ? 1.0 : 0.0)));
+    CHECK(near(out.back().exit_price, price));
+    CHECK(out.back().exit_time == input[4].timestamp);
+}
+void check_script_after_open_call() {
+    const auto input = bars();
+    Probe p(Mode::Half);
+    p.run(input.data(), static_cast<int>(input.size()));
+    CHECK(near(p.script_size, 892346.23));
+    const auto& out = p.closed();
+    CHECK(out.size() == 3);
+    if (out.size() != 3) return;
+    CHECK(out[0].exit_comment == "Margin call");
+    CHECK(out[0].qty == 1);
+    CHECK(out[0].exit_time == input[4].timestamp);
+    CHECK(near(out[0].exit_price, 1.12373));
+    CHECK(out[1].exit_comment == "half");
+    CHECK(near(out[1].qty, 446173.11));
+    CHECK(out[1].exit_time == input[5].timestamp);
+    CHECK(near(out[2].qty, 446173.12));
+    CHECK(out[2].exit_time == input[6].timestamp);
+}
+}
+int main() {
+    check_priced_exit(Mode::Bracket, true, 1.12401);
+    // The funded control has a rounding deficit at the final CLOSE, after
+    // the take-profit has already filled. Do not pre-process that future point.
+    check_priced_exit(Mode::Funded, false, 1.12401);
+    check_priced_exit(Mode::OpenRace, false, 1.12373);
+    check_priced_exit(Mode::Stop, true, 1.12365);
+    check_priced_exit(Mode::Disabled, false, 1.12401);
+    check_script_after_open_call();
+    std::printf("open money before priced exit: %d passed / %d failed\n", passed, failed);
+    return failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
A carried long's opening money-rounding margin check could run after a resting take-profit or stop reached later in the bar, closing the wrong quantity and changing subsequent trades.

Settle the opening check first for a single carried, fee-free long with one owned full-position priced exit. Preserve priority for exits already marketable at the open. Keep the actual chart bar for financial-class eligibility and restrict only the valuation path to its opening point; existing arithmetic and other callers are unchanged. Update the README with the measured round 30 scoreboard.

Validation on final `49c525f78a44a23ea18bec03b18cfc36fb92a1d2`:

- Cloud Run measures all **4,190 probes**: **4,173 excellent / 17 strong / zero moderate**. EURUSD Master Trend improves to **100% matching and zero count gap**; the other **4,189 canonical results are unchanged**.
- Both full sweeps have identical trade CSVs, grades, input hashes, and lane settings for all 4,190 probes. README totals: **2,817,243 matched / 2,819,967 TradingView trades**; EURUSD 15m: **368 excellent / 5 strong**.
- Covered TradingView controls verify opening margin before a later TP/stop, funded and opening-priority cases, and script-visible partial quantities. The regression fixture also preserves financial-class eligibility across a lot-value boundary. **223/223 tests pass**, including 49 focused assertions; C ABI and build freshness pass.
- Exact-final Grok 4.6 high review: **P0/P1/P2 = 0**. Formal gate `pineforge-pr-gate-mdxzq`: **PASS**, target score **+1**, all **704 hard probes unchanged**, zero tolerated exceptions. Snapshot: `1227d9f7ad67213e82e505d78d15b5ff80d9d56a0eecf13460358ce9541417de`.

Codegen remains `3fd97fe28abd7b191cb376d9f5db4e056fcfae4b`. Grading metrics, verifier, harness, population, tapes, symbol inputs, and FX policy are unchanged. Runtime eligibility has no strategy, symbol, date, or benchmark-ID conditions.
