### PR TITLE
Fix whole-lot opening budgets after completed closes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 TradingView's strategy tester is the reference every Pine author trusts, and nothing outside TradingView reproduced it — until now. PineForge is a C++17 runtime with a stable C ABI that runs PineScript v6 strategies exactly the way TradingView's broker emulator does: same fills, same sizing, same margin calls, same trailing stops, same `request.security()` buckets, on any OHLCV you give it, in microseconds per bar.
 
-- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,180 excellent, 10 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,481 matched by the verifier.
+- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,181 excellent, 9 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,485 matched by the verifier.
 - **Open.** Engine, transpiler, corpus, benchmarks and the validation tooling are all public and Apache-2.0. The only thing you cannot download is the closed test set, because TradingView's Terms of Service forbid redistributing community scripts.
 - **Fast.** In-process, no interpreter: median **162× faster than PyneCore** on 99 timed strategies. Parameter sweeps re-run a loaded `.so` with new inputs — no recompile, no fork.
 - **Deterministic to the bit.** Two runs with the same inputs produce identical trade lists. Same on Linux and macOS.
@@ -110,20 +110,20 @@ Lifecycle-aware compiled modules reset Pine variables, indicator/history buffers
 
 ## Validation scoreboard
 
-**Round 37 · 2026-09-09:** **4,180 excellent / 10 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
+**Round 38 · 2026-09-09:** **4,181 excellent / 9 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
 
 | Board | Test set | Result | TradingView trades evaluated |
 |---|---|---|---|
 | **Public** — [open corpus](https://github.com/pineforge-4pass/pineforge-corpus) | 312 reference strategies, Apache-2.0, reproducible by anyone | **309/309 graded excellent** (ETH/USDT-perp 15m; the corpus' declared engine-only / anomaly probes are not graded) | 429,866 |
-| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,871 excellent + 10 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
+| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,872 excellent + 9 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
 
-**2,819,967 TradingView trades** evaluated, **2,817,481 matched by the verifier** (99.91%), from the round 37 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
+**2,819,967 TradingView trades** evaluated, **2,817,485 matched by the verifier** (99.91%), from the round 38 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
 
-Round 37 corrects MFI source direction and compiled-strategy reuse. MFI uses Pine's existing absolute float-comparison band, so equal-decimal HLC3 values do not contribute a full bar's money flow because of binary rounding residue. A reused compiled strategy resets persistent Pine state before each new batch or stream warmup, while retaining input settings and preserving accumulated state within an active stream.
+Round 38 corrects admission of an opening order whose whole-lot quantity uses rounded equity but whose exact cost exceeds the available budget. The rule applies to either direction and also after a separate close has completed. The valid closing fill is preserved; the unaffordable opening is declined.
 
-**RSI/MFI Divergence Momentum (antoniolinux)** on **NYSE:F 15m** moves from strong to excellent: canonical match rises from 95.2% to 100%, the trade-count gap falls from 2 to 0, and entry-price, exit-price, PnL and quantity error remain zero at the 90th percentile. The same strategy on **OANDA:EURUSD 15m** and **EWO/RSI Advanced Signals (pridarasx)** on **NYSE:F 15m** remain excellent and improve to 100% canonical match. Independent raw inspection verifies **315/315 strict entry-and-exit matches** across these three probes, gaining 13 with none lost. The pre-existing EURUSD open-position mark and display-precision differences remain; this is not complete reporting-byte equality.
+**Support Resistance Zones (lazyhacker22)** on **NYSE:F 15m** moves from strong to excellent: canonical match rises from 99.7% to 100%, with zero trade-count gap and zero entry-price, exit-price, PnL and quantity error at the 90th percentile. Independent comparison of the unfiltered trade files gains **551 exact physical trade-pair matches, with none lost**. The remaining physical-row difference is one TradingView trade represented as two engine margin fragments with equal total quantity and PnL; canonical match is 100%.
 
-The fixes have no strategy, symbol or date lookup. Direct TradingView controls distinguish below-band and above-band MFI movements at three price scales, including a nonzero HLC3 rounding residue. Separate Cloud diagnostics retain the same C handle across repeated runs and verify the lifecycle repair. All **704 hard-surface probes** retain their canonical grades, quantity metrics and trade CSVs; 4,187 of 4,190 CSVs are unchanged. Verifier code, grading rules, profile-selection code, reference tapes, feeds, input files and scored population are unchanged.
+The fix has no strategy, symbol or date lookup. Sixteen TradingView controls cover both directions, flat entries, separate closes, reversals, explicit quantities and budget boundaries. A Cloud diagnostic reproduces the original selected trade CSV and confirms that a one-lot allowance admitted an order whose cost exceeded frozen equity by one binary64 step. All **704 hard-surface probes** retain their canonical grades, quantity metrics and trade CSVs; **4,189 of 4,190 CSVs are unchanged**. Verifier code, grading rules, profile-selection code, reference tapes, feeds, input files and scored population are unchanged.
 
 ### The closed test, lane by lane
 
@@ -139,12 +139,12 @@ The fixes have no strategy, symbol or date lookup. Direct TradingView controls d
 | NASDAQ:AAPL · 15m | 356 | 354 | 2 | — |
 | NSE:NIFTY · 15m | 191 | 191 | — | — |
 | NSE:NIFTY · 1D | 145 | 145 | — | — |
-| NYSE:F · 15m | 340 | 337 | 3 | — |
+| NYSE:F · 15m | 340 | 338 | 2 | — |
 | NYSE:F · 1D | 263 | 263 | — | — |
 | OANDA:EURUSD · 15m | 373 | 372 | 1 | — |
 | OANDA:XAUUSD · 15m | 376 | 375 | 1 | — |
 | OANDA:XAUUSD · 1D | 248 | 248 | — | — |
-| **Total** | **3,881** | **3,871** | **10** | **0** |
+| **Total** | **3,881** | **3,872** | **9** | **0** |
 
 ### How a probe is graded
 

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -5764,22 +5764,36 @@ void BacktestEngine::apply_filled_order_to_state(
             }
         }
     }
