### PR TITLE
Fix both-touch dual-stop transactions and placement sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 TradingView's strategy tester is the reference every Pine author trusts, and nothing outside TradingView reproduced it — until now. PineForge is a C++17 runtime with a stable C ABI that runs PineScript v6 strategies exactly the way TradingView's broker emulator does: same fills, same sizing, same margin calls, same trailing stops, same `request.security()` buckets, on any OHLCV you give it, in microseconds per bar.
 
-- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,177 excellent, 13 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,337 matched by the verifier.
+- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,178 excellent, 12 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,448 matched by the verifier.
 - **Open.** Engine, transpiler, corpus, benchmarks and the validation tooling are all public and Apache-2.0. The only thing you cannot download is the closed test set, because TradingView's Terms of Service forbid redistributing community scripts.
 - **Fast.** In-process, no interpreter: median **162× faster than PyneCore** on 99 timed strategies. Parameter sweeps re-run a loaded `.so` with new inputs — no recompile, no fork.
 - **Deterministic to the bit.** Two runs with the same inputs produce identical trade lists. Same on Linux and macOS.
@@ -108,18 +108,18 @@ Every PineForge-compiled strategy `.so` exports this same ABI — write the harn
 
 ## Validation scoreboard
 
-**Round 34 · 2026-09-08:** **4,177 excellent / 13 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
+**Round 35 · 2026-09-08:** **4,178 excellent / 12 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
 
 | Board | Test set | Result | TradingView trades evaluated |
 |---|---|---|---|
 | **Public** — [open corpus](https://github.com/pineforge-4pass/pineforge-corpus) | 312 reference strategies, Apache-2.0, reproducible by anyone | **309/309 graded excellent** (ETH/USDT-perp 15m; the corpus' declared engine-only / anomaly probes are not graded) | 429,866 |
-| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,868 excellent + 13 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
+| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,869 excellent + 12 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
 
-**2,819,967 TradingView trades** evaluated, **2,817,337 matched by the verifier** (99.91%), from the round 34 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
+**2,819,967 TradingView trades** evaluated, **2,817,448 matched by the verifier** (99.91%), from the round 35 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
 
-Round 34 corrects admission for ordinary process-on-close long MARKET orders and places the covered money-margin event at the next bar's open, before order-fill recalculation. **Overnight Gap Capture** on **OANDA:EURUSD 15m** moves from strong to excellent: zero count gap, 100% matched, and zero entry-price, exit-price, PnL and quantity error at the 90th percentile. Its **3,669 closed trades** match TradingView on entry/exit time, side, quantity and prices.
+Round 35 corrects ordinary pairs of unlinked stop-entry orders placed while flat. After the first stop opens a position, the later stop consumes its own transaction quantity: it can partially close, flatten, or reverse only the remainder, in either path direction. Default percent-of-equity stops retain their placement quantity consistently through admission and execution. **Decoded Volatility Expansion** on **OANDA:XAUUSD 15m** moves from strong to excellent: zero count gap, 100% canonical match, and zero entry-price, exit-price, PnL and quantity error at the 90th percentile. All **514 closed-trade identities** match TradingView on entry/exit time, side, quantity and prices.
 
-The changes use broker state, physical order/position provenance and instrument tick/lot facts. A four-cell Cloud experiment separates admission from opening-event timing; the combined change is required for the conversion. The other **4,189 trade CSVs are byte-identical** to round 33, and their canonical grades and metrics are unchanged, including all **704 hard-surface probes**. Codegen, verifier, grading rules, profile-selection code, reference tapes, feeds, input files and scored population are unchanged.
+The rule uses order-book and position provenance, with no strategy, symbol or date lookup. Sixteen independent TradingView controls and an unchanged-output Cloud trace pin the cause. Seven hard-surface corpus probes gain **72 exact trade matches**, with no previously exact match lost; their canonical grades and metrics remain unchanged. The other **4,182 trade CSVs are byte-identical** to round 34, and all **4,189 other probes** retain their canonical grades and quantity metrics. Verifier code, grading rules, profile-selection code, reference tapes, feeds, input files and scored population are unchanged.
 
 ### The closed test, lane by lane
 
@@ -138,9 +138,9 @@ The changes use broker state, physical order/position provenance and instrument 
 | NYSE:F · 15m | 340 | 336 | 4 | — |
 | NYSE:F · 1D | 263 | 263 | — | — |
 | OANDA:EURUSD · 15m | 373 | 371 | 2 | — |
-| OANDA:XAUUSD · 15m | 376 | 374 | 2 | — |
+| OANDA:XAUUSD · 15m | 376 | 375 | 1 | — |
 | OANDA:XAUUSD · 1D | 248 | 248 | — | — |
-| **Total** | **3,881** | **3,868** | **13** | **0** |
+| **Total** | **3,881** | **3,869** | **12** | **0** |
 
 ### How a probe is graded
 

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -4079,7 +4079,8 @@ private:
                                      std::vector<size_t>& filled_indices,
                                      bool flat_dual_stop_pair = false);
     bool stop_entry_margin_admission_declines(
-        const PendingOrder& order, double fill_price, const Bar& bar) const;
+        const PendingOrder& order, double fill_price, const Bar& bar,
+        bool flat_dual_stop_pair = false) const;
     // True iff `order` is a default percent_of_equity <= 100 pure STOP that
     // carries its placement snapshot (PendingOrder::default_stop_placement_qty)
     // and the fill price is a usable positive print: the fill-time admission

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -4076,7 +4076,8 @@ private:
                                      int& exit_closed_from_bar,
                                      uint64_t& exit_closed_from_incarnation,
                                      bool& exit_closed_was_long,
