### PR TITLE
fix: reset compiled script runs and align MFI source direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 TradingView's strategy tester is the reference every Pine author trusts, and nothing outside TradingView reproduced it — until now. PineForge is a C++17 runtime with a stable C ABI that runs PineScript v6 strategies exactly the way TradingView's broker emulator does: same fills, same sizing, same margin calls, same trailing stops, same `request.security()` buckets, on any OHLCV you give it, in microseconds per bar.
 
-- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,179 excellent, 11 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,468 matched by the verifier.
+- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,180 excellent, 10 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,481 matched by the verifier.
 - **Open.** Engine, transpiler, corpus, benchmarks and the validation tooling are all public and Apache-2.0. The only thing you cannot download is the closed test set, because TradingView's Terms of Service forbid redistributing community scripts.
 - **Fast.** In-process, no interpreter: median **162× faster than PyneCore** on 99 timed strategies. Parameter sweeps re-run a loaded `.so` with new inputs — no recompile, no fork.
 - **Deterministic to the bit.** Two runs with the same inputs produce identical trade lists. Same on Linux and macOS.
@@ -110,20 +110,20 @@ Lifecycle-aware compiled modules reset Pine variables, indicator/history buffers
 
 ## Validation scoreboard
 
-**Round 36 · 2026-09-09:** **4,179 excellent / 11 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
+**Round 37 · 2026-09-09:** **4,180 excellent / 10 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
 
 | Board | Test set | Result | TradingView trades evaluated |
 |---|---|---|---|
 | **Public** — [open corpus](https://github.com/pineforge-4pass/pineforge-corpus) | 312 reference strategies, Apache-2.0, reproducible by anyone | **309/309 graded excellent** (ETH/USDT-perp 15m; the corpus' declared engine-only / anomaly probes are not graded) | 429,866 |
-| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,870 excellent + 11 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
+| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,871 excellent + 10 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
 
-**2,819,967 TradingView trades** evaluated, **2,817,468 matched by the verifier** (99.91%), from the round 36 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
+**2,819,967 TradingView trades** evaluated, **2,817,481 matched by the verifier** (99.91%), from the round 37 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
 
-Round 36 corrects the timing of margin events around owned trailing exits under `process_orders_on_close`. A carried short's liquidation precedes the script's position/equity reads and default sizing. A carried long's money-rounding check uses only price-path waypoints before its resolved trailing exit. Short margin excursions include the favorable prices reached before liquidation, without borrowing a later low.
+Round 37 corrects MFI source direction and compiled-strategy reuse. MFI uses Pine's existing absolute float-comparison band, so equal-decimal HLC3 values do not contribute a full bar's money flow because of binary rounding residue. A reused compiled strategy resets persistent Pine state before each new batch or stream warmup, while retaining input settings and preserving accumulated state within an active stream.
 
-**EMA 9 + VWAP Strategy with ATR Trailing Stop (WinTheTrade)** on **OANDA:EURUSD 15m** moves from strong to excellent: 100% canonical match, zero count gap, and zero entry-price, exit-price, PnL and quantity error at the 90th percentile. On **BINANCE:BTCUSDT 15m**, the same strategy remains excellent and its quantity error falls to zero; all **2,158 raw closed-trade identities** match TradingView. EURUSD has **1,757 of 1,759 raw identities exact**: one remaining closing group is split into two TradingView allocations but combined by the engine at the same times and prices, with the same total quantity. This is not a claim of complete raw allocation or PnL display-byte equality.
+**RSI/MFI Divergence Momentum (antoniolinux)** on **NYSE:F 15m** moves from strong to excellent: canonical match rises from 95.2% to 100%, the trade-count gap falls from 2 to 0, and entry-price, exit-price, PnL and quantity error remain zero at the 90th percentile. The same strategy on **OANDA:EURUSD 15m** and **EWO/RSI Advanced Signals (pridarasx)** on **NYSE:F 15m** remain excellent and improve to 100% canonical match. Independent raw inspection verifies **315/315 strict entry-and-exit matches** across these three probes, gaining 13 with none lost. The pre-existing EURUSD open-position mark and display-precision differences remain; this is not complete reporting-byte equality.
 
-The rules use physical order and position provenance, with no strategy, symbol or date lookup. Independent TradingView controls and Cloud diagnostics pin the event order and the price-path boundary. All **704 hard-surface probes** retain their canonical grades and metrics. Verifier code, grading rules, profile-selection code, reference tapes, feeds, input files and scored population are unchanged.
+The fixes have no strategy, symbol or date lookup. Direct TradingView controls distinguish below-band and above-band MFI movements at three price scales, including a nonzero HLC3 rounding residue. Separate Cloud diagnostics retain the same C handle across repeated runs and verify the lifecycle repair. All **704 hard-surface probes** retain their canonical grades, quantity metrics and trade CSVs; 4,187 of 4,190 CSVs are unchanged. Verifier code, grading rules, profile-selection code, reference tapes, feeds, input files and scored population are unchanged.
 
 ### The closed test, lane by lane
 
@@ -139,12 +139,12 @@ The rules use physical order and position provenance, with no strategy, symbol o
 | NASDAQ:AAPL · 15m | 356 | 354 | 2 | — |
 | NSE:NIFTY · 15m | 191 | 191 | — | — |
 | NSE:NIFTY · 1D | 145 | 145 | — | — |
-| NYSE:F · 15m | 340 | 336 | 4 | — |
+| NYSE:F · 15m | 340 | 337 | 3 | — |
 | NYSE:F · 1D | 263 | 263 | — | — |
 | OANDA:EURUSD · 15m | 373 | 372 | 1 | — |
 | OANDA:XAUUSD · 15m | 376 | 375 | 1 | — |
 | OANDA:XAUUSD · 1D | 248 | 248 | — | — |
-| **Total** | **3,881** | **3,870** | **11** | **0** |
+| **Total** | **3,881** | **3,871** | **10** | **0** |
 
 ### How a probe is graded
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ int main(void) {
 
 Every PineForge-compiled strategy `.so` exports this same ABI — write the harness once, swap strategies forever. Worked examples for [C](https://cdocs.pineforge.dev/examples_c.html), [Python sweeps](https://cdocs.pineforge.dev/examples_python_sweep.html), [Rust](https://cdocs.pineforge.dev/examples_rust.html), [multi-strategy](https://cdocs.pineforge.dev/examples_multi.html) and [magnifier A/B](https://cdocs.pineforge.dev/examples_magnifier.html) are in the docs.
 
+Lifecycle-aware compiled modules reset Pine variables, indicator/history buffers and the broker book before each batch run or `strategy_stream_begin` warmup. Inputs and runtime settings persist until changed; ticks within a stream continue its state. Regenerate and rebuild existing modules with current codegen and matching engine headers/archive to obtain this behavior; the [internal C++ rebuild boundary](docs/pages/abi-stability.md) is checked at compile/link time.
+
 ---
 
 ## Validation scoreboard

--- a/docs/pages/abi-stability.md
+++ b/docs/pages/abi-stability.md
@@ -111,6 +111,15 @@ notice:
 - Internal symbol names (anything not tagged `PF_API`).
 - The shape of internal log lines (use them for humans, not parsers).
 
+Rebuild generated C++ objects against matching engine headers and the runtime
+archive. The script-run preparation hook uses the internal
+`engine_script_run_v1` inline namespace, so an object compiled against the old
+`BacktestEngine` vtable cannot silently bind the new run loop. Newly generated
+lifecycle-aware modules also require `PINEFORGE_HAS_SCRIPT_RUN_PREPARE_V1` at
+compile time. Regenerate and rebuild a strategy module to obtain complete
+script-state reset; replacing an archive does not retrofit an old module.
+These checks do not change the public C function signatures or POD layouts.
+
 If you find yourself reaching for any of these from outside the closed
 PineForge transpiler, you're holding it wrong — file an issue and we'll
 lift the missing surface into the public ABI.

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -26,6 +26,11 @@
 // Angle-bracket form is the installed public path (deliberate).
 #include <pineforge/pineforge.h>
 
+// Generated modules using the full script lifecycle reset must be rebuilt
+// against a runtime providing this hook. This is an internal C++ capability;
+// it does not change any public C POD or exported C function signature.
+#define PINEFORGE_HAS_SCRIPT_RUN_PREPARE_V1 1
+
 namespace pineforge {
 
 enum class PositionSide { FLAT, LONG, SHORT };
@@ -3752,6 +3757,14 @@ protected:
         bool calling_bar_complete = false);
     void publish_security_eval_state_at_calling_boundary(
         SecurityEvalState& state);
+
+    // A new batch run (including stream_begin's historical warmup) starts a
+    // fresh script lifecycle. Called once after broker reset, before any
+    // requested/chart computation or per-bar checkpoint. Generated subclasses
+    // reset their own persistent state here, then optionally prepare the
+    // current run's static TA cache. Config/inputs/feeds belong to the engine
+    // and survive. Streaming ticks and fill recalculations never call this.
+    virtual void prepare_script_run(const Bar*, int, bool) {}
 
     virtual void configure_security_evaluators() {}
     virtual void evaluate_security(int sec_id, const Bar& bar, bool is_complete) {}

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1076,6 +1076,11 @@ struct StrategyOverrides {
     int close_entries_rule = -1;
 };
 
+// The C++ subclass contract is internal, unlike pineforge.h's stable C ABI.
+// Changing its vtable requires all generated/native C++ objects to be rebuilt.
+// Version the mangled class name so an object using the old vtable cannot
+// silently link to the new run loop and dispatch the wrong virtual slot.
+inline namespace engine_script_run_v1 {
 class BacktestEngine {
 protected:
     // --- Position state ---
@@ -5158,4 +5163,5 @@ public:
     void trace(const std::string& name, int value)   { trace(name, static_cast<double>(value)); }
 };
 
+} // inline namespace engine_script_run_v1
 } // namespace pineforge

--- a/scripts/check_script_cpp_abi.py
+++ b/scripts/check_script_cpp_abi.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Link-only check: stale C++ subclass objects must not bind the new vtable.
+
+Neither linked program is executed. The public C ABI is checked separately.
+"""
+import argparse
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--compiler", required=True)
+    parser.add_argument("--library", required=True)
+    parser.add_argument("--include", required=True)
+    parser.add_argument("--generated-include", required=True)
+    parser.add_argument("--extra-flag", action="append", default=[])
+    args = parser.parse_args()
+    caller = '''
+int main(int argc, char** argv) {
+    auto* strategy = reinterpret_cast<pineforge::BacktestEngine*>(argv);
+    strategy->run(nullptr, argc);
+    return 0;
+}
+'''
+    current = '#include <pineforge/engine.hpp>\n' + caller
+    legacy = '''namespace pineforge {
+struct Bar;
+class BacktestEngine { public: void run(const Bar*, int); };
+}
+''' + caller
+    with tempfile.TemporaryDirectory(prefix="pf-script-cpp-abi-") as temporary:
+        root = Path(temporary)
+        def link(name, source):
+            path = root / (name + ".cpp")
+            path.write_text(source)
+            return subprocess.run(
+                [args.compiler, "-std=c++17", "-O0", "-I", args.include,
+                 "-I", args.generated_include, *args.extra_flag, str(path),
+                 args.library, "-pthread", "-o", str(root / name)],
+                capture_output=True, text=True, timeout=60,
+            )
+        fresh = link("current", current)
+        if fresh.returncode:
+            raise RuntimeError("current C++ contract failed to link:\n" + fresh.stderr)
+        stale = link("legacy", legacy)
+        if stale.returncode == 0:
+            raise RuntimeError("legacy unversioned C++ run symbol still links to the new runtime")
+        if "undefined" not in stale.stderr.lower() or "BacktestEngine" not in stale.stderr:
+            raise RuntimeError("legacy link failed for an unexpected reason:\n" + stale.stderr)
+    print("current C++ contract links; stale object rejected; no executable run")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -754,6 +754,9 @@ void BacktestEngine::reset_run_state() {
     named_entry_cancelled_incarnation_in_current_eval_.clear();
     pending_close_qty_in_bar_ = 0.0;
     pos_view_freeze_bar_ = -1;   // KI-64: fresh run starts with no frozen view
+    pos_view_frozen_side_ = PositionSide::FLAT;
+    pos_view_frozen_qty_ = 0.0;
+    pos_view_frozen_entry_qty_.clear();
     sb_close_active_ = false;
     sb_close_bar_ = -1;
     sb_close_calls_ = 0;
@@ -774,6 +777,13 @@ void BacktestEngine::reset_run_state() {
     fold_exit_path_extremes_ = false;
     fold_exit_trail_peak_ = std::numeric_limits<double>::quiet_NaN();
     last_exit_fill_was_trail_ = false;
+    trail_best_before_bar_ = std::numeric_limits<double>::quiet_NaN();
+    trail_best_before_bar_index_ = -1;
+    trail_best_before_bar_position_cycle_ = 0;
+    trail_best_before_bar_fill_seq_ = 0;
+    priced_entry_activity_bar_ = -1;
+    priced_entry_filled_this_bar_ = false;
+    open_margin_slice_bar_ = -1;
 
     // Equity + position-size extremes.
     max_equity_ = initial_capital_;

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -909,6 +909,7 @@ void BacktestEngine::run(const Bar* bars, int n) {
             "timestamped account-currency FX does not support calc_on_order_fills");
     }
     reset_run_state();
+    prepare_script_run(bars, n, !stream_warmup_mode_);
     equity_curve_.reserve((size_t)std::max(n, 0));
 
     std::string detected_tf = "";
@@ -1520,8 +1521,6 @@ void BacktestEngine::run_tf_impl(const Bar* input_bars, int n_input,
     magnifier_samples_ = magnifier_samples;
     magnifier_dist_ = magnifier_dist;
 
-    configure_security_evaluators();
-
     // Runtime diagnostics baseline
     diag_input_bars_processed_ = n_input;
     diag_script_bars_processed_ = 0;
@@ -1529,6 +1528,14 @@ void BacktestEngine::run_tf_impl(const Bar* input_bars, int n_input,
     diag_magnifier_sample_ticks_processed_ = 0;
 
     reset_run_state();
+    // Match the generated wrapper's original static/dynamic eligibility from
+    // the caller's arguments, before auto-detection filled effective TFs.
+    // A new stream always computes its warmup dynamically so later ticks do
+    // not inherit a finite historical precalculation cache.
+    prepare_script_run(input_bars, n_input,
+        !stream_warmup_mode_ && !bar_magnifier
+        && input_tf.empty() && script_tf.empty());
+    configure_security_evaluators();
 
     // Determine aggregation ratio for script TF
     int ratio = tf_ratio(effective_input_tf, effective_script_tf);

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -738,11 +738,16 @@ void BacktestEngine::reset_run_state() {
     // Open position + pending orders.
     reset_position_state_to_flat();   // position_side_/qty/price/time/count,
                                       // pyramid_entries_, trail, partial ids
+    // Cycle ownership is scoped to this run, like order incarnations below.
+    // A flat transition within a run must keep advancing it; only a new run
+    // returns the allocator to its constructor value.
+    next_position_cycle_seq_ = 1;
     pending_orders_.clear();
     // PendingOrder incarnations are report provenance scoped to one run.
     // Resetting keeps a reused handle byte/identity-equivalent to a fresh
     // handle while preserving the invariant that zero means unavailable.
     next_order_incarnation_ = 1;
+    next_order_seq_ = 1;
     last_rejected_strategy_entry_call_bar_ = -1;
     pending_flat_market_pair_disqualified_bars_.clear();
     default_flat_market_gross_disqualified_bars_.clear();

--- a/src/ta_oscillators.cpp
+++ b/src/ta_oscillators.cpp
@@ -9,6 +9,7 @@
 
 #include <pineforge/ta.hpp>
 #include <pineforge/na.hpp>
+#include <pineforge/pine_float_compare.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -456,8 +457,10 @@ double MFI::compute(double src, double vol) {
     double pos = 0, neg = 0;
     if (!is_na(prev_src_)) {
         double mf = src * vol;
-        if (src > prev_src_) pos = mf;
-        else if (src < prev_src_) neg = mf;
+        // Equal-decimal source values can differ by binary64 residue. MFI
+        // classifies direction with Pine's absolute comparison band as well.
+        if (pine_float_gt(src, prev_src_)) pos = mf;
+        else if (pine_float_lt(src, prev_src_)) neg = mf;
     }
     prev_src_ = src;
     pos_buffer_.push_back(pos);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    test_script_run_prepare
     test_pooc_open_money_event
     test_live_abort
     test_placement_rejection_bracket_ownership

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TEST_SOURCES
     test_recompute
     test_str_utils
     test_ta
+    test_mfi_source_direction
     test_ta_indicators_extras
     test_kc
     test_ta_rma_warmup

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -237,6 +237,28 @@ set(TEST_SOURCES
 find_package(Threads REQUIRED)
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
+set(_pf_script_cpp_abi_flags)
+if(PINEFORGE_ENABLE_SANITIZERS)
+    list(APPEND _pf_script_cpp_abi_flags --extra-flag=-fsanitize=address,undefined)
+endif()
+if(PINEFORGE_ENABLE_COVERAGE)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        list(APPEND _pf_script_cpp_abi_flags
+            --extra-flag=-fprofile-instr-generate --extra-flag=-fcoverage-mapping)
+    else()
+        list(APPEND _pf_script_cpp_abi_flags --extra-flag=--coverage)
+    endif()
+endif()
+add_test(
+    NAME test_script_cpp_abi
+    COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/check_script_cpp_abi.py
+            --compiler ${CMAKE_CXX_COMPILER}
+            --library $<TARGET_FILE:pineforge>
+            --include ${PROJECT_SOURCE_DIR}/include
+            --generated-include ${PROJECT_BINARY_DIR}/include
+            ${_pf_script_cpp_abi_flags}
+)
+
 add_test(
     NAME test_derive_corpus_feeds
     COMMAND ${Python3_EXECUTABLE}

--- a/tests/test_mfi_source_direction.cpp
+++ b/tests/test_mfi_source_direction.cpp
@@ -1,0 +1,180 @@
+// MFI source direction uses Pine's absolute float-comparison band. The
+// 2026-09-09 TV controls compare builtin MFI with explicit up/down money flow
+// at sources 0.001, 10, and 60000, including equal-decimal HLC3 residues.
+// Only literal/synthetic indicator inputs are used here; no strategy or feed.
+
+#include <pineforge/na.hpp>
+#include <pineforge/ta.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <initializer_list>
+
+using namespace pineforge;
+
+namespace {
+
+int passed = 0;
+int failed = 0;
+
+void check(bool condition, const char* label) {
+    if (condition) {
+        ++passed;
+    } else {
+        ++failed;
+        std::printf("FAIL %s\n", label);
+    }
+}
+
+void check_value(double actual, double expected, const char* label) {
+    if (std::isfinite(actual) && std::fabs(actual - expected) <= 1e-11) {
+        ++passed;
+    } else {
+        ++failed;
+        std::printf("FAIL %s: actual=%.17g expected=%.17g\n",
+                    label, actual, expected);
+    }
+}
+
+// Independently specified three-transition window:
+//   base -> base+1, volume 2: positive budget 2*(base+1)
+//   base+1 -> base, volume 3: negative budget 3*base
+// The fourth sample supplies the test's stated extra flow. Expected values
+// use these fixed budgets, never a comparison helper or a mirrored MFI loop.
+void seed_window(ta::MFI& mfi, double base) {
+    check(is_na(mfi.compute(base, 9.0)), "initial sample remains warmup");
+    check(is_na(mfi.compute(base + 1.0, 2.0)), "second sample remains warmup");
+    check(is_na(mfi.compute(base, 3.0)), "third sample remains warmup");
+}
+
+double percent(double positive, double negative) {
+    return 100.0 * positive / (positive + negative);
+}
+
+double observe_fourth(double base, double source) {
+    ta::MFI mfi(3);
+    seed_window(mfi, base);
+    return mfi.compute(source, 5.0);
+}
+
+void test_absolute_band_at_three_scales() {
+    for (double base : {0.001, 10.0, 60000.0}) {
+        const double positive = 2.0 * (base + 1.0);
+        const double negative = 3.0 * base;
+        const double neutral = percent(positive, negative);
+        check_value(observe_fourth(base, base), neutral, "exact equality is neutral");
+
+        // Both directions strictly inside the TV-pinned absolute band.
+        const double tiny_up = base + 5e-11;
+        const double tiny_down = base - 5e-11;
+        check(tiny_up > base && tiny_up - base < 1e-10,
+              "positive below-band fixture is distinct in binary64");
+        check(tiny_down < base && base - tiny_down < 1e-10,
+              "negative below-band fixture is distinct in binary64");
+        check_value(observe_fourth(base, tiny_up), neutral, "below-band rise is neutral");
+        check_value(observe_fourth(base, tiny_down), neutral, "below-band fall is neutral");
+
+        // Above-band controls at all three scales refute relative tolerance,
+        // tick rounding, and suppressing every small decimal change.
+        const double above_up = base + 1.2e-10;
+        const double above_down = base - 1.2e-10;
+        check(above_up - base > 1e-10, "positive above-band fixture");
+        check(base - above_down > 1e-10, "negative above-band fixture");
+        check_value(observe_fourth(base, above_up),
+                    percent(positive + 5.0 * above_up, negative),
+                    "above-band rise retains all positive money");
+        check_value(observe_fourth(base, above_down),
+                    percent(positive, negative + 5.0 * above_down),
+                    "above-band fall retains all negative money");
+
+        const double large_up = base + 1e-8;
+        const double large_down = base - 1e-8;
+        check_value(observe_fourth(base, large_up),
+                    percent(positive + 5.0 * large_up, negative),
+                    "large rise remains positive");
+        check_value(observe_fourth(base, large_down),
+                    percent(positive, negative + 5.0 * large_down),
+                    "large fall remains negative");
+    }
+}
+
+void test_equal_decimal_hlc3_residue() {
+    const double first = (8.80 + 8.68 + 8.78) / 3.0;
+    const double second = (8.80 + 8.69 + 8.77) / 3.0;
+    check(first != second && std::fabs(first - second) < 1e-10,
+          "equal-decimal HLC3 fixture carries a binary64 residue");
+    check_value(observe_fourth(first, second),
+                percent(2.0 * (first + 1.0), 3.0 * first),
+                "HLC3 residue contributes no flow");
+    check_value(observe_fourth(second, first),
+                percent(2.0 * (second + 1.0), 3.0 * second),
+                "reversed HLC3 residue contributes no flow");
+}
+
+void test_recompute_replaces_flow_without_advancing() {
+    for (double base : {0.001, 10.0, 60000.0}) {
+        ta::MFI mfi(3);
+        seed_window(mfi, base);
+        const double positive = 2.0 * (base + 1.0);
+        const double negative = 3.0 * base;
+        const double up = base + 1.2e-10;
+        const double down = base - 1.2e-10;
+        check_value(mfi.compute(up, 5.0),
+                    percent(positive + 5.0 * up, negative),
+                    "initial fourth sample carries positive flow");
+        for (int repeat = 0; repeat < 3; ++repeat) {
+            check_value(mfi.recompute(base - 5e-11, 11.0),
+                        percent(positive, negative),
+                        "recompute removes the prior positive flow");
+            check_value(mfi.recompute(down, 7.0),
+                        percent(positive, negative + 7.0 * down),
+                        "recompute replaces direction and volume");
+        }
+        check_value(mfi.recompute(base, 13.0), percent(positive, negative),
+                    "final exact-tie recompute is neutral");
+        // The next committed sample evicts the old positive transition. The
+        // retained negative budget is 3*base; the new positive is 7*(base+2).
+        check_value(mfi.compute(base + 2.0, 7.0),
+                    percent(7.0 * (base + 2.0), negative),
+                    "recompute preserves next-window eviction");
+    }
+}
+
+void test_existing_zero_flow_nan_and_warmup_contracts() {
+    ta::MFI flat(3), rising(3), falling(3);
+    for (int index = 0; index < 3; ++index) {
+        check(is_na(flat.compute(10.0, 2.0)), "flat warmup unchanged");
+        check(is_na(rising.compute(10.0 + index, 2.0)), "rising warmup unchanged");
+        check(is_na(falling.compute(10.0 - index, 2.0)), "falling warmup unchanged");
+    }
+    check_value(flat.compute(10.0, 2.0), 100.0, "both-zero flow still returns 100");
+    check_value(rising.compute(13.0, 2.0), 100.0, "one-sided positive flow unchanged");
+    check_value(falling.compute(7.0, 2.0), 0.0, "one-sided negative flow unchanged");
+
+    ta::MFI missing_source(2);
+    missing_source.compute(10.0, 1.0);
+    missing_source.compute(12.0, 1.0);
+    check_value(missing_source.compute(na<double>(), 1.0), 100.0,
+                "NaN source supplies no directional flow");
+    check_value(missing_source.compute(10.0, 1.0), 100.0,
+                "first source after NaN remains neutral");
+    check_value(missing_source.compute(9.0, 1.0), 0.0,
+                "direction resumes after a finite previous source");
+
+    ta::MFI missing_volume(2);
+    missing_volume.compute(10.0, 1.0);
+    missing_volume.compute(12.0, na<double>());
+    check(is_na(missing_volume.compute(11.0, 1.0)),
+          "NaN volume on directional flow still propagates");
+}
+
+}  // namespace
+
+int main() {
+    test_absolute_band_at_three_scales();
+    test_equal_decimal_hlc3_residue();
+    test_recompute_replaces_flow_without_advancing();
+    test_existing_zero_flow_nan_and_warmup_contracts();
+    std::printf("test_mfi_source_direction: passed=%d failed=%d\n", passed, failed);
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/test_script_run_prepare.cpp
+++ b/tests/test_script_run_prepare.cpp
@@ -1,0 +1,112 @@
+// Literal lifecycle contract test. Compiled Pine/indicator reuse is a separate
+// Cloud diagnostic: this test establishes the engine-owned dispatch boundary.
+#include <pineforge/engine.hpp>
+#include <cassert>
+#include <stdexcept>
+#include <vector>
+
+using namespace pineforge;
+
+class ScriptProbe final : public BacktestEngine {
+public:
+    int preparations = 0;
+    int configurations = 0;
+    int value = -999;
+    bool prepared = false;
+    bool allow_precalc = false;
+    bool fail_preparation = false;
+    std::vector<int> observed;
+
+    ScriptProbe() { initial_capital_ = 12345.0; }
+
+    void prepare_script_run(const Bar*, int, bool allow) override {
+        ++preparations;
+        prepared = true;
+        allow_precalc = allow;
+        observed.clear();
+        value = std::stoi(inputs_.at("seed"));
+        assert(trades_.empty());
+        assert(signed_position_size() == 0.0);
+        assert(initial_capital_ == 12345.0);
+        if (fail_preparation) throw std::runtime_error("literal preparation failure");
+    }
+
+    void configure_security_evaluators() override {
+        assert(prepared);
+        assert(observed.empty());
+        assert(value == std::stoi(inputs_.at("seed")));
+        ++configurations;
+    }
+
+    void on_bar(const Bar&) override {
+        assert(prepared);
+        observed.push_back(++value);
+    }
+};
+
+int main() {
+    const Bar bars[] = {
+        {10, 11, 9, 10, 1, 60000},
+        {11, 12, 10, 11, 2, 120000},
+        {12, 13, 11, 12, 3, 180000},
+    };
+    ScriptProbe p;
+    p.set_input("seed", "7");
+    // Enter via the base API, as stream_begin and other native callers do.
+    BacktestEngine& base = p;
+    base.run(bars, 1);
+    assert(p.preparations == 1 && p.allow_precalc);
+    assert((p.observed == std::vector<int>{8}));
+    base.run(bars, 3);
+    assert(p.preparations == 2 && p.allow_precalc);
+    assert((p.observed == std::vector<int>{8, 9, 10}));
+
+    p.prepared = false;
+    base.run(bars, 3, "1", "1");
+    assert(p.preparations == 3 && !p.allow_precalc);
+    assert(p.configurations == 1);
+    assert((p.observed == std::vector<int>{8, 9, 10}));
+    base.run(bars, 3, "", "");
+    assert(p.preparations == 4 && p.allow_precalc);
+    base.run(bars, 3, "", "1");
+    assert(p.preparations == 5 && !p.allow_precalc);
+    base.run(bars, 3, "1", "");
+    assert(p.preparations == 6 && !p.allow_precalc);
+    base.run(bars, 3, "", "", true);
+    assert(p.preparations == 7 && !p.allow_precalc);
+
+    // A changed input persists and is resolved afresh, not reset to defaults.
+    p.set_input("seed", "19");
+    base.run(bars, 2, "1", "1");
+    assert((p.observed == std::vector<int>{20, 21}));
+    base.run(nullptr, 0);
+    assert(p.observed.empty() && p.value == 19);
+    const int before_failure = p.preparations;
+    p.fail_preparation = true;
+    base.run(bars, 3);
+    assert(p.preparations == before_failure + 1);
+    assert(p.observed.empty());
+    p.fail_preparation = false;
+    base.run(bars, 2);
+    assert((p.observed == std::vector<int>{20, 21}));
+
+    p.set_input("seed", "7");
+    const int before_stream = p.preparations;
+    assert(base.stream_begin(bars, 2, "1", "1"));
+    assert(p.preparations == before_stream + 1 && !p.allow_precalc);
+    assert((p.observed == std::vector<int>{8, 9}));
+    assert(base.stream_push_tick(TradeTick{180000, 1, 12, 1}));
+    assert(base.stream_advance_time(240000));
+    assert(p.preparations == before_stream + 1);
+    assert(p.observed.size() >= 3 && p.observed[2] == 10);
+    assert(base.stream_end());
+    assert(p.preparations == before_stream + 1);
+
+    assert(base.stream_begin(bars, 2, "1", "1"));
+    assert(p.preparations == before_stream + 2);
+    assert((p.observed == std::vector<int>{8, 9}));
+    assert(base.stream_end());
+    base.run(bars, 3);
+    assert(p.preparations == before_stream + 3 && p.allow_precalc);
+    assert((p.observed == std::vector<int>{8, 9, 10}));
+}

--- a/tests/test_script_run_prepare.cpp
+++ b/tests/test_script_run_prepare.cpp
@@ -53,7 +53,21 @@ public:
     }
     int64_t next_cycle() const { return next_position_cycle_seq_; }
     int64_t next_order_sequence() const { return next_order_seq_; }
+    uint64_t next_incarnation() const { return next_order_incarnation_; }
     const std::vector<uint64_t>& hashes() const { return broker_state_hashes_; }
+    void seed_prior_run_snapshots() {
+        pos_view_freeze_bar_ = 7;
+        pos_view_frozen_side_ = PositionSide::LONG;
+        pos_view_frozen_qty_ = 2.0;
+        pos_view_frozen_entry_qty_["previous"] = 2.0;
+        trail_best_before_bar_ = 99.0;
+        trail_best_before_bar_index_ = 7;
+        trail_best_before_bar_position_cycle_ = 3;
+        trail_best_before_bar_fill_seq_ = 9;
+        priced_entry_activity_bar_ = 7;
+        priced_entry_filled_this_bar_ = true;
+        open_margin_slice_bar_ = 7;
+    }
 };
 
 int main() {
@@ -89,7 +103,18 @@ int main() {
     assert(reused_cycles.next_cycle() == fresh_cycles.next_cycle());
     assert(fresh_cycles.next_order_sequence() == 5);
     assert(reused_cycles.next_order_sequence() == fresh_cycles.next_order_sequence());
+    assert(fresh_cycles.next_incarnation() == 5);
+    assert(reused_cycles.next_incarnation() == fresh_cycles.next_incarnation());
+    assert(fresh_cycles.hashes().size() == 6);
+    assert(reused_cycles.hashes().size() == 6);
     assert(reused_cycles.hashes() == fresh_cycles.hashes());
+
+    CycleProbe fresh_empty, previous_snapshots;
+    fresh_empty.run(nullptr, 0);
+    previous_snapshots.seed_prior_run_snapshots();
+    assert(previous_snapshots.broker_state_hash() != fresh_empty.broker_state_hash());
+    previous_snapshots.run(nullptr, 0);
+    assert(previous_snapshots.broker_state_hash() == fresh_empty.broker_state_hash());
 
     p.prepared = false;
     base.run(bars, 3, "1", "1");

--- a/tests/test_script_run_prepare.cpp
+++ b/tests/test_script_run_prepare.cpp
@@ -44,6 +44,18 @@ public:
     }
 };
 
+class CycleProbe final : public BacktestEngine {
+public:
+    void on_bar(const Bar&) override {
+        if (bar_index_ % 3 == 0)
+            strategy_entry("L", true, na<double>(), na<double>(), 1.0);
+        if (bar_index_ % 3 == 1) strategy_close_all();
+    }
+    int64_t next_cycle() const { return next_position_cycle_seq_; }
+    int64_t next_order_sequence() const { return next_order_seq_; }
+    const std::vector<uint64_t>& hashes() const { return broker_state_hashes_; }
+};
+
 int main() {
     const Bar bars[] = {
         {10, 11, 9, 10, 1, 60000},
@@ -60,6 +72,24 @@ int main() {
     base.run(bars, 3);
     assert(p.preparations == 2 && p.allow_precalc);
     assert((p.observed == std::vector<int>{8, 9, 10}));
+
+    const Bar cycle_bars[] = {
+        {10, 10, 10, 10, 1, 60000}, {11, 11, 11, 11, 1, 120000},
+        {12, 12, 12, 12, 1, 180000}, {13, 13, 13, 13, 1, 240000},
+        {14, 14, 14, 14, 1, 300000}, {15, 15, 15, 15, 1, 360000},
+    };
+    CycleProbe fresh_cycles, reused_cycles;
+    fresh_cycles.set_broker_state_hash_recording(true);
+    reused_cycles.set_broker_state_hash_recording(true);
+    fresh_cycles.run(cycle_bars, 6);
+    reused_cycles.run(cycle_bars, 6);
+    reused_cycles.run(cycle_bars, 6);
+    // Two separate opens within each run consume two distinct cycle IDs.
+    assert(fresh_cycles.next_cycle() == 3);
+    assert(reused_cycles.next_cycle() == fresh_cycles.next_cycle());
+    assert(fresh_cycles.next_order_sequence() == 5);
+    assert(reused_cycles.next_order_sequence() == fresh_cycles.next_order_sequence());
+    assert(reused_cycles.hashes() == fresh_cycles.hashes());
 
     p.prepared = false;
     base.run(bars, 3, "1", "1");


### PR DESCRIPTION
Reusing a compiled strategy handle could retain Pine series, indicator and collection state across backtests. Add an engine-owned preparation hook after broker reset and before precalculation/security evaluation, and reset run-local allocation counters and cached broker snapshots. The companion codegen change resets generated persistent members through that hook. Configured inputs survive a new run, while ticks and order-fill recalculations within one stream retain their state.

MFI also classified equal-decimal source values by raw binary comparison, allowing a tiny HLC3 rounding residue to contribute a full bar's money flow. Use the existing Pine float-comparison helpers for direction. Direct TradingView controls distinguish below-band and above-band movements at three price scales. The fixes have no strategy, symbol or date lookup.

Addresses engine issue #219. This pair requires regenerated strategy C++ and rebuilt modules against matching engine headers/library; the internal C++ namespace prevents stale objects from silently binding the changed virtual layout. The public C ABI is unchanged. Companion codegen commit: `c8ffe587c8fb82435fec34121a93fab2b7018924`.

Validation:

- Final Cloud sweep `cand-r37-full-b-20260909`: 72/72 cases, 4,190/4,190 probes; **4,180 excellent / 10 strong / 0 moderate**, up one excellent from Round 36. The README-inclusive pair reproduces the first full sweep's grades, quantities and trade CSVs exactly.
- Ford 15m RSI/MFI becomes excellent: canonical match 95.2% to 100%, count gap 2 to 0. EURUSD MFI and Ford EWO remain excellent and reach 100% canonical match.
- All 704 hard probes retain identical grades, quantity metrics and trade CSVs; 4,187/4,190 CSVs are unchanged. No verifier, grading, threshold, profile, feed, reference, input or population changes.
- Independent raw audit: 315/315 strict entry-and-exit matches across the three changed probes, 13 gained and none lost. Overall verifier matches 2,817,481 of 2,819,967 TradingView trades.
- Real retained-C-handle Cloud diagnostics on fixed 5,000-bar windows: Cashflow 42/41/41 becomes 42/42/42; CHoCH/BOS 133/134/134 becomes 133/133/133. SMA152 stays at 232 trades with repeated-run hashes now equal. Fresh controls agree; these are current windows, not the reporter's older counts.
- Full native build: 249/249 checks. Full codegen suite with candidate engine headers/library: 2,802 passed, 1 pre-existing skip. Permanent compiled C-ABI tests cover repeated/short batches, input A-B-A, stream restart/continuity and mutable collections/UDTs with order-fill recalculation. New literal MFI controls fail on the old source (17 failures) and pass all 157 checks on the candidate.
- Independent Grok 4.6 high review of the exact final engine/codegen pair: zero actionable P0/P1/P2 findings. Runtime and tests are unchanged from the fully tested pair; only README documentation was added before the final Cloud sweep.

Known limits: the EURUSD open-position mark retains its pre-existing price difference, and CSV display-precision differences remain. Exact MFI behavior at the inclusive 1e-10 boundary is inherited from the existing TV-pinned generic helper; the new direct MFI controls bracket that boundary. No all-column or byte-for-byte reporting equality is claimed.

Cloud PR gate `pineforge-pr-gate-xh6xb`: **PASS**, target score +1, hard regressions 0, tolerated exceptions empty, full 4,190-probe coverage. Verdict recorded and corroborated in Postgres for engine `0d152028f540bf48242ea190cf33144756ba6b40` and codegen `c8ffe587c8fb82435fec34121a93fab2b7018924`. Candidate snapshot `8bd08fd50eb8b1785ad364dd7759e9a5e4b0625e9f3b2c13e64816d77788d52c` (788,836 bytes), unchanged population `3d72f815de54e4a2f6fdff6bb2294ea99c38849888390ded4ecd68ac3e5a9110`. Independent final audit verifies all 72 immutable case/input manifests, source bundles, 64/64 runner tasks and successful pipeline completion. Both companion PRs must merge before the composite baseline promotion.
