### PR TITLE
Preserve standing exits when a reversal is rejected at placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 TradingView's strategy tester is the reference every Pine author trusts, and nothing outside TradingView reproduced it — until now. PineForge is a C++17 runtime with a stable C ABI that runs PineScript v6 strategies exactly the way TradingView's broker emulator does: same fills, same sizing, same margin calls, same trailing stops, same `request.security()` buckets, on any OHLCV you give it, in microseconds per bar.
 
-- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,173 excellent, 17 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,243 matched by the verifier.
+- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,174 excellent, 16 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,305 matched by the verifier.
 - **Open.** Engine, transpiler, corpus, benchmarks and the validation tooling are all public and Apache-2.0. The only thing you cannot download is the closed test set, because TradingView's Terms of Service forbid redistributing community scripts.
 - **Fast.** In-process, no interpreter: median **162× faster than PyneCore** on 99 timed strategies. Parameter sweeps re-run a loaded `.so` with new inputs — no recompile, no fork.
 - **Deterministic to the bit.** Two runs with the same inputs produce identical trade lists. Same on Linux and macOS.
@@ -76,7 +76,7 @@ Prefer zero install? The hosted server at **[mcp.pineforge.dev/mcp](https://mcp.
 git clone https://github.com/pineforge-4pass/pineforge-engine.git && cd pineforge-engine
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
-ctest --test-dir build --output-on-failure     # 223 tests
+ctest --test-dir build --output-on-failure     # 224 tests
 bash tutorial/run.sh                            # MACD on BTC/USDT, end to end
 python3 tutorial/run_stream.py                  # OHLCV warm-up → realtime trades
 ```
@@ -108,16 +108,16 @@ Every PineForge-compiled strategy `.so` exports this same ABI — write the harn
 
 ## Validation scoreboard
 
-**Round 30 · 2026-09-08:** **4,173 excellent / 17 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
+**Round 31 · 2026-09-08:** **4,174 excellent / 16 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
 
 | Board | Test set | Result | TradingView trades evaluated |
 |---|---|---|---|
 | **Public** — [open corpus](https://github.com/pineforge-4pass/pineforge-corpus) | 312 reference strategies, Apache-2.0, reproducible by anyone | **309/309 graded excellent** (ETH/USDT-perp 15m; the corpus' declared engine-only / anomaly probes are not graded) | 429,866 |
-| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,864 excellent + 17 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
+| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,865 excellent + 16 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
 
-**2,819,967 TradingView trades** evaluated, **2,817,243 matched by the verifier** (99.90%), from the round 30 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
+**2,819,967 TradingView trades** evaluated, **2,817,305 matched by the verifier** (99.91%), from the round 31 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
 
-Round 30 improves the EUR/USD 15m **Master Trend Strategy [Jake TheBoss]** from strong to excellent, with **100% trade matching and zero count gap**. A carried long now receives its opening money-rounding margin check before a later owned, fully reserved priced exit. Exits already marketable at the open retain priority. The engine keeps the actual chart bar for eligibility and checks only its opening point, preserving existing margin arithmetic and other execution modes. The fix uses broker state and order ownership, with no strategy, symbol, date, or benchmark-ID conditions. Grading rules, verifier, harness, population, and tapes are unchanged.
+Round 31 improves the EUR/USD 15m **Fast Scalper With Stops** from strong to excellent, with **100% trade matching and zero count gap**. Standing stops and limits now stay active when a reversal fails its placement-budget check. A reversal admitted at placement and rejected at the opening gap retains its existing exit-ownership behavior. The fix uses order state and ownership, with no strategy, symbol, date, or benchmark-ID conditions. Admission arithmetic, grading rules, verifier, harness, population, inputs, and tapes are unchanged.
 
 ### The closed test, lane by lane
 
@@ -135,10 +135,10 @@ Round 30 improves the EUR/USD 15m **Master Trend Strategy [Jake TheBoss]** from 
 | NSE:NIFTY · 1D | 145 | 145 | — | — |
 | NYSE:F · 15m | 340 | 336 | 4 | — |
 | NYSE:F · 1D | 263 | 263 | — | — |
-| OANDA:EURUSD · 15m | 373 | 368 | 5 | — |
+| OANDA:EURUSD · 15m | 373 | 369 | 4 | — |
 | OANDA:XAUUSD · 15m | 376 | 374 | 2 | — |
 | OANDA:XAUUSD · 1D | 248 | 248 | — | — |
-| **Total** | **3,881** | **3,864** | **17** | **0** |
+| **Total** | **3,881** | **3,865** | **16** | **0** |
 
 ### How a probe is graded
 
@@ -152,7 +152,7 @@ A grade is never one lucky run. Every candidate build is measured over the whole
 
 ### What the closed test taught the engine
 
-Every gap was closed by pinning the rule TradingView actually follows — never by loosening the grader. Each rule was isolated with sensor strategies exported from TradingView (capital sweeps, literal replays, per-bar state encoded into order comments) and landed with a replay test on the recorded bars. Among them: the broker carries money at **ten significant digits** (equity rounding, the whole-order drop band, the one-contract margin call, the raw lot floor on every lot-stepped symbol); a trailing stop restarts from the issuing bar's *close* when `trail_points` changes and never folds that bar's extreme; a zero-offset trail rides the raw running best and its arming open fills at the nearest-tick print; a declined all-in reversal kills a bracket's stop and limit legs but never its trail leg, and a `strategy.close` queued beside a dropped reversal still fills; sparse `ta.atr`/`ta.tr` read the chart's previous close on every execution; pivot levels snap to the tick grid; early-close sessions complete their higher-timeframe bucket; and account-currency conversion is left out of the comparison entirely, because TradingView's FX series is a moving target no fixed table reproduces.
+Every gap was closed by pinning the rule TradingView actually follows — never by loosening the grader. Each rule was isolated with sensor strategies exported from TradingView (capital sweeps, literal replays, per-bar state encoded into order comments) and landed with a replay test on the recorded bars. Among them: the broker carries money at **ten significant digits** (equity rounding, the whole-order drop band, the one-contract margin call, the raw lot floor on every lot-stepped symbol); a trailing stop restarts from the issuing bar's *close* when `trail_points` changes and never folds that bar's extreme; a zero-offset trail rides the raw running best and its arming open fills at the nearest-tick print; a reversal rejected at placement preserves standing exits and a separately queued `strategy.close`, while the distinct fill-time rejection rules govern stop, limit, and trailing legs; sparse `ta.atr`/`ta.tr` read the chart's previous close on every execution; pivot levels snap to the tick grid; early-close sessions complete their higher-timeframe bucket; and account-currency conversion is left out of the comparison entirely, because TradingView's FX series is a moving target no fixed table reproduces.
 
 ### Reproduce the public board yourself
 

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -5162,7 +5162,7 @@ void BacktestEngine::apply_filled_order_to_state(
     // Same-direction adds are out of scope (no tape).
     // round 9 family R follow-up — rule 5 (engine.hpp; campaign notes
     // log-20260905t205824z-af397c83, log-20260905t210117z-ab914192): once
-    // the rounded-cost admission has passed, the broker's fill-time margin
+    // the rounded-cost admission has passed, the broker's placement margin
     // check runs on the PRICE scale. The price at which the rounded equity
     // exactly buys the frozen quantity,
     //
@@ -5275,13 +5275,14 @@ void BacktestEngine::apply_filled_order_to_state(
                     // famag-A1-ef/A3-ef/A4-ef/A5-ef) is atomic with its
                     // co-queued close (#91, suppress_declined_reversal_
                     // close_legs) — so the suppression is NOT applied here.
-                    // The position's priced brackets still go dormant as
-                    // for any declined reversal (the close, if any, takes
-                    // the position at the open; if none, the hold is the
-                    // KI-54 shape).
-                    if (reversal_entry) {
-                        mark_position_brackets_dormant_on_declined_reversal(bar);
-                    }
+                    // A placement-rejected order never acquires the old
+                    // position's priced exits either. Covered R31 TV
+                    // controls r31-r5-stop-z-tie/g-tie preserve the standing
+                    // stop; adding 0.0005 cash to the gap control admits at
+                    // placement, then the opening-gap rejection kills it.
+                    // The partial-margin controls r31-fast-r5-child/bare
+                    // also keep the old stop, identical to no reversal.
+                    // Only the fill-time rejection below owns that kill.
                     decline_and_cancel();
                     return;
                 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    test_placement_rejection_bracket_ownership
     test_integer_short_margin_state
     test_intraday_order_session_day
     test_open_money_before_priced_exit

--- a/tests/test_placement_rejection_bracket_ownership.cpp
+++ b/tests/test_placement_rejection_bracket_ownership.cpp
@@ -1,0 +1,116 @@
+// A placement-level whole-order rejection never acquires the old position's
+// priced exits. An admitted reversal declined at the opening gap still does.
+// Covered TV controls r31-r5-stop-{z-tie,g-tie,g-gap,g-none} (2026-09-07):
+// short 870000 @ 1.13523; standing stop 1.13530. The two rule-5 ties keep
+// that stop live, while capital +0.0005 at the adverse-gap signal kills it.
+// r31-r5-limit-{g-tie,g-gap,g-none} pins the same distinction for a standing
+// profit limit at 1.13165. Neither control family has any margin-call slice.
+// These compact synthetic schedules preserve the pinned account budgets;
+// they contain no indicator, symbol, date, or strategy-specific dispatch.
+#include <pineforge/engine.hpp>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+int passed = 0;
+int failed = 0;
+#define CHECK(x) do { if (x) ++passed; else { ++failed; \
+    std::printf("FAIL line %d: %s\n", __LINE__, #x); } } while (false)
+const double kNa = std::numeric_limits<double>::quiet_NaN();
+enum class Mode { ZeroGapPlacement, AdverseGapPlacement, FillGap, NoReversal };
+enum class Leg { Stop, Limit };
+Bar bar(int i, double o, double h, double l, double c) {
+    Bar b;
+    b.timestamp = 1000000LL + i * 900000LL;
+    b.open = o; b.high = h; b.low = l; b.close = c; b.volume = 1.0;
+    return b;
+}
+std::vector<Bar> schedule(Mode mode, Leg leg) {
+    const bool zero = mode == Mode::ZeroGapPlacement;
+    return {
+        bar(0, 1.13596, 1.13622, 1.13513, 1.13524),
+        bar(1, 1.13523, 1.13523, 1.13378, 1.13388),
+        zero ? bar(2, 1.13375, 1.13448, 1.13345, 1.13384)
+             : bar(2, 1.13232, 1.13263, 1.13174, 1.13207),
+        zero ? bar(3, 1.13384, 1.13391, 1.13273, 1.13276)
+             : bar(3, 1.13209, 1.13350, 1.13196, 1.13349),
+        leg == Leg::Stop ? bar(4, 1.13368, 1.13546, 1.13332, 1.13476)
+                         : bar(4, 1.13189, 1.13282, 1.13156, 1.13231),
+    };
+}
+class Probe : public BacktestEngine {
+    Mode mode_;
+    Leg leg_;
+public:
+    double signal_equity = kNa;
+    Probe(Mode mode, Leg leg) : mode_(mode), leg_(leg) {
+        initial_capital_ = mode == Mode::ZeroGapPlacement ? 998790.695916
+            : mode == Mode::AdverseGapPlacement ? 997250.797032 : 997250.797532;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100.0;
+        margin_long_ = margin_short_ = 100.0;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        pyramiding_ = 0;
+        qty_step_ = 0.01;
+        syminfo_.pointvalue = 1.0;
+        set_syminfo_mintick(0.00001);
+        set_margin_call_enabled(true);
+    }
+    void on_bar(const Bar& b) override {
+        if (bar_index_ == 0) {
+            strategy_entry("Owned", false, kNa, kNa, 870000.0);
+            strategy_exit("Standing", "Owned",
+                          leg_ == Leg::Limit ? 1.13165 : kNa,
+                          leg_ == Leg::Stop ? 1.13530 : kNa);
+        }
+        if (bar_index_ == 2) {
+            signal_equity = current_equity() + open_profit(b.close);
+            if (mode_ != Mode::NoReversal) strategy_entry("Attempt", true);
+        }
+    }
+    const std::vector<Trade>& closed() const { return trades_; }
+    double position() const { return signed_position_size(); }
+};
+bool near(double a, double b, double eps = 1e-8) {
+    return std::abs(a - b) < eps;
+}
+void check(Mode mode, double equity, bool exit_lives, Leg leg = Leg::Stop) {
+    const auto input = schedule(mode, leg);
+    Probe p(mode, leg);
+    p.run(input.data(), static_cast<int>(input.size()));
+    CHECK(near(p.signal_equity, equity));
+    if (!exit_lives) {
+        CHECK(p.closed().empty());
+        CHECK(near(p.position(), -870000.0));
+        return;
+    }
+    CHECK(p.closed().size() == 1);
+    CHECK(near(p.position(), 0.0));
+    if (p.closed().size() != 1) return;
+    const auto& t = p.closed()[0];
+    CHECK(!t.is_long);
+    CHECK(t.entry_id == "Owned");
+    CHECK(t.exit_id == "Standing");
+    CHECK(near(t.qty, 870000.0));
+    CHECK(near(t.entry_price, 1.13523));
+    CHECK(near(t.exit_price, leg == Leg::Stop ? 1.13530 : 1.13165));
+    CHECK(t.exit_time == input[4].timestamp);
+    CHECK(t.exit_comment != "Margin call");
+}
+}
+int main() {
+    check(Mode::ZeroGapPlacement, 999999.995916, true);
+    check(Mode::AdverseGapPlacement, 999999.997032, true);
+    check(Mode::FillGap, 999999.997532, false);
+    check(Mode::NoReversal, 999999.997532, true);
+    check(Mode::AdverseGapPlacement, 999999.997032, true, Leg::Limit);
+    check(Mode::FillGap, 999999.997532, false, Leg::Limit);
+    check(Mode::NoReversal, 999999.997532, true, Leg::Limit);
+    std::printf("placement rejection bracket ownership: %d passed / %d failed\n",
+                passed, failed);
+    return failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
A reversal rejected by the price-scale placement check could disable the current position's standing stops and limits. Preserve those exits when placement drops the reversal. The existing opening-gap rejection behavior and admission arithmetic remain unchanged.

Round 31 improves EURUSD 15m Fast Scalper With Stops from strong to excellent: 100% trade matching, zero count gap. The final README records **4,174 excellent / 16 strong / zero moderate** across 4,190 probes, with 2,817,305 of 2,819,967 TradingView trades matched.

Validation:

- Ten covered TradingView controls distinguish placement rejection from opening-gap rejection for stops and limits.
- 224/224 C++ tests, 61 focused assertions, and the C ABI check pass.
- Two complete 4,190-probe Cloud Run sweeps agree on every trade file and grade. The other 4,189 probes are byte-identical to the baseline, with zero canonical regressions; grading, profiles, inputs, feeds, and population are unchanged.
- Formal gate `pineforge-pr-gate-9fdrb`: PASS, score +1, 704 hard probes unchanged and no exceptions.
- Independent Grok 4.6 high review of final commit `e3f0d28b2b430c22082d673c8a10d1253f9f63bb`: zero P0/P1/P2 findings.