-                                     std::vector<size_t>& filled_indices);
+                                     std::vector<size_t>& filled_indices,
+                                     bool flat_dual_stop_pair = false);
     bool stop_entry_margin_admission_declines(
         const PendingOrder& order, double fill_price, const Bar& bar) const;
     // True iff `order` is a default percent_of_equity <= 100 pure STOP that
@@ -4084,8 +4085,13 @@ private:
     // and the fill price is a usable positive print: the fill-time admission
     // and dispatch then consume the placement quantity instead of re-sizing
     // at the fill.
+    // The pair context exists only inside the ordinary atomic two-stop scan.
+    // No callback or stable-frame ABI read occurs between its two fills.
+    bool flat_dual_stop_opposite_is_live(
+        const PendingOrder& order, bool flat_dual_stop_pair) const;
     bool use_default_stop_placement_qty(
-        const PendingOrder& order, double fill_price) const;
+        const PendingOrder& order, double fill_price,
+        bool flat_dual_stop_pair = false) const;
     // design-declined-reversal-close-leg: called at the KI-54 reversal-decline
     // site with the just-declined MARKET reversal entry. Flags every pending
     // FULL close that was co-queued after it on the same bar against the held
@@ -4137,7 +4143,8 @@ private:
                                  bool later_same_tick_entry);
     void apply_entry_order_fill(PendingOrder& order, double fill_price,
                                 const Bar& bar,
-                                double& trail_best_path_state);
+                                double& trail_best_path_state,
+                                bool flat_dual_stop_pair = false);
     void apply_exit_order_fill(PendingOrder& order, double fill_price,
                                int& exit_closed_from_bar,
                                uint64_t& exit_closed_from_incarnation,
@@ -4175,7 +4182,8 @@ private:
         internal::DualEntryStopPathWinner dual_entry_path,
         const std::unordered_set<std::string>& pass0_opposing_skip_ids,
         int exit_closed_from_bar, uint64_t exit_closed_from_incarnation,
-        bool exit_closed_was_long, const Bar& bar);
+        bool exit_closed_was_long, const Bar& bar,
+        bool flat_dual_stop_pair = false);
     struct FillEvaluation {
         enum class Kind { Fill, NoFill, DeferredToOpposingPass };
         Kind kind;

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -407,7 +407,7 @@ void BacktestEngine::process_pending_orders(const Bar& bar) {
                     && !order.is_long))
             && check_risk_allow_entry(order.is_long)
             && stop_entry_margin_admission_declines(
-                order, fill.fill_price, bar);
+                order, fill.fill_price, bar, flat_dual_stop_pair);
         const double realized_before_fill = net_profit_sum_;
         apply_filled_order_to_state(
             order, i, fill.fill_price, fill.is_limit_fill, bar,
@@ -5115,7 +5115,8 @@ int BacktestEngine::pending_order_effective_levels(int index, double* stop,
 // price. Admission therefore never approves one quantity and executes
 // another.
 bool BacktestEngine::stop_entry_margin_admission_declines(
-        const PendingOrder& order, double fill_price, const Bar& /*bar*/) const {
+        const PendingOrder& order, double fill_price, const Bar& /*bar*/,
+        bool flat_dual_stop_pair) const {
     if (order.type != OrderType::ENTRY
         || std::isnan(order.stop_price)
         || !std::isnan(order.limit_price)
@@ -5131,7 +5132,8 @@ bool BacktestEngine::stop_entry_margin_admission_declines(
         || cost_basis <= 0.0) {
         return false;
     }
-    const double fill_qty = use_default_stop_placement_qty(order, fill_price)
+    const double fill_qty = use_default_stop_placement_qty(
+        order, fill_price, flat_dual_stop_pair)
         ? std::abs(order.default_stop_placement_qty)
         : std::abs(calc_qty_for_type(fill_price, order.qty, order.qty_type));
     const double required = fill_qty * cost_basis * syminfo_.pointvalue
@@ -5242,7 +5244,8 @@ void BacktestEngine::apply_filled_order_to_state(
     // CANCELLED (consumed here, removed by compaction). Does NOT touch the
     // :443 created_bar eligibility, the signal-time MARKET gate, or any
     // margin=0 path (all byte-identical when margin_pct==0).
-    if (stop_entry_margin_admission_declines(order, fill_price, bar)) {
+    if (stop_entry_margin_admission_declines(
+            order, fill_price, bar, flat_dual_stop_pair)) {
         decline_and_cancel();
         return;
     }

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -311,6 +311,41 @@ void BacktestEngine::process_pending_orders(const Bar& bar) {
             pending_orders_, dual_entry_path_, process_orders_on_close_,
             calc_on_order_fills_, bar_magnifier_enabled_);
 
+    // A true-flat, same-signal pair owns two independent transactions.
+    // The later stop may reduce, flatten, or reverse the first position.
+    // Snapshot the book before the first fill is compacted; this is local
+    // to the ordinary no-callback scan, never stored in broker/ABI state.
+    bool flat_dual_stop_pair = continue_after_stop_margin_decline_scope
+        && pending_orders_.size() == 2
+        && !coof_scheduler_active_ && !stream_warmup_mode_
+        && stream_phase_ == StreamPhase::IDLE
+        && slippage_ == 0 && commission_value_ == 0.0
+        && account_currency_fx_ == 1.0 && account_currency_fx_timestamps_.empty()
+        && max_intraday_filled_orders_ == 0 && risk_max_position_size_ == 0.0
+        && risk_direction_ == RiskDirection::BOTH
+        && risk_max_intraday_loss_ == 0.0 && risk_max_drawdown_ == 0.0
+        && risk_max_cons_loss_days_ == 0;
+    if (flat_dual_stop_pair) {
+        for (const PendingOrder& member : pending_orders_) {
+            const bool explicit_fixed = std::isfinite(member.qty)
+                && member.qty > kQtyEpsilon
+                && (member.qty_type < 0
+                    || member.qty_type == static_cast<int>(QtyType::FIXED));
+            const bool default_fixed = std::isnan(member.qty)
+                && default_qty_type_ == QtyType::FIXED
+                && default_qty_value_ > 0.0;
+            const bool default_percent = std::isnan(member.qty)
+                && default_qty_type_ == QtyType::PERCENT_OF_EQUITY
+                && default_qty_value_ > 0.0 && default_qty_value_ <= 100.0
+                && std::isfinite(member.default_stop_placement_qty)
+                && member.default_stop_placement_qty > kQtyEpsilon;
+            if (!explicit_fixed && !default_fixed && !default_percent) {
+                flat_dual_stop_pair = false;
+                break;
+            }
+        }
+    }
+
     for (int opposing_pass = 0; opposing_pass < 2; ++opposing_pass) {
         // Pass 1 only re-evaluates orders pass 0 deferred into the skip set;
         // with an empty set every order classifies Skip and the pass is a
@@ -334,7 +369,7 @@ void BacktestEngine::process_pending_orders(const Bar& bar) {
         auto eligibility = classify_order_eligibility(
             order, opposing_pass, dual_entry_path_, pass0_opposing_skip_ids,
             exit_closed_from_bar, exit_closed_from_incarnation,
-            exit_closed_was_long, bar);
+            exit_closed_was_long, bar, flat_dual_stop_pair);
         if (eligibility == OrderEligibility::Remove) {
             invalidate_pending_flat_market_pair(order.created_seq);
             filled_indices.push_back(i);
@@ -379,7 +414,7 @@ void BacktestEngine::process_pending_orders(const Bar& bar) {
             trail_best_path_state,
             exit_closed_from_bar, exit_closed_from_incarnation,
             exit_closed_was_long,
-            filled_indices);
+            filled_indices, flat_dual_stop_pair);
         if (risk_max_intraday_loss_ > 0.0) {
             // The closing fill's own realized P&L is not yet part of the
             // equity TradingView checks at this tick (pinned t1).
@@ -4707,12 +4742,28 @@ void BacktestEngine::compact_filled_pending_orders(
 // close) filling from FLAT — the shape every tape and the ahtisham decode
 // pin. A stop placed while a position is held (a same-direction add, a
 // reversal, a deferred-flip carry) keeps the established fill-time sizing
-// of its kernel, and a fill against a live opposite position keeps the
-// reversal kernel's own sizing; both still passed the family-E placement
-// check at the call. A non-positive fill print (a zero open) falls back too,
+// of its kernel. The ordinary same-signal flat dual-stop transaction keeps
+// its original snapshot for the later opposite fill as well; other live
+// opposite fills retain the reversal kernel's own sizing. Every stop still
+// passed the family-E placement check at the call. A non-positive fill print (a zero open) falls back too,
 // so the zero-lot decline stays byte-identical.
+bool BacktestEngine::flat_dual_stop_opposite_is_live(
+        const PendingOrder& order, bool flat_dual_stop_pair) const {
+    return flat_dual_stop_pair
+        && order.type == OrderType::ENTRY
+        && std::isfinite(order.stop_price) && std::isnan(order.limit_price)
+        && order.created_position_side == PositionSide::FLAT
+        && !order.created_after_position_close_in_bar
+        && position_side_ != PositionSide::FLAT
+        && order.is_long != (position_side_ == PositionSide::LONG)
+        && position_open_bar_ == bar_index_
+        && position_entry_count_ == 1 && pyramid_entries_.size() == 1
+        && position_qty_ > kQtyEpsilon;
+}
+
 bool BacktestEngine::use_default_stop_placement_qty(
-        const PendingOrder& order, double fill_price) const {
+        const PendingOrder& order, double fill_price,
+        bool flat_dual_stop_pair) const {
     if (order.type != OrderType::ENTRY
         || std::isnan(order.stop_price)
         || !std::isnan(order.limit_price)
@@ -4727,7 +4778,8 @@ bool BacktestEngine::use_default_stop_placement_qty(
         && std::isfinite(fill_price) && fill_price > 0.0
         && order.created_position_side == PositionSide::FLAT
         && !order.created_after_position_close_in_bar
-        && position_side_ == PositionSide::FLAT;
+        && (position_side_ == PositionSide::FLAT
+            || flat_dual_stop_opposite_is_live(order, flat_dual_stop_pair));
 }
 
 
@@ -5121,7 +5173,8 @@ void BacktestEngine::apply_filled_order_to_state(
         int& exit_closed_from_bar,
         uint64_t& exit_closed_from_incarnation,
         bool& exit_closed_was_long,
-        std::vector<size_t>& filled_indices) {
+        std::vector<size_t>& filled_indices,
+        bool flat_dual_stop_pair) {
     const bool inherits_pooc_close_fill =
         intraday_cap_count_pooc_full_close_fills_
         && order.incarnation != 0
@@ -6334,7 +6387,8 @@ void BacktestEngine::apply_filled_order_to_state(
         apply_market_order_fill(order, fill_price, bar, trail_best_path_state,
                                 later_same_tick_entry);
     } else if (order.type == OrderType::ENTRY) {
-        apply_entry_order_fill(order, fill_price, bar, trail_best_path_state);
+        apply_entry_order_fill(order, fill_price, bar, trail_best_path_state,
+                               flat_dual_stop_pair);
     } else if (order.type == OrderType::EXIT) {
         apply_exit_order_fill(
             order, fill_price, exit_closed_from_bar,
@@ -7309,7 +7363,8 @@ void BacktestEngine::apply_market_order_fill(PendingOrder& order, double fill_pr
 
 void BacktestEngine::apply_entry_order_fill(PendingOrder& order, double fill_price,
                                             const Bar& bar,
-                                            double& trail_best_path_state) {
+                                            double& trail_best_path_state,
+                                            bool flat_dual_stop_pair) {
     PositionSide side_before = position_side_;
     double qty_before = position_qty_;
     int count_before = position_entry_count_;
@@ -7415,7 +7470,7 @@ void BacktestEngine::apply_entry_order_fill(PendingOrder& order, double fill_pri
     // quantity it was sized with at placement (see
     // use_default_stop_placement_qty); every other stop sizes at the fill.
     const bool use_placement_qty =
-        use_default_stop_placement_qty(order, fill_price);
+        use_default_stop_placement_qty(order, fill_price, flat_dual_stop_pair);
     const double dispatch_qty = use_placement_qty
         ? order.default_stop_placement_qty
         : order.qty;
@@ -8201,7 +8256,8 @@ BacktestEngine::OrderEligibility BacktestEngine::classify_order_eligibility(
         internal::DualEntryStopPathWinner dual_entry_path,
         const std::unordered_set<std::string>& pass0_opposing_skip_ids,
         int exit_closed_from_bar, uint64_t exit_closed_from_incarnation,
-        bool exit_closed_was_long, const Bar& bar) {
+        bool exit_closed_was_long, const Bar& bar,
+        bool flat_dual_stop_pair) {
     using internal::DualEntryStopPathWinner;
     if (order.declined_by_replaced_short_market) {
         return OrderEligibility::Remove;
@@ -8238,16 +8294,18 @@ BacktestEngine::OrderEligibility BacktestEngine::classify_order_eligibility(
         if (!pass0_opposing_skip_ids.count(order.id)) {
             return OrderEligibility::Skip;
         }
-        // Pass 0 deferred this leg as the path loser. TradingView only applies
-        // a same-bar second touch as a bracket exit when the buy-stop leads on
-        // the path; if the sell-stop leads, the later buy touch is discarded.
-        if (dual_entry_path == DualEntryStopPathWinner::ShortFirst && order.is_long) {
-            return OrderEligibility::Remove;
-        }
-        if (!(dual_entry_path == DualEntryStopPathWinner::LongFirst && !order.is_long)) {
-            if (dual_entry_path != DualEntryStopPathWinner::None
-                && dual_entry_path != DualEntryStopPathWinner::Tie) {
+        // The literal two-stop controls are symmetric in path and source
+        // order. Keep the legacy orientation rule outside that proven book;
+        // inside it the later transaction must reach normal fill handling.
+        if (!flat_dual_stop_opposite_is_live(order, flat_dual_stop_pair)) {
+            if (dual_entry_path == DualEntryStopPathWinner::ShortFirst && order.is_long) {
                 return OrderEligibility::Remove;
+            }
+            if (!(dual_entry_path == DualEntryStopPathWinner::LongFirst && !order.is_long)) {
+                if (dual_entry_path != DualEntryStopPathWinner::None
+                    && dual_entry_path != DualEntryStopPathWinner::Tie) {
+                    return OrderEligibility::Remove;
+                }
             }
         }
     }
@@ -8322,22 +8380,19 @@ BacktestEngine::OrderEligibility BacktestEngine::classify_order_eligibility(
         bool flat_armed_opposite_same_bar = flat_armed
             && position_side_ != requested
             && position_open_bar_ == bar_index_;
-        // TV only lets this same-bar opposite leg fire as a bracket exit
-        // when it nets the just-opened position to exactly flat (or a
-        // partial close with no remainder) — probe 80's near-stop pair
-        // (both FIXED qty=1) closes to flat on the very bar the position
-        // opened. When the opposite leg's tx_qty EXCEEDS the just-opened
-        // position's qty (equity/price-based sizing, where the two legs'
-        // divisors differ, guarantees a nonzero remainder), TV does NOT
-        // let the loser fire same-bar at all — it defers the whole order
-        // to a later bar instead of flash-reversing into a small leftover
-        // opposite position (waranyutrkm-inside-day-breakout-strategy).
+        // Preserve the legacy quantity throttle outside the independently
+        // pinned ordinary two-stop book. The covered pair below can consume
+        // a reducing, equal, or excess transaction (the last opens only its
+        // remainder). Other books retain the established no-extra-leg
+        // behavior, including the older inside-day/deferred-order cases.
+        // Probe 80's fixed-one near-stop pair closes exactly flat.
         // Approximate the fill price with the order's own trigger level:
         // exact for FIXED qty (price-independent) and precise enough for
         // equity/cash sizing, whose legs differ by construction, not by
         // slippage-scale noise.
         bool flat_armed_opposite_close = flat_armed_opposite_same_bar;
-        if (flat_armed_opposite_same_bar) {
+        if (flat_armed_opposite_same_bar
+            && !flat_dual_stop_opposite_is_live(order, flat_dual_stop_pair)) {
             // No frozen-qty lookup here: this branch is reached only for
             // OrderType::ENTRY (priced entries), and frozen_default_qty is set
             // solely on MARKET / RAW_ORDER placements, so it is always NaN.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -217,6 +217,7 @@ set(TEST_SOURCES
     test_trail_activation_tick_bar
     test_session_predicates_daily_chart
     test_pooc_money_admission
+    test_dual_stop_transactions
     test_live_run_status
     test_live_realtime_tail
     test_live_probe_suppress_tail

--- a/tests/test_dual_stop_transactions.cpp
+++ b/tests/test_dual_stop_transactions.cpp
@@ -31,6 +31,7 @@ struct Control {
     bool oca = false;
     bool default_percent = false;
     int forced_path = 0;
+    double injected_long_snapshot = NaN;
 };
 
 class Pair : public BacktestEngine {
@@ -61,7 +62,13 @@ public:
             // Derived ABI values at the stable flat signal boundary remain
             // the same quantities the covered transactions later consume.
             for (size_t i = 0; i < pending_orders_.size(); ++i) {
-                const auto& order = pending_orders_[i];
+                auto& order = pending_orders_[i];
+                // Test-only mutation canary, never a TradingView oracle.
+                // Make the actual admission path face an existing snapshot
+                // that is larger than its live-equity re-size.
+                if (order.is_long && std::isfinite(c.injected_long_snapshot)) {
+                    order.default_stop_placement_qty = c.injected_long_snapshot;
+                }
                 double q = NaN;
                 int close_only = -1, partition = -1;
                 CHECK(probe_fill_qty(static_cast<int>(i),
@@ -72,6 +79,8 @@ public:
             }
         }
         if (bar_index_ == 1) {
+            after_fills_signed_qty = signed_position_size();
+            after_fills_live_buy_qty = calc_qty_for_type(long_stop(), NaN, -1);
             strategy_cancel_all();
             strategy_close_all();
         }
@@ -82,6 +91,8 @@ public:
     bool flat_and_empty() const { return position_side_ == PositionSide::FLAT && pending_orders_.empty(); }
     double abi_long_qty = NaN;
     double abi_short_qty = NaN;
+    double after_fills_signed_qty = NaN;
+    double after_fills_live_buy_qty = NaN;
 private:
     Control c;
 };
@@ -135,6 +146,26 @@ void run(const Control& control, std::vector<Expected> expected) {
         CHECK(std::abs(pair.abi_long_qty - (control.capital == 10548 ? 3.16 : 3.15)) < 1e-10);
     }
 }
+// Unlike the literal TV controls, this is a mutation-sensitive component
+// test. A 3.17 snapshot cannot fit capital10548 at the later3337.762 fill,
+// while live re-sizing would approve3.15. Run the real scanner: if either
+// admission caller loses the pair context it approves3.15 but dispatches3.17,
+// incorrectly reversing long0.01. The preserved short proves rejection.
+void admission_snapshot_canary() {
+    Control control{"admission uses dispatched snapshot",false,3.16,3.16,
+                    10548,100,false,false,true,0,3.17};
+    Pair pair(control);
+    const Bar bars[] = {
+        {3332.84,3332.87,3330.565,3330.965,1497,1755560700000LL},
+        {3330.915,3337.985,3326.285,3336.315,5952,1755561600000LL},
+        {3336.29,3339.355,3335.65,3337.485,2256,1755562500000LL},
+    };
+    pair.run(bars,3);
+    CHECK(std::abs(pair.abi_long_qty - 3.17) < 1e-10);
+    CHECK(std::abs(pair.after_fills_live_buy_qty - 3.15) < 1e-10);
+    CHECK(std::abs(pair.after_fills_signed_qty + 3.16) < 1e-10);
+    CHECK(pair.flat_and_empty());
+}
 } // namespace
 
 int main() {
@@ -154,6 +185,7 @@ int main() {
     // Forcing the already-natural order changes no transaction policy.
     run({"same low-first path forced",false,3.15,3.16,20000,100,false,false,false,2}, less);
     run({"same high-first path forced",true,3.16,3.15,20000,100,false,false,false,1}, {{true,3.15,3333,3331.5,1}, {true,0.01,3333,3332.84,2}});
+    admission_snapshot_canary();
     std::printf("%d passed, %d failed\n", passed, failed);
     return failed ? 1 : 0;
 }

--- a/tests/test_dual_stop_transactions.cpp
+++ b/tests/test_dual_stop_transactions.cpp
@@ -1,0 +1,159 @@
+/*
+ * Literal TradingView dual-stop transaction controls, exported 2026-09-08.
+ * OANDA:XAUUSD 15m, 2025-08-18..20; no indicator or corpus execution here.
+ * The low-first and high-first bars each touch two stops armed while flat.
+ * TV reduces / flattens / reverses by the second transaction, independently
+ * of source call order; OCA cancel removes the second order. Capital 10548
+ * distinguishes a frozen default BUY 3.16 from a live re-size to 3.15.
+ * The independent short-only margin-amount question is outside this test.
+ */
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+namespace {
+int passed = 0;
+int failed = 0;
+#define CHECK(x) do { if (x) ++passed; else { ++failed; std::printf("FAIL %s:%d %s\n", __FILE__, __LINE__, #x); } } while (0)
+const double NaN = std::numeric_limits<double>::quiet_NaN();
+
+struct Control {
+    const char* name;
+    bool high_first = false;
+    double long_qty = 3.15;
+    double short_qty = 3.16;
+    double capital = 20000;
+    double margin = 100;
+    bool reverse_calls = false;
+    bool oca = false;
+    bool default_percent = false;
+    int forced_path = 0;
+};
+
+class Pair : public BacktestEngine {
+public:
+    explicit Pair(Control control) : c(control) {
+        initial_capital_ = c.capital;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100;
+        commission_value_ = 0;
+        slippage_ = 0;
+        pyramiding_ = 1;
+        margin_long_ = margin_short_ = c.margin;
+        qty_step_ = 0.01;
+        syminfo_mintick_ = 0.001;
+        set_margin_call_enabled(true);
+        set_path_order(c.forced_path);
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            auto enter = [&](bool is_long) {
+                strategy_entry(is_long ? "L" : "S", is_long, NaN,
+                    is_long ? long_stop() : short_stop(),
+                    c.default_percent ? NaN : (is_long ? c.long_qty : c.short_qty),
+                    "", c.oca ? "pair" : "", c.oca ? 1 : 0);
+            };
+            enter(!c.reverse_calls);
+            enter(c.reverse_calls);
+            // Derived ABI values at the stable flat signal boundary remain
+            // the same quantities the covered transactions later consume.
+            for (size_t i = 0; i < pending_orders_.size(); ++i) {
+                const auto& order = pending_orders_[i];
+                double q = NaN;
+                int close_only = -1, partition = -1;
+                CHECK(probe_fill_qty(static_cast<int>(i),
+                    order.is_long ? long_stop() : short_stop(),
+                    &q, &close_only, &partition) == 0);
+                if (order.is_long) abi_long_qty = q;
+                else abi_short_qty = q;
+            }
+        }
+        if (bar_index_ == 1) {
+            strategy_cancel_all();
+            strategy_close_all();
+        }
+    }
+    double long_stop() const { return c.high_first ? 3333.0 : 3337.762; }
+    double short_stop() const { return c.high_first ? 3331.5 : 3327.593; }
+    const std::vector<Trade>& closed() const { return trades_; }
+    bool flat_and_empty() const { return position_side_ == PositionSide::FLAT && pending_orders_.empty(); }
+    double abi_long_qty = NaN;
+    double abi_short_qty = NaN;
+private:
+    Control c;
+};
+
+struct Expected {
+    bool is_long;
+    double qty;
+    double entry;
+    double exit;
+    int exit_bar;
+};
+
+void run(const Control& control, std::vector<Expected> expected) {
+    std::printf("-- %s --\n", control.name);
+    std::vector<Bar> bars;
+    if (control.high_first) {
+        bars = {
+            {3333.595, 3333.61, 3331.785, 3332.325, 627, 1755558900000LL},
+            {3332.36, 3333.275, 3331.37, 3332.88, 1185, 1755559800000LL},
+            {3332.84, 3332.87, 3330.565, 3330.965, 1497, 1755560700000LL},
+        };
+    } else {
+        bars = {
+            {3332.84, 3332.87, 3330.565, 3330.965, 1497, 1755560700000LL},
+            {3330.915, 3337.985, 3326.285, 3336.315, 5952, 1755561600000LL},
+            {3336.29, 3339.355, 3335.65, 3337.485, 2256, 1755562500000LL},
+        };
+    }
+    Pair pair(control);
+    pair.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(pair.closed().size() == expected.size());
+    const size_t n = std::min(pair.closed().size(), expected.size());
+    for (size_t i = 0; i < n; ++i) {
+        const auto& got = pair.closed()[i];
+        const auto& want = expected[i];
+        CHECK(got.is_long == want.is_long);
+        CHECK(std::abs(got.qty - want.qty) < 1e-10);
+        CHECK(std::abs(got.entry_price - want.entry) < 1e-9);
+        CHECK(std::abs(got.exit_price - want.exit) < 1e-9);
+        CHECK(got.entry_time == bars[1].timestamp);
+        CHECK(got.exit_time == bars[want.exit_bar].timestamp);
+        CHECK(got.entry_bar_index == 1);
+        CHECK(got.exit_bar_index == want.exit_bar);
+    }
+    CHECK(pair.flat_and_empty());
+    double ignored = 0;
+    int close_only = 0, partition = 0;
+    CHECK(pair.probe_fill_qty(0, 3333, &ignored, &close_only, &partition) == -1);
+    if (control.default_percent) {
+        CHECK(std::abs(pair.abi_short_qty - 3.16) < 1e-10);
+        CHECK(std::abs(pair.abi_long_qty - (control.capital == 10548 ? 3.16 : 3.15)) < 1e-10);
+    }
+}
+} // namespace
+
+int main() {
+    const std::vector<Expected> less = {{false,3.15,3327.593,3337.762,1}, {false,0.01,3327.593,3336.29,2}};
+    run({"short first: partial"}, less);
+    run({"short first: equal",false,3.16,3.16}, {{false,3.16,3327.593,3337.762,1}});
+    run({"short first: excess",false,3.17,3.16}, {{false,3.16,3327.593,3337.762,1}, {true,0.01,3337.762,3336.29,2}});
+    run({"short first: reversed source calls",false,3.15,3.16,20000,100,true}, less);
+    run({"short first: OCA cancel",false,3.15,3.16,20000,100,false,true}, {{false,3.16,3327.593,3336.29,2}});
+    run({"short first: default percent",false,3.15,3.16,10542.28225,100,false,false,true}, less);
+    run({"high first: partial",true,3.16,3.15}, {{true,3.15,3333,3331.5,1}, {true,0.01,3333,3332.84,2}});
+    run({"high first: equal",true,3.16,3.16}, {{true,3.16,3333,3331.5,1}});
+    run({"high first: excess",true,3.16,3.17}, {{true,3.16,3333,3331.5,1}, {false,0.01,3331.5,3332.84,2}});
+    run({"default snapshot discriminator",false,3.16,3.16,10548,100,false,false,true}, {{false,3.16,3327.593,3337.762,1}});
+    run({"default snapshot reversed calls",false,3.16,3.16,10548,100,true,false,true}, {{false,3.16,3327.593,3337.762,1}});
+    run({"default snapshot margin disabled",false,3.16,3.16,10548,0,false,false,true}, {{false,3.16,3327.593,3337.762,1}});
+    // Forcing the already-natural order changes no transaction policy.
+    run({"same low-first path forced",false,3.15,3.16,20000,100,false,false,false,2}, less);
+    run({"same high-first path forced",true,3.16,3.15,20000,100,false,false,false,1}, {{true,3.15,3333,3331.5,1}, {true,0.01,3333,3332.84,2}});
+    std::printf("%d passed, %d failed\n", passed, failed);
+    return failed ? 1 : 0;
+}

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -708,11 +708,10 @@ static void test_blocked_entry_does_not_consume_intraday_fill_quota() {
 // This is the exact-zero-remainder case (both legs FIXED qty=1): confirmed by
 // real corpus probe 80 (order-dual-stop-both-touch-priority-01, Trade 1 —
 // entry long + exit long at the identical timestamp). When the opposite leg's
-// qty is NOT equal (equity/price-based sizing, e.g. equity/priceA vs
-// equity/priceB), TV instead defers the whole order to a later bar rather
-// than flattening-with-remainder — see
-// waranyutrkm-inside-day-breakout-strategy and classify_order_eligibility's
-// flat_armed_opposite_close remainder check.
+// qty differs, the 2026-09-08 ordinary unlinked-pair controls additionally
+// pin partial closes and excess-quantity reversals in both directions;
+// test_dual_stop_transactions covers those transaction quantities. Other
+// order-book classes retain their separately tested legacy rules.
 static void test_flat_bracket_dual_stop_closes_on_opposite_touch() {
     std::printf("test_flat_bracket_dual_stop_closes_on_opposite_touch\n");
 
@@ -4945,9 +4944,21 @@ static void test_opposite_stop_entries_follow_path_order() {
 
     strat.run(bars, 2);
 
-    CHECK(strat.trade_count() == 0);  // no exit yet
-    CHECK(strat.get_signed_position_size() < 0.0);
-    CHECK(near(strat.get_entry_price(), 95.0, 0.5));
+    // 2026-09-08 independent default-FIXED TV controls (pyramiding
+    // omitted/0/1) confirm that the later unlinked stop closes the first
+    // one-unit position. Keep the first-fill path proof and assert its
+    // subsequent close instead of the old unsupported no-exit expectation.
+    CHECK(strat.trade_count() == 1);
+    CHECK(near(strat.get_signed_position_size(), 0.0, 1e-9));
+    if (strat.trade_count() == 1) {
+        const auto& trade = strat.get_trade(0);
+        CHECK(!trade.is_long);
+        CHECK(near(trade.entry_price, 95.0, 1e-9));
+        CHECK(near(trade.exit_price, 105.0, 1e-9));
+        CHECK(near(trade.qty, 1.0, 1e-9));
+        CHECK(trade.entry_time == bars[1].timestamp);
+        CHECK(trade.exit_time == bars[1].timestamp);
+    }
 }
 
 // The opposing-stop arbitration helper also has to follow the open-proximity
@@ -4986,9 +4997,21 @@ static void test_opposite_stop_entries_use_open_proximity_path_priority() {
 
     strat.run(bars, 2);
 
-    CHECK(strat.trade_count() == 0);
-    CHECK(strat.get_signed_position_size() < 0.0);
-    CHECK(near(strat.get_entry_price(), 97.0, 0.5));
+    // 2026-09-08 independent default-FIXED TV controls (pyramiding
+    // omitted/0/1) confirm that the later unlinked stop closes the first
+    // one-unit position. Keep the first-fill path proof and assert its
+    // subsequent close instead of the old unsupported no-exit expectation.
+    CHECK(strat.trade_count() == 1);
+    CHECK(near(strat.get_signed_position_size(), 0.0, 1e-9));
+    if (strat.trade_count() == 1) {
+        const auto& trade = strat.get_trade(0);
+        CHECK(!trade.is_long);
+        CHECK(near(trade.entry_price, 97.0, 1e-9));
+        CHECK(near(trade.exit_price, 105.0, 1e-9));
+        CHECK(near(trade.qty, 1.0, 1e-9));
+        CHECK(trade.entry_time == bars[1].timestamp);
+        CHECK(trade.exit_time == bars[1].timestamp);
+    }
 }
 
 // strategy.close(id) must only close entries matching that id.


### PR DESCRIPTION
Ordinary unlinked stop-entry pairs placed while flat could discard a later buy-stop touch after the first sell stop filled. The later transaction now reduces, flattens, or reverses only its remaining quantity in either path direction. Default percent-of-equity orders retain the same placement quantity through admission and execution.

The scope follows the two-order book and position provenance. It introduces no strategy/symbol/date lookup, persistent broker field, ABI export, or hash waiver. Sixteen independently exported TradingView controls and a Cloud trace of the original output establish the rule. The trace confirmed the exact removal branch before the later margin liquidation.

Validation:

- 244 native checks and 260 transaction assertions pass, including a mutation canary that fails on the original admission/dispatch mismatch.
- Exact-head independent Grok review and Codex audit; C ABI, state-hash coverage, and pending-order mirror checks pass.
- Complete engine control: 72 cases / 4,190 probes, 4,178 excellent / 12 strong / 0 moderate. Ahtisham XAUUSD 15m is the only canonical conversion, matching all 514 raw trade identities exactly.
- Seven hard corpus probes gain 72 exact raw trade matches with none lost. Other 4,182 CSVs are unchanged; all 4,189 other probes retain canonical grades and quantity metrics. Existing residuals remain disclosed.
- README reflects the measured board. Grading rules, profile selection, input files, reference tapes, feeds, and population are unchanged.

This engine change and the codegen constant-folder security fix are one composite campaign candidate. Two complete final-composite sweeps agree on all 4,190 CSVs, grades, quantity metrics, input/lane identities, matched counts and reference counts. Corrected codegen contributes no output delta versus the engine control. Formal Cloud gate `pineforge-pr-gate-p9fmx`: **PASS**, target score **+1**, 4,190 comparable probes, 704 hard probes, **zero regressions and zero tolerated exceptions**. The exact composite receipt is recorded in Postgres; the publish hook corroborates it before publication. Both repositories must merge at their exact gated commits before composite baseline promotion.
