### PR TITLE
Fix margin timing around carried POOC trailing exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 TradingView's strategy tester is the reference every Pine author trusts, and nothing outside TradingView reproduced it — until now. PineForge is a C++17 runtime with a stable C ABI that runs PineScript v6 strategies exactly the way TradingView's broker emulator does: same fills, same sizing, same margin calls, same trailing stops, same `request.security()` buckets, on any OHLCV you give it, in microseconds per bar.
 
-- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,178 excellent, 12 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,448 matched by the verifier.
+- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,179 excellent, 11 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,468 matched by the verifier.
 - **Open.** Engine, transpiler, corpus, benchmarks and the validation tooling are all public and Apache-2.0. The only thing you cannot download is the closed test set, because TradingView's Terms of Service forbid redistributing community scripts.
 - **Fast.** In-process, no interpreter: median **162× faster than PyneCore** on 99 timed strategies. Parameter sweeps re-run a loaded `.so` with new inputs — no recompile, no fork.
 - **Deterministic to the bit.** Two runs with the same inputs produce identical trade lists. Same on Linux and macOS.
@@ -76,7 +76,7 @@ Prefer zero install? The hosted server at **[mcp.pineforge.dev/mcp](https://mcp.
 git clone https://github.com/pineforge-4pass/pineforge-engine.git && cd pineforge-engine
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
-ctest --test-dir build --output-on-failure     # 225 tests
+ctest --test-dir build --output-on-failure     # all enabled unit, replay and ABI checks
 bash tutorial/run.sh                            # MACD on BTC/USDT, end to end
 python3 tutorial/run_stream.py                  # OHLCV warm-up → realtime trades
 ```
@@ -108,18 +108,20 @@ Every PineForge-compiled strategy `.so` exports this same ABI — write the harn
 
 ## Validation scoreboard
 
-**Round 35 · 2026-09-08:** **4,178 excellent / 12 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
+**Round 36 · 2026-09-09:** **4,179 excellent / 11 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
 
 | Board | Test set | Result | TradingView trades evaluated |
 |---|---|---|---|
 | **Public** — [open corpus](https://github.com/pineforge-4pass/pineforge-corpus) | 312 reference strategies, Apache-2.0, reproducible by anyone | **309/309 graded excellent** (ETH/USDT-perp 15m; the corpus' declared engine-only / anomaly probes are not graded) | 429,866 |
-| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,869 excellent + 12 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
+| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,870 excellent + 11 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
 
-**2,819,967 TradingView trades** evaluated, **2,817,448 matched by the verifier** (99.91%), from the round 35 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
+**2,819,967 TradingView trades** evaluated, **2,817,468 matched by the verifier** (99.91%), from the round 36 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
 
-Round 35 corrects ordinary pairs of unlinked stop-entry orders placed while flat. After the first stop opens a position, the later stop consumes its own transaction quantity: it can partially close, flatten, or reverse only the remainder, in either path direction. Default percent-of-equity stops retain their placement quantity consistently through admission and execution. **Decoded Volatility Expansion** on **OANDA:XAUUSD 15m** moves from strong to excellent: zero count gap, 100% canonical match, and zero entry-price, exit-price, PnL and quantity error at the 90th percentile. All **514 closed-trade identities** match TradingView on entry/exit time, side, quantity and prices.
+Round 36 corrects the timing of margin events around owned trailing exits under `process_orders_on_close`. A carried short's liquidation precedes the script's position/equity reads and default sizing. A carried long's money-rounding check uses only price-path waypoints before its resolved trailing exit. Short margin excursions include the favorable prices reached before liquidation, without borrowing a later low.
 
-The rule uses order-book and position provenance, with no strategy, symbol or date lookup. Sixteen independent TradingView controls and an unchanged-output Cloud trace pin the cause. Seven hard-surface corpus probes gain **72 exact trade matches**, with no previously exact match lost; their canonical grades and metrics remain unchanged. The other **4,182 trade CSVs are byte-identical** to round 34, and all **4,189 other probes** retain their canonical grades and quantity metrics. Verifier code, grading rules, profile-selection code, reference tapes, feeds, input files and scored population are unchanged.
+**EMA 9 + VWAP Strategy with ATR Trailing Stop (WinTheTrade)** on **OANDA:EURUSD 15m** moves from strong to excellent: 100% canonical match, zero count gap, and zero entry-price, exit-price, PnL and quantity error at the 90th percentile. On **BINANCE:BTCUSDT 15m**, the same strategy remains excellent and its quantity error falls to zero; all **2,158 raw closed-trade identities** match TradingView. EURUSD has **1,757 of 1,759 raw identities exact**: one remaining closing group is split into two TradingView allocations but combined by the engine at the same times and prices, with the same total quantity. This is not a claim of complete raw allocation or PnL display-byte equality.
+
+The rules use physical order and position provenance, with no strategy, symbol or date lookup. Independent TradingView controls and Cloud diagnostics pin the event order and the price-path boundary. All **704 hard-surface probes** retain their canonical grades and metrics. Verifier code, grading rules, profile-selection code, reference tapes, feeds, input files and scored population are unchanged.
 
 ### The closed test, lane by lane
 
@@ -137,10 +139,10 @@ The rule uses order-book and position provenance, with no strategy, symbol or da
 | NSE:NIFTY · 1D | 145 | 145 | — | — |
 | NYSE:F · 15m | 340 | 336 | 4 | — |
 | NYSE:F · 1D | 263 | 263 | — | — |
-| OANDA:EURUSD · 15m | 373 | 371 | 2 | — |
+| OANDA:EURUSD · 15m | 373 | 372 | 1 | — |
 | OANDA:XAUUSD · 15m | 376 | 375 | 1 | — |
 | OANDA:XAUUSD · 1D | 248 | 248 | — | — |
-| **Total** | **3,881** | **3,869** | **12** | **0** |
+| **Total** | **3,881** | **3,870** | **11** | **0** |
 
 ### How a probe is graded
 
@@ -192,7 +194,7 @@ PyneCore's 15 non-excellent strategies involve `strategy.exit(stop=…, limit=�
 - `libpineforge.a` — the static runtime: order matching and fills, sizing and margin, the bar magnifier, 66 indicator classes, `request.security()`, time and session math.
 - `<pineforge/pineforge.h>` — the public C ABI, the stability-pinned consumer surface.
 - `<pineforge/*.hpp>` — internal C++ headers the transpiler emits against (not part of the stability guarantee).
-- 223 ctest cases, most of them replays of recorded TradingView bars; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
+- C++ unit and recorded TradingView replay tests; CI on Linux + macOS × Release + Debug, sanitizers, and a `find_package` smoke consumer.
 - `corpus/` — the 312-strategy public validation corpus (submodule).
 - `benchmarks/` — the three-way comparison harness and the throughput package.
 - `scripts/` — `run_corpus.sh`, `verify_corpus.py`, `run_strategy.py` (load any `.so` via ctypes), `regen_corpus_cpp.sh`, `coverage.sh`.
@@ -258,7 +260,7 @@ src/                    26 .cpp files split by concern
   ├── ta_*.cpp                        66 indicator classes (moving averages, oscillators,
   │                                   volatility/trend, extremes/volume, misc)
   └── magnifier / matrix / session_time / timeframe / timezone / math / str_utils
-tests/                  223 ctest cases (C++ unit + TradingView replay tests, 1 pure-C ABI check)
+tests/                  C++ unit, TradingView replay and pure-C ABI tests
 corpus/                 public submodule: 312 strategies + the 1-minute feed and derived 15m bars
 benchmarks/             three-way comparison harness, throughput package, results/
 scripts/                run_corpus.sh, verify_corpus.py, run_strategy.py, regen_corpus_cpp.sh, coverage.sh

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1995,7 +1995,7 @@ protected:
                         const std::string& oca_name = "",
                         int oca_type = 0);
 
-    void process_pending_orders(const Bar& bar);
+    void process_pending_orders(const Bar& bar, bool before_pooc_script = false);
     struct CoofFillResult {
         bool filled = false;
         double fill_price = std::numeric_limits<double>::quiet_NaN();
@@ -4103,14 +4103,20 @@ private:
     // margin-call trigger on a margin-100 LONG (process_margin_call; rule
     // and pins on tv_money_long_margin_call in engine_fills.cpp).
     // The POOC extension is called only before the close-time script or at
-    // the specifically scoped positive-slip opening point, with no pending
-    // broker orders. End-of-bar callers keep it disabled so a
+    // the specifically scoped positive-slip opening point, normally with no
+    // pending broker orders. End-of-bar callers keep it disabled so a
     // close/add cannot make earlier prices act on the post-close position.
     // Opening-only callers retain the actual chart bar for all eligibility
-    // checks while restricting valuation to its first path point.
+    // checks while restricting valuation to its first path point. A scoped
+    // old trailing exit can instead bound valuation strictly before its fill.
     bool tv_money_long_margin_call(const Bar& bar,
                                   bool carried_pooc_pre_close = false,
-                                  bool opening_only = false);
+                                  bool opening_only = false,
+                                  double before_exit_path_position =
+                                      std::numeric_limits<double>::quiet_NaN());
+    bool pooc_trail_money_pre_exit_scope(const Bar& bar,
+                                        const PendingOrder& order,
+                                        double exit_path_position) const;
     // Positive-slip, single terminal-C MARKET lot covered by the opening
     // money-event controls. Shared by post-entry deferral and next-O dispatch.
     bool pooc_opening_money_scope(const Bar& bar) const;

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -1331,6 +1331,17 @@ void BacktestEngine::process_carried_pooc_short_margin_before_script(const Bar& 
         if (!std::isfinite(trigger_bar.low) || !(trigger_bar.low > activation)) {
             return;
         }
+        // This newly earlier checkpoint precedes the normal full-bar
+        // excursion sample. Preserve the price path actually visited before
+        // the short's adverse high, including a favorable low on low-first
+        // bars; never give the liquidated slice a later high-first bar's low.
+        double prefix_low = std::min(bar.open, bar.high);
+        if (!internal::bar_path_uses_high_first(bar)) {
+            prefix_low = std::min(prefix_low, bar.low);
+        }
+        auto& entry = pyramid_entries_.front();
+        const double runup = (entry.price - prefix_low) * entry.qty;
+        if (runup > entry.max_runup) entry.max_runup = runup;
     }
     const std::size_t trades_before = trades_.size();
     process_margin_call(bar);

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -246,7 +246,8 @@ void BacktestEngine::process_carried_long_money_before_priced_orders(
                               /*opening_only=*/true);
 }
 