-    // Round17 ADXAE F: rule1 sizes from ten-digit rounded equity, so an
-    // integer-lot exact-budget tie need not satisfy the raw-equity floor
-    // invariant. At the zero-gap Apr28 open, Q768 * P12.31 is 9454.08 but
-    // frozen E is 9454.0799999999981; TV drops the entry. The general float
-    // allowance must not donate that missing budget in this pinned shape.
-    // Keep fractional lots, reversals, fees, other execution modes and all
-    // non-tie/gap admission rules on their established paths.
-    if (order.type == OrderType::MARKET && order.is_long && std::isnan(order.qty)
+    // Whole-lot all-in sizing uses ten-digit rounded equity, which can lift
+    // an exact notional tie above the frozen raw budget. At an unchanged
+    // fill price, the lot allowance must not fund that missing amount. This
+    // applies to either opening direction, including after a separate close
+    // has already filled. Completed closes remain in the vector until the end
+    // of the pass; they do not make this a competing-order opening.
+    // Only the opening leg is declined. Fractional lots, reversals, fees,
+    // other execution modes and non-tie/gap rules retain their own paths.
+    const auto sole_opening_after_closes = [&]() {
+        for (size_t index = 0; index < pending_orders_.size(); ++index) {
+            if (index != order_index
+                && (pending_orders_[index].type != OrderType::EXIT
+                    || pending_orders_[index].id.compare(0, kClosePrefix.size(), kClosePrefix) != 0
+                    || std::find(filled_indices.begin(), filled_indices.end(), index)
+                           == filled_indices.end())) {
+                return false;
+            }
+        }
+        return true;
+    };
+    if (order.type == OrderType::MARKET && std::isnan(order.qty)
         && !order.affordability_close_only && !order.sbmt_member
         && position_side_ == PositionSide::FLAT
-        && order.created_position_side == PositionSide::FLAT
-        && !order.created_after_position_close_in_bar
+        && (order.created_position_side == PositionSide::FLAT
+            || order.created_after_position_close_in_bar)
         && !order.created_by_same_id_replacement
-        && order.created_bar == bar_index_ - 1 && pending_orders_.size() == 1
+        && order.created_bar == bar_index_ - 1 && sole_opening_after_closes()
         && default_qty_type_ == QtyType::PERCENT_OF_EQUITY
-        && default_qty_value_ == 100 && margin_long_ == 100
+        && default_qty_value_ == 100
+        && (order.is_long ? margin_long_ : margin_short_) == 100
         // Omitted Pine pyramiding retains the engine's single-entry default1;
         // explicit0 has the same first-opening shape. Adds remain out of scope.
         && pyramiding_ >= 0 && pyramiding_ <= 1

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    test_integer_opening_budget
     test_script_run_prepare
     test_pooc_open_money_event
     test_live_abort

--- a/tests/test_integer_opening_budget.cpp
+++ b/tests/test_integer_opening_budget.cpp
@@ -1,0 +1,96 @@
+// Literal broker fixtures for the TV-proven whole-lot budget boundary.
+// No registered strategy or reference tape is executed by this test.
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <pineforge/engine.hpp>
+
+using namespace pineforge;
+namespace {
+int passed = 0, failed = 0;
+#define CHECK(condition) do { if (condition) ++passed; else { ++failed; \
+    std::printf("FAIL %d: %s\n", __LINE__, #condition); } } while (0)
+constexpr double NA = std::numeric_limits<double>::quiet_NaN();
+constexpr double PRICE = 9.17;
+constexpr double BUDGET = 978503.19;
+const Bar bars[] = {
+    {PRICE, PRICE, PRICE, PRICE, 1, 1000},
+    {PRICE, PRICE, PRICE, PRICE, 1, 2000},
+    {PRICE, PRICE, PRICE, PRICE, 1, 3000},
+    {PRICE, PRICE, PRICE, PRICE, 1, 4000},
+    {PRICE, PRICE, PRICE, PRICE, 1, 5000},
+};
+
+class Opening : public BacktestEngine {
+public:
+    Opening(double budget, bool new_long, bool seed, bool same_side = false,
+            bool competing = false, double percent = 100)
+        : new_long_(new_long), seed_(seed), same_side_(same_side),
+          competing_(competing) {
+        initial_capital_ = budget;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = percent;
+        margin_long_ = margin_short_ = 100;
+        script_has_strategy_close_ = true;
+        pyramiding_ = 1;
+        qty_step_ = syminfo_.pointvalue = 1;
+        set_syminfo_mintick(.01);
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0 && seed_)
+            strategy_entry("Seed", same_side_ ? new_long_ : !new_long_, NA, NA, 1);
+        if (bar_index_ == 1) {
+            if (seed_) strategy_close("Seed");
+            if (competing_)
+                strategy_entry("Resting", new_long_, new_long_ ? 1 : 1000, NA, 1);
+            strategy_entry("New", new_long_);
+        }
+        if (bar_index_ == 2) opened_qty = position_qty_;
+        if (bar_index_ == 3) strategy_close("New");
+    }
+    double opened_qty = -1;
+private:
+    bool new_long_, seed_, same_side_, competing_;
+};
+
+void check(double budget, bool new_long, bool seed, bool expected,
+           bool same_side = false, bool competing = false, double percent = 100) {
+    Opening engine(budget, new_long, seed, same_side, competing, percent);
+    engine.run(bars, 5);
+    if (engine.opened_qty != (expected ? (percent == 100 ? 106707 : 105639) : 0)) {
+        std::printf("budget=%.17g long=%d seed=%d same=%d competing=%d percent=%.1f opened=%.17g trades=%d\n",
+                    budget, new_long, seed, same_side, competing, percent,
+                    engine.opened_qty, engine.trade_count());
+    }
+    CHECK(engine.last_error().empty());
+    CHECK(engine.opened_qty == (expected ? (percent == 100 ? 106707 : 105639) : 0));
+    CHECK(engine.trade_count() == (seed ? 1 : 0) + (expected ? 1 : 0));
+    if (seed && engine.trade_count() > 0) {
+        const auto& close = engine.get_trade(0);
+        CHECK(close.entry_bar_index == 1);
+        CHECK(close.exit_bar_index == 2);
+        CHECK(close.qty == 1);
+        CHECK(close.entry_price == PRICE && close.exit_price == PRICE);
+    }
+}
+}  // namespace
+
+int main() {
+    const double below = std::nextafter(BUDGET, 0.0);
+    const double above = std::nextafter(BUDGET, std::numeric_limits<double>::infinity());
+    for (bool new_long : {false, true}) {
+        for (bool seed : {false, true}) {
+            check(below, new_long, seed, false);
+            check(BUDGET, new_long, seed, true);
+            check(above, new_long, seed, true);
+            check(below, new_long, seed, true, false, false, 99);
+            check(below, new_long, seed, true, false, true);
+        }
+        check(below, new_long, true, false, true);
+        // A same-direction call made while the seed is still held is over
+        // the pyramiding cap and follows the existing post-close removal.
+        check(BUDGET, new_long, true, false, true);
+    }
+    std::printf("%d passed, %d failed\n", passed, failed);
+    return failed ? 1 : 0;
+}


### PR DESCRIPTION
Whole-lot percent-of-equity orders can be sized from rounded equity even when their exact notional cost exceeds the frozen budget. After a separate close, the general one-lot allowance could admit that unaffordable opening. Apply the existing exact-budget check to both directions and recognize completed internal closes while preserving the closing fill and existing competing-order exclusions.

The fix has no strategy, symbol, or date lookup. The affected Ford 15-minute probe moves from strong to excellent with 100% canonical match and zero P90 entry, exit, PnL, and quantity discrepancy. README records the measured scoreboard and the remaining physical margin-fragment distinction.

Validation: 250 native tests pass; 16 TradingView controls and an unchanged-output Cloud diagnostic establish the budget boundary. The full 4,190-probe comparison yields 4,181 excellent / 9 strong / 0 moderate, with all 704 hard probes unchanged and 4,189 trade CSVs identical. Grading, profiles, input files, feeds, references, and population are unchanged. Independent exact-head review is GREEN.

The README-inclusive Cloud sweep reproduces all 4,190 earlier results. PR gate `pineforge-pr-gate-svv5q` is **PASS**: target score +1, zero hard regressions, no tolerated exceptions, complete coverage. Recorded candidate snapshot: `0258370541cfd00acd419f75ef3dc731c531632ed369487167ab92d23eb0f099` (788,828 bytes), bound to engine `5c2be9d9f2c936b4903fd76c324bd8bdf74876ae` and codegen `c8ffe587c8fb82435fec34121a93fab2b7018924`.