-void BacktestEngine::process_pending_orders(const Bar& bar) {
+void BacktestEngine::process_pending_orders(const Bar& bar, bool before_pooc_script) {
+    const uint64_t fills_at_pass_start = broker_fill_event_seq_;
     // Update risk state
     update_risk_state();
     process_carried_long_money_before_priced_orders(bar);
@@ -394,8 +395,12 @@ void BacktestEngine::process_pending_orders(const Bar& bar) {
         // pre-on_bar equity, so re-freeze default-sized market orders
         // exactly like the end-of-bar call sites do.
         if (fill.exit_path_fill
-            && margin_call_slice_before_priced_exit(
-                   bar, fill.fill_price, fill.exit_path_position)) {
+            && ((before_pooc_script && broker_fill_event_seq_ == fills_at_pass_start
+                 && pooc_trail_money_pre_exit_scope(bar, order, fill.exit_path_position)
+                 && tv_money_long_margin_call(bar, /*carried_pooc_pre_close=*/true,
+                                              /*opening_only=*/false, fill.exit_path_position))
+                || margin_call_slice_before_priced_exit(
+                       bar, fill.fill_price, fill.exit_path_position))) {
             refresh_frozen_default_sizing_after_margin_call();
         }
 
@@ -1905,9 +1910,58 @@ bool BacktestEngine::pooc_opening_money_scope(const Bar& bar) const {
         && entry.entry_bar_index == position_open_bar_;
 }
 
+// The resolved trail fill owns a path position, so only earlier waypoints
+// can value this still-carried lot. An unresolved foreign EXIT is not a
+// competing reservation on that lot; other live orders keep their old path.
+bool BacktestEngine::pooc_trail_money_pre_exit_scope(
+        const Bar& bar, const PendingOrder& order, double exit_path_position) const {
+    if (!process_orders_on_close_ || position_side_ != PositionSide::LONG
+        || calc_on_order_fills_ || coof_scheduler_active_ || bar_magnifier_enabled_
+        || stream_warmup_mode_ || stream_phase_ != StreamPhase::IDLE
+        || position_open_bar_ < 0 || position_open_bar_ >= bar_index_
+        || bar.timestamp != current_bar_.timestamp
+        || !(position_qty_ > 1.0 + kQtyEpsilon) || !std::isfinite(position_qty_)
+        || position_entry_count_ != 1 || pyramid_entries_.size() != 1
+        || pyramiding_ < 0 || pyramiding_ > 1
+        || pyramid_entries_.front().entry_bar_index != position_open_bar_
+        || pyramid_entries_.front().entry_incarnation == 0
+        || commission_value_ != 0.0 || slippage_ != 0
+        || margin_long_ != 100.0 || syminfo_.pointvalue != 1.0
+        || active_account_currency_fx() != 1.0
+        || !account_currency_fx_timestamps_.empty()
+        || !(qty_step_ > 0.0 && qty_step_ < 1.0) || !tv_money_scope(bar.close)
+        || !std::isfinite(exit_path_position)
+        || !(exit_path_position > kPathPosEps) || exit_path_position > 3.0 + kPathPosEps
+        || order.type != OrderType::EXIT
+        || order.from_entry != pyramid_entries_.front().entry_id
+        || order.created_bar >= bar_index_ || order.dormant_bracket
+        || order.dormant_reissue_pending || order.suppress_as_declined_reversal_close
+        || !order.oca_name.empty() || order.oca_type != 0
+        || !std::isnan(order.stop_price) || !std::isnan(order.limit_price)
+        || !std::isnan(order.profit_ticks) || !std::isnan(order.loss_ticks)
+        || !std::isfinite(order.trail_offset) || !(order.trail_offset > 0.0)
+        || (!std::isfinite(order.trail_points) && !std::isfinite(order.trail_price))) {
+        return false;
+    }
+    const bool full_position = std::isfinite(order.qty)
+        ? order.qty >= position_qty_
+        : std::isnan(order.qty) && std::isfinite(order.qty_percent)
+            && order.qty_percent >= 100.0;
+    if (!full_position) return false;
+    for (const auto& other : pending_orders_) {
+        if (&other == &order) continue;
+        if (other.type != OrderType::EXIT || other.from_entry.empty()
+            || cycle_filled_entry_ids_.count(other.from_entry) != 0
+            || other.created_bar >= bar_index_ || other.dormant_bracket
+            || other.dormant_reissue_pending) return false;
+    }
+    return true;
+}
+
 bool BacktestEngine::tv_money_long_margin_call(const Bar& bar,
                                               bool carried_pooc_pre_close,
-                                              bool opening_only) {
+                                              bool opening_only,
+                                              double before_exit_path_position) {
     if (!margin_call_enabled_) return false;
     if (position_side_ != PositionSide::LONG) return false;
     if (!std::isfinite(margin_long_)
@@ -1920,17 +1974,22 @@ bool BacktestEngine::tv_money_long_margin_call(const Bar& bar,
             || (coof_scheduler_active_ && !coof_fill_recalc_active_
                 && !coof_evaluating_path_segment_
                 && !coof_cursor_is_bar_close_ && coof_hist_path_index_ == 0));
+    const bool before_trail_exit = carried_pooc_pre_close && !opening_only
+        && std::isfinite(before_exit_path_position)
+        && before_exit_path_position > kPathPosEps
+        && before_exit_path_position <= 3.0 + kPathPosEps;
     if (process_orders_on_close_) {
-        // Apart from the separately proven positive-slip opening-only route,
-        // this extension has no oracle for pending orders racing the money
-        // trigger, adds, fees/slippage, currency conversion or risk-forced
-        // exits. Keep their prior POOC behavior. End-of-bar calls stay out
+        // Apart from the positive-slip opening-only route and the validated
+        // old trailing exit's bounded path, pending-order races, adds,
+        // fees/slippage, conversion and risk-forced exits keep their prior
+        // POOC behavior. End-of-bar calls stay out
         // even when the script merely reduced an older position: its current
         // quantity did not exist over this bar's already-traversed path.
         if (!carried_pooc_pre_close || position_open_bar_ < 0
-            || position_open_bar_ >= bar_index_ || !pending_orders_.empty()
+            || position_open_bar_ >= bar_index_
+            || (!pending_orders_.empty() && !before_trail_exit)
             || opening_affordability_pending_
-            || (pyramiding_ != 0 && !slipped_pooc_open)
+            || (pyramiding_ != 0 && !slipped_pooc_open && !before_trail_exit)
             || position_entry_count_ != 1 || pyramid_entries_.size() != 1
             || pyramid_entries_.front().entry_bar_index >= bar_index_
             || commission_value_ != 0.0
@@ -1995,6 +2054,8 @@ bool BacktestEngine::tv_money_long_margin_call(const Bar& bar,
     int fire_path_point = -1;
     const int path_end = opening_only ? 1 : 4;
     for (int i = start; i < path_end; ++i) {
+        if (before_trail_exit
+            && !(static_cast<double>(i) < before_exit_path_position - kPathPosEps)) break;
         const double p = path[i];
         if (!std::isfinite(p) || !(p > 0.0)) continue;
         const double value = qty * p * pv * fx;

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -1280,12 +1280,12 @@ void BacktestEngine::process_carried_pooc_short_margin_before_script(const Bar& 
         || last_margin_call_event_bar_ == bar_index_) {
         return;
     }
-    // These controls cover exact required-margin valuation. A sub-account-unit
-    // lot uses the separately rounded-money cascade; its carried POOC state
-    // still has unresolved ownership/budget evidence and retains its existing
-    // scheduling. Use the broker's established financial class at this same
-    // adverse mark, rather than inferring the class from a symbol or strategy.
-    if (tv_money_scope(round_to_mintick(bar.high))) return;
+    // Rounded-money positions have their own admission arithmetic. Extend
+    // this checkpoint only when a full owned trailing exit remains inactive
+    // throughout the completed old-order pass. Its resting instruction cannot
+    // postpone the carried position's margin event until after close sizing.
+    const bool rounded_money = tv_money_scope(round_to_mintick(bar.high));
+    if (rounded_money && pending_orders_.size() != 1) return;
     for (const auto& order : pending_orders_) {
         // The completed old-order pass proved this bracket unfilled. Reject
         // competing entries/closes, foreign/global owners and deferred order
@@ -1300,6 +1300,30 @@ void BacktestEngine::process_carried_pooc_short_margin_before_script(const Bar& 
             || order.dormant_bracket || order.dormant_reissue_pending
             || !std::isnan(order.profit_ticks) || !std::isnan(order.loss_ticks)
             || (!priced && !trailing)) {
+            return;
+        }
+    }
+    if (rounded_money) {
+        const auto& order = pending_orders_.front();
+        const bool full_position = std::isfinite(order.qty)
+            ? order.qty >= position_qty_
+            : std::isnan(order.qty) && std::isfinite(order.qty_percent)
+                && order.qty_percent >= 100.0;
+        if (!full_position || !std::isfinite(order.trail_offset)
+            || !(order.trail_offset > 0.0)
+            || !std::isnan(order.stop_price) || !std::isnan(order.limit_price)) {
+            return;
+        }
+        double stop = 0.0, limit = 0.0, activation = 0.0;
+        if (pending_order_effective_levels(0, &stop, &limit, &activation) != 0
+            || !std::isnan(stop) || !std::isnan(limit)
+            || !std::isfinite(activation)
+            || !std::isfinite(trail_best_price_)
+            || !(trail_best_price_ > activation)) {
+            return;
+        }
+        const Bar trigger_bar = broker_trigger_bar(bar);
+        if (!std::isfinite(trigger_bar.low) || !(trigger_bar.low > activation)) {
             return;
         }
     }

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -223,7 +223,7 @@ void BacktestEngine::dispatch_bar() {
     if (process_orders_on_close_) {
         const bool no_pending_broker_orders = pending_orders_.empty();
         const uint64_t fills_before_pending = broker_fill_event_seq_;
-        process_pending_orders(current_bar_);   // step 1: old stop/limit
+        process_pending_orders(current_bar_, /*before_pooc_script=*/true); // step 1: old stop/limit
         evaluate_max_intraday_loss_over_path(current_bar_);
         // Round 13 D: the carried 1x-long rounded-money event belongs before
         // the close-time script. TV's full/30% close pins read the already

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SOURCES
     test_stop_open_margin_script_state
     test_carried_pooc_short_margin_state
     test_rounded_carried_short_trail
+    test_pooc_long_money_before_trail
     test_pooc_flat_signal_cost
     test_small_money_margin_residual
     test_high_value_signal_cost

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TEST_SOURCES
     test_open_money_before_priced_exit
     test_stop_open_margin_script_state
     test_carried_pooc_short_margin_state
+    test_rounded_carried_short_trail
     test_pooc_flat_signal_cost
     test_small_money_margin_residual
     test_high_value_signal_cost

--- a/tests/test_pooc_long_money_before_trail.cpp
+++ b/tests/test_pooc_long_money_before_trail.cpp
@@ -1,0 +1,167 @@
+// Literal controls for the rounding trim before a carried POOC long's trail.
+// Synthetic timestamps; no historical feed, Pine source or grader is loaded.
+#include <pineforge/engine.hpp>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+constexpr double qnan = std::numeric_limits<double>::quiet_NaN();
+int passed = 0, failed = 0;
+#define CHECK(x) do { if (x) ++passed; else { ++failed; std::printf("FAIL %d %s\n", __LINE__, #x); } } while (0)
+bool near(double a, double b) { return std::abs(a - b) < 1e-7; }
+const std::vector<Bar> bars = {
+    {1.15186, 1.15267, 1.15179, 1.15226, 1755, 1000},
+    {1.15225, 1.15285, 1.15194, 1.15252, 1631, 2000},
+    {1.15256, 1.15277, 1.15230, 1.15240, 1323, 3000},
+    {1.15240, 1.15272, 1.15210, 1.15263, 1659, 4000},
+};
+
+class LongTrail : public BacktestEngine {
+public:
+    bool explicit_qty = false;
+    bool foreign = true;
+    bool entry_active = false;
+    bool parked = false;
+    bool no_exit = false;
+    double entry_qty = 866832.09;
+    double script_view = qnan;
+    LongTrail(bool funded = false, int pyramid = 0,
+              double capital = 998815.9440528) {
+        initial_capital_ = capital + (funded ? 0.01 : 0.0);
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100.0;
+        qty_step_ = 0.01;
+        syminfo_mintick_ = 0.00001;
+        syminfo_.pointvalue = 1.0;
+        margin_long_ = margin_short_ = 100.0;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        pyramiding_ = pyramid;
+        process_orders_on_close_ = true;
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) {
+            strategy_entry("L", true, qnan, qnan, explicit_qty ? entry_qty : qnan);
+            if (parked) strategy_entry("Parked", true, 0.50, qnan, 1.0);
+        }
+        if (bar_index_ == 1) script_view = signed_position_size();
+        if (!no_exit) {
+            if (entry_active) strategy_exit("LX", "L", qnan, qnan, qnan, 0.001, 1.15);
+            else strategy_exit("LX", "L", qnan, qnan, 0.001, 0.001);
+        }
+        if (foreign) strategy_exit("SX", "S", qnan, qnan, 0.001, 0.001);
+        if (bar_index_ == 3) strategy_close_all();
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+};
+
+void test_rounding_slice_precedes_resolved_trail() {
+    for (int pyramid : {0, 1}) {
+        for (bool explicit_qty : {false, true}) {
+            for (bool foreign : {false, true}) {
+                LongTrail engine(false, pyramid);
+                engine.explicit_qty = explicit_qty;
+                engine.foreign = foreign;
+                engine.run(bars.data(), static_cast<int>(bars.size()));
+                CHECK(engine.rows().size() == 2);
+                CHECK(near(engine.script_view, 0.0));
+                if (engine.rows().size() != 2) continue;
+                const auto& margin = engine.rows()[0];
+                const auto& trail = engine.rows()[1];
+                CHECK(margin.exit_id == "__margin_call__");
+                CHECK(near(margin.qty, 1.0));
+                CHECK(margin.entry_time == 1000 && margin.exit_time == 2000);
+                CHECK(near(margin.entry_price, 1.15226));
+                CHECK(near(margin.exit_price, 1.15194));
+                CHECK(near(margin.pnl, -0.00032));
+                CHECK(near(margin.max_runup, 0.0));
+                CHECK(near(margin.max_drawdown, 0.00032));
+                CHECK(trail.exit_id == "LX");
+                CHECK(near(trail.qty, 866831.09));
+                CHECK(trail.entry_time == 1000 && trail.exit_time == 2000);
+                CHECK(near(trail.exit_price, 1.15227));
+                CHECK(near(trail.max_runup, 866831.09 * 0.00001));
+                CHECK(near(trail.max_drawdown, 866831.09 * 0.00032));
+            }
+        }
+    }
+}
+
+void test_funded_and_preserved_entry_active_controls() {
+    LongTrail funded(true);
+    funded.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(funded.rows().size() == 1);
+    if (!funded.rows().empty()) {
+        CHECK(funded.rows()[0].exit_id == "LX");
+        CHECK(near(funded.rows()[0].qty, 866832.09));
+        CHECK(funded.rows()[0].exit_time == 2000);
+    }
+    // TV's entry-active control exits at the entry close. Both the prior
+    // and current runtime defer that separate behavior to the next open;
+    // retain that known timing gap here and prove this change does not add
+    // a rounding trim from a later waypoint. The original TV oracle and
+    // failing timing assertions are retained in campaign evidence.
+    LongTrail immediate;
+    immediate.entry_active = true;
+    immediate.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(immediate.rows().size() == 1);
+    if (!immediate.rows().empty()) {
+        CHECK(immediate.rows()[0].exit_id == "LX");
+        CHECK(near(immediate.rows()[0].qty, 866832.09));
+        CHECK(immediate.rows()[0].exit_time == 2000);
+        CHECK(near(immediate.rows()[0].exit_price, 1.15225));
+    }
+}
+
+void test_competing_entry_keeps_its_existing_path() {
+    LongTrail engine;
+    engine.parked = true;
+    engine.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(engine.rows().size() == 1);
+    if (!engine.rows().empty()) {
+        CHECK(engine.rows()[0].exit_id == "LX");
+        CHECK(near(engine.rows()[0].qty, 866832.09));
+        CHECK(near(engine.rows()[0].exit_price, 1.15227));
+    }
+}
+
+void test_later_waypoint_cannot_precede_the_trail_fill() {
+    // The open, low and trail-fill valuations are covered; rounding first
+    // exceeds equity at the later high. Independent explicit-qty TV controls
+    // show no trim with the trail, but one at the high without that exit.
+    for (bool no_exit : {false, true}) {
+        LongTrail engine(false, 0, 998814.97614375);
+        engine.explicit_qty = true;
+        engine.entry_qty = 866831.25;
+        engine.no_exit = no_exit;
+        engine.foreign = !no_exit;
+        engine.run(bars.data(), static_cast<int>(bars.size()));
+        CHECK(engine.rows().size() == (no_exit ? 2u : 1u));
+        if (engine.rows().empty()) continue;
+        const auto& first = engine.rows().front();
+        CHECK(first.exit_time == 2000);
+        if (no_exit) {
+            CHECK(first.exit_id == "__margin_call__");
+            CHECK(near(first.qty, 1.0));
+            CHECK(near(first.exit_price, 1.15285));
+            CHECK(near(engine.rows().back().qty, 866830.25));
+        } else {
+            CHECK(first.exit_id == "LX");
+            CHECK(near(first.qty, 866831.25));
+            CHECK(near(first.exit_price, 1.15227));
+        }
+    }
+}
+} // namespace
+
+int main() {
+    test_rounding_slice_precedes_resolved_trail();
+    test_funded_and_preserved_entry_active_controls();
+    test_competing_entry_keeps_its_existing_path();
+    test_later_waypoint_cannot_precede_the_trail_fill();
+    std::printf("%d passed, %d failed\n", passed, failed);
+    return failed ? 1 : 0;
+}

--- a/tests/test_rounded_carried_short_trail.cpp
+++ b/tests/test_rounded_carried_short_trail.cpp
@@ -1,0 +1,147 @@
+// Literal command fixtures pinned by independent TradingView controls. Synthetic
+// timestamps avoid any strategy/date routing; no historical feed is loaded.
+#include <pineforge/engine.hpp>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+constexpr double qnan = std::numeric_limits<double>::quiet_NaN();
+int passed = 0, failed = 0;
+#define CHECK(x) do { if (x) ++passed; else { ++failed; std::printf("FAIL %d %s\n", __LINE__, #x); } } while (0)
+bool near(double a, double b) { return std::abs(a - b) < 1e-7; }
+
+enum class Action { DEFAULT_REVERSE, SMALL_REVERSE, HALF, HOLD };
+enum class ExitShape { ABSOLUTE_TRAIL, RELATIVE_TRAIL, NONE, PARTIAL_TRAIL, PRICED };
+
+const std::vector<Bar> bars = {
+    {1.12214, 1.12228, 1.12180, 1.12224, 1405, 1000},
+    {1.12224, 1.12282, 1.12224, 1.12280, 1597, 2000},
+    {1.12284, 1.12396, 1.12284, 1.12384, 2272, 3000},
+    {1.12382, 1.12516, 1.12379, 1.12455, 2317, 4000},
+    {1.12456, 1.12464, 1.12399, 1.12414, 1550, 5000},
+    {1.12413, 1.12418, 1.12359, 1.12385, 1391, 6000},
+    {1.12386, 1.12424, 1.12383, 1.12420, 1294, 7000},
+};
+
+class RoundedShort : public BacktestEngine {
+public:
+    Action action;
+    ExitShape exit_shape;
+    bool funded;
+    bool competing = false;
+    double first_view = qnan, boundary_view = qnan, boundary_equity = qnan;
+    double after_action_view = qnan;
+    std::size_t boundary_closed = 0;
+    RoundedShort(Action a, ExitShape e = ExitShape::ABSOLUTE_TRAIL, bool extra_cash = false)
+        : action(a), exit_shape(e), funded(extra_cash) {
+        initial_capital_ = 1000928.7880272 + (funded ? 10000.0 : 0.0);
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100.0;
+        qty_step_ = 0.01;
+        syminfo_mintick_ = 0.00001;
+        syminfo_.pointvalue = 1.0;
+        margin_long_ = margin_short_ = 100.0;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        pyramiding_ = 0;
+        process_orders_on_close_ = true;
+    }
+    void on_bar(const Bar& bar) override {
+        if (bar_index_ == 0) {
+            strategy_entry("S", false, qnan, qnan, funded ? 891902.61 : qnan);
+            if (competing) strategy_entry("Parked", true, 0.50, qnan, 1.0);
+        }
+        if (bar_index_ == 1) first_view = signed_position_size();
+        if (bar_index_ == 3) {
+            boundary_view = signed_position_size();
+            boundary_equity = current_equity() + open_profit(bar.close);
+            boundary_closed = trades_.size();
+            if (action == Action::DEFAULT_REVERSE) strategy_entry("L", true);
+            if (action == Action::SMALL_REVERSE) strategy_entry("L", true, qnan, qnan, 1.0);
+            if (action == Action::HALF) strategy_close("S", "half", qnan, 50.0);
+        }
+        if (exit_shape == ExitShape::ABSOLUTE_TRAIL || exit_shape == ExitShape::PARTIAL_TRAIL) {
+            strategy_exit("SX", "S", qnan, qnan, qnan, 1.0, 1.10,
+                          exit_shape == ExitShape::PARTIAL_TRAIL ? 50.0 : 100.0);
+        } else if (exit_shape == ExitShape::RELATIVE_TRAIL) {
+            strategy_exit("SX", "S", qnan, qnan, 0.001, 0.001);
+        } else if (exit_shape == ExitShape::PRICED) {
+            strategy_exit("SX", "S", qnan, 1.30);
+        }
+        if (bar_index_ == 4) after_action_view = signed_position_size();
+        if (bar_index_ == 6) strategy_close_all();
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+};
+
+void test_margin_is_visible_before_script_actions() {
+    for (ExitShape shape : {ExitShape::ABSOLUTE_TRAIL, ExitShape::RELATIVE_TRAIL}) {
+        for (Action action : {Action::DEFAULT_REVERSE, Action::SMALL_REVERSE, Action::HALF, Action::HOLD}) {
+            RoundedShort engine(action, shape);
+            engine.run(bars.data(), static_cast<int>(bars.size()));
+            CHECK(near(engine.first_view, -888216.89));
+            CHECK(near(engine.boundary_view, -884473.25));
+            CHECK(near(engine.boundary_equity, 998872.5856733001));
+            CHECK(engine.boundary_closed == 2);
+            CHECK(engine.rows().size() == (action == Action::HOLD ? 3u : 4u));
+            if (engine.rows().size() < 3) continue;
+            CHECK(engine.rows()[0].exit_id == "__margin_call__");
+            CHECK(engine.rows()[0].exit_time == 2000);
+            CHECK(near(engine.rows()[0].qty, 3685.72));
+            CHECK(near(engine.rows()[0].exit_price, 1.12282));
+            CHECK(engine.rows()[1].exit_id == "__margin_call__");
+            CHECK(engine.rows()[1].exit_time == 4000);
+            CHECK(near(engine.rows()[1].qty, 3743.64));
+            CHECK(near(engine.rows()[1].exit_price, 1.12516));
+            if (action == Action::DEFAULT_REVERSE || action == Action::SMALL_REVERSE) {
+                CHECK(engine.rows()[2].exit_time == 4000);
+                CHECK(near(engine.rows()[2].qty, 884473.25));
+                CHECK(near(engine.rows()[2].exit_price, 1.12455));
+                CHECK(near(engine.after_action_view, action == Action::DEFAULT_REVERSE ? 888242.03 : 1.0));
+            } else if (action == Action::HALF) {
+                CHECK(near(engine.rows()[2].qty, 442236.62));
+                CHECK(near(engine.after_action_view, -442236.63));
+            } else {
+                CHECK(near(engine.after_action_view, -884473.25));
+            }
+        }
+    }
+}
+
+void test_funded_control_does_not_create_margin() {
+    RoundedShort engine(Action::DEFAULT_REVERSE, ExitShape::ABSOLUTE_TRAIL, true);
+    engine.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(near(engine.boundary_view, -891902.61));
+    CHECK(near(engine.boundary_equity, 1008868.4929981));
+    CHECK(engine.boundary_closed == 0);
+    CHECK(engine.rows().size() == 2);
+    CHECK(near(engine.after_action_view, 897130.84));
+}
+
+void test_other_order_shapes_retain_the_existing_checkpoint() {
+    for (ExitShape shape : {ExitShape::NONE, ExitShape::PARTIAL_TRAIL, ExitShape::PRICED}) {
+        RoundedShort engine(Action::HOLD, shape);
+        engine.run(bars.data(), static_cast<int>(bars.size()));
+        CHECK(near(engine.first_view, -891902.61));
+        CHECK(near(engine.boundary_view, -888216.89));
+        CHECK(engine.boundary_closed == 1);
+        CHECK(engine.rows().size() == 3);
+    }
+    RoundedShort competing(Action::HOLD);
+    competing.competing = true;
+    competing.run(bars.data(), static_cast<int>(bars.size()));
+    CHECK(near(competing.boundary_view, -888216.89));
+    CHECK(competing.boundary_closed == 1);
+}
+} // namespace
+
+int main() {
+    test_margin_is_visible_before_script_actions();
+    test_funded_control_does_not_create_margin();
+    test_other_order_shapes_retain_the_existing_checkpoint();
+    std::printf("%d passed, %d failed\n", passed, failed);
+    return failed ? 1 : 0;
+}

--- a/tests/test_rounded_carried_short_trail.cpp
+++ b/tests/test_rounded_carried_short_trail.cpp
@@ -136,12 +136,75 @@ void test_other_order_shapes_retain_the_existing_checkpoint() {
     CHECK(near(competing.boundary_view, -888216.89));
     CHECK(competing.boundary_closed == 1);
 }
+
+class ExcursionShort : public BacktestEngine {
+public:
+    ExcursionShort() {
+        initial_capital_ = 1532722.4186011;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100.0;
+        qty_step_ = 0.00001;
+        syminfo_mintick_ = 0.01;
+        syminfo_.pointvalue = 1.0;
+        margin_long_ = margin_short_ = 100.0;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        pyramiding_ = 0;
+        process_orders_on_close_ = true;
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) strategy_entry("S", false);
+        strategy_exit("SX", "S", qnan, qnan, qnan, 1.0, 60000.0);
+        if (bar_index_ == 2) strategy_close_all();
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+};
+
+void test_margin_excursion_samples_only_the_traversed_prefix() {
+    // The first two price bars and opening budget reconstruct the independent
+    // daily control's 8.34992 margin slice. Its low precedes the adverse high.
+    // Synthetic timestamps and an early terminal close isolate that slice.
+    const std::vector<Bar> low_first = {
+        {65971.20, 69516.65, 65821.97, 68432.16, 1, 1000},
+        {68432.16, 71777.00, 68391.41, 69948.63, 1, 2000},
+        {69948.64, 71321.00, 68977.91, 70191.86, 1, 3000},
+    };
+    ExcursionShort engine;
+    engine.run(low_first.data(), static_cast<int>(low_first.size()));
+    CHECK(engine.rows().size() == 2);
+    if (engine.rows().size() == 2) {
+        const auto& margin = engine.rows()[0];
+        CHECK(margin.exit_id == "__margin_call__");
+        CHECK(margin.exit_time == 2000);
+        CHECK(near(margin.qty, 8.34992));
+        CHECK(near(margin.exit_price, 71777.0));
+        CHECK(near(margin.max_runup, 8.34992 * 40.75));
+        CHECK(near(engine.rows()[1].max_runup, 14.04777 * 40.75));
+    }
+    // Reverse the waypoint order: the favorable low comes AFTER liquidation.
+    // It belongs to the survivor, never to the already-closed margin slice.
+    const std::vector<Bar> high_first = {
+        low_first[0],
+        {68432.16, 69000.0, 67000.0, 68500.0, 1, 2000},
+        {68500.0, 68600.0, 68400.0, 68500.0, 1, 3000},
+    };
+    ExcursionShort later_low;
+    later_low.run(high_first.data(), static_cast<int>(high_first.size()));
+    CHECK(later_low.rows().size() == 2);
+    if (later_low.rows().size() == 2) {
+        CHECK(later_low.rows()[0].exit_id == "__margin_call__");
+        CHECK(near(later_low.rows()[0].exit_price, 69000.0));
+        CHECK(near(later_low.rows()[0].max_runup, 0.0));
+        CHECK(later_low.rows()[1].max_runup > 0.0);
+    }
+}
 } // namespace
 
 int main() {
     test_margin_is_visible_before_script_actions();
     test_funded_control_does_not_create_margin();
     test_other_order_shapes_retain_the_existing_checkpoint();
+    test_margin_excursion_samples_only_the_traversed_prefix();
     std::printf("%d passed, %d failed\n", passed, failed);
     return failed ? 1 : 0;
 }


### PR DESCRIPTION
Carried positions with owned trailing exits could process margin too late under `process_orders_on_close`, leaving the close-time script to read stale position/equity and freeze the wrong default quantity. Settle eligible rounded-money shorts before those reads, and check eligible carried longs only at price-path waypoints before their resolved trailing fill. Preserve the short's favorable excursion already traversed before liquidation.

The rules use physical order and position provenance; there is no strategy, symbol or date lookup. No verifier, grade, threshold, profile selection, feed, reference, input or population changes. README reports the final tested engine head `399eeadaa34cdbae0e30829f0a6c1dbe900cdfa0` with codegen `0fe2189f2cb845cc7371ce56dd55ad9cff72dda0`.

Validation:

- Final Cloud sweep `cand-round36b-20260909`: 72/72 cases, 4,190/4,190 probes; **4,179 excellent / 11 strong / 0 moderate**, up one excellent from Round 35. Matched 2,817,468 / 2,819,967 TradingView trades.
- EURUSD 15m WinTheTrade becomes excellent: canonical match 100%, count gap 0, quantity/entry/exit/PnL P90 0. BTCUSDT 15m quantity P90 improves from 0.012 to 0.
- All 704 hard probes retain identical grades, quantity metrics and trade CSVs. All other canonical metrics are unchanged; 4,188 of 4,190 CSVs are byte-identical to Round 35.
- Independent immutable-artifact and registry audit: all 72 cases, exact source trees and image pins verified; runner 64/64 tasks succeeded. Independent raw audit retains all 2,506 gained exact identities, with none lost. BTC daily CSV is fully baseline-identical, including pre-liquidation MFE.
- Fresh full native build: 247/247 tests; short/long fixtures 157/152 assertions. Independent Grok 4.6 high review on the exact candidate: zero actionable P0/P1/P2.
- Cloud PR gate `pineforge-pr-gate-bsx5q`: **PASS**, target score +1, hard regressions 0, tolerated exceptions empty. Verdict recorded and corroborated in Postgres. Snapshot `246d9aa8903d68caef8f3fa4aa94a0ef00102cbdd4e2ac814ab69f4f199f4069` (788,836 bytes); population `3d72f815de54e4a2f6fdff6bb2294ea99c38849888390ded4ecd68ac3e5a9110` unchanged.

Known limits: EURUSD has 1,757/1,759 exact physical identities; one closing group is split into two TV allocations but combined by the engine at identical times/prices and total quantity. Existing EURUSD PnL and excursion display differences remain; corrected quantities can enlarge their absolute dollar differences while preserving per-unit values at exported precision. This is not complete raw reporting equality or a TV anomaly. The preexisting entry-active absolute-trail close-versus-next-open timing gap remains outside this change; its control verifies legacy preservation, not TV timing parity.
