### PR TITLE
fix: apply price admission to ordinary fractional market entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 TradingView's strategy tester is the reference every Pine author trusts, and nothing outside TradingView reproduced it — until now. PineForge is a C++17 runtime with a stable C ABI that runs PineScript v6 strategies exactly the way TradingView's broker emulator does: same fills, same sizing, same margin calls, same trailing stops, same `request.security()` buckets, on any OHLCV you give it, in microseconds per bar.
 
-- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,181 excellent, 9 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,817,485 matched by the verifier.
+- **Proven, not promised.** All 4,190 probes — 312 open reference strategies plus 413 real community scripts on 15 markets and timeframes — grade *excellent* or *strong* against TradingView's own trade lists: **4,182 excellent, 8 strong, zero moderate**. The current full sweep evaluates 2,819,967 TradingView trades, with 2,818,237 matched by the verifier.
 - **Open.** Engine, transpiler, corpus, benchmarks and the validation tooling are all public and Apache-2.0. The only thing you cannot download is the closed test set, because TradingView's Terms of Service forbid redistributing community scripts.
 - **Fast.** In-process, no interpreter: median **162× faster than PyneCore** on 99 timed strategies. Parameter sweeps re-run a loaded `.so` with new inputs — no recompile, no fork.
 - **Deterministic to the bit.** Two runs with the same inputs produce identical trade lists. Same on Linux and macOS.
@@ -110,18 +110,18 @@ Lifecycle-aware compiled modules reset Pine variables, indicator/history buffers
 
 ## Validation scoreboard
 
-**Round 38 · 2026-09-09:** **4,181 excellent / 9 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
+**Round 39 · 2026-09-09:** **4,182 excellent / 8 strong / zero moderate** across all **4,190 scored probes**. This round adds one excellent result, with zero regressions on any canonical metric.
 
 | Board | Test set | Result | TradingView trades evaluated |
 |---|---|---|---|
 | **Public** — [open corpus](https://github.com/pineforge-4pass/pineforge-corpus) | 312 reference strategies, Apache-2.0, reproducible by anyone | **309/309 graded excellent** (ETH/USDT-perp 15m; the corpus' declared engine-only / anomaly probes are not graded) | 429,866 |
-| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,872 excellent + 9 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
+| **Closed test** — the parity campaign | 413 community-shared TradingView scripts across 15 market/timeframe lanes: **3,881 script-lane probes** — private under TradingView's Terms of Service | **3,873 excellent + 8 strong + zero moderate** = 3,881/3,881 (100%) excellent-or-strong | 2,390,101 |
 
-**2,819,967 TradingView trades** evaluated, **2,817,485 matched by the verifier** (99.91%), from the round 38 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
+**2,819,967 TradingView trades** evaluated, **2,818,237 matched by the verifier** (99.94%), from the round 39 full Cloud Run sweep. **18 TradingView-side anomalies** remain excluded under the unchanged population; each was documented before exclusion. No scored probe remains below *strong*.
 
-Round 38 corrects admission of an opening order whose whole-lot quantity uses rounded equity but whose exact cost exceeds the available budget. The rule applies to either direction and also after a separate close has completed. The valid closing fill is preserved; the unaffordable opening is declined.
+Round 39 extends the existing price-scale admission check to ordinary, fee-free fractional market entries when one minimum lot is worth at least one account unit. It shares the existing financial and order-book scope with the signal-cost check. A separately queued close still fills when the opening is declined, and entries placed after a close retain their established exception.
 
-**Support Resistance Zones (lazyhacker22)** on **NYSE:F 15m** moves from strong to excellent: canonical match rises from 99.7% to 100%, with zero trade-count gap and zero entry-price, exit-price, PnL and quantity error at the 90th percentile. Independent comparison of the unfiltered trade files gains **551 exact physical trade-pair matches, with none lost**. The remaining physical-row difference is one TradingView trade represented as two engine margin fragments with equal total quantity and PnL; canonical match is 100%.
+**PK Willow Pulse UT Williams Live Movement** on **BINANCE:BTCUSDT 15m** moves from strong to excellent: canonical match rises from 96.9% to 100%, with zero trade-count gap and zero entry-price, exit-price, PnL and quantity error at the 90th percentile. Independent comparison of the unfiltered files matches all **12,408 physical trade pairs** on side, entry/exit times, prices and quantity, gaining **10,756 matches with none lost**. Including the displayed PnL in the exact comparison gains **2,193 matches with none lost**; the files use different PnL display precision.
 
 The fix has no strategy, symbol or date lookup. Sixteen TradingView controls cover both directions, flat entries, separate closes, reversals, explicit quantities and budget boundaries. A Cloud diagnostic reproduces the original selected trade CSV and confirms that a one-lot allowance admitted an order whose cost exceeded frozen equity by one binary64 step. All **704 hard-surface probes** retain their canonical grades, quantity metrics and trade CSVs; **4,189 of 4,190 CSVs are unchanged**. Verifier code, grading rules, profile-selection code, reference tapes, feeds, input files and scored population are unchanged.
 

--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ Round 39 extends the existing price-scale admission check to ordinary, fee-free 
 
 **PK Willow Pulse UT Williams Live Movement** on **BINANCE:BTCUSDT 15m** moves from strong to excellent: canonical match rises from 96.9% to 100%, with zero trade-count gap and zero entry-price, exit-price, PnL and quantity error at the 90th percentile. Independent comparison of the unfiltered files matches all **12,408 physical trade pairs** on side, entry/exit times, prices and quantity, gaining **10,756 matches with none lost**. Including the displayed PnL in the exact comparison gains **2,193 matches with none lost**; the files use different PnL display precision.
 
-The fix has no strategy, symbol or date lookup. Sixteen TradingView controls cover both directions, flat entries, separate closes, reversals, explicit quantities and budget boundaries. A Cloud diagnostic reproduces the original selected trade CSV and confirms that a one-lot allowance admitted an order whose cost exceeded frozen equity by one binary64 step. All **704 hard-surface probes** retain their canonical grades, quantity metrics and trade CSVs; **4,189 of 4,190 CSVs are unchanged**. Verifier code, grading rules, profile-selection code, reference tapes, feeds, input files and scored population are unchanged.
+The fix has no strategy, symbol or date lookup. TradingView controls pin both directions, flat entries, reversal/close ordering and funding boundaries. A Cloud diagnostic reproduces the original selected trade CSV across all six observed invocations and confirms that the engine passed signal-cost admission but skipped the price-scale check for a high-value fractional lot. The exact explicit-quantity reversal control exposed a separate gap that remains unchanged by this default-sizing fix. All **704 hard-surface probes** retain their canonical grades, quantity metrics and trade CSVs; **4,189 of 4,190 CSVs are unchanged**. Verifier code, grading rules, profile-selection code, reference tapes, feeds, input files and scored population are unchanged.
 
 ### The closed test, lane by lane
 
 | Market · timeframe | Probes | Excellent | Strong | Moderate |
 |---|---:|---:|---:|---:|
 | BINANCE:ETHUSDT.P · 15m *(hard lane: zero regression allowed)* | 395 | 394 | 1 | — |
-| BINANCE:BTCUSDT · 15m | 354 | 353 | 1 | — |
+| BINANCE:BTCUSDT · 15m | 354 | 354 | — | — |
 | BINANCE:BTCUSDT · 1D | 259 | 259 | — | — |
 | CME_MINI:ES1! · 15m | 174 | 173 | 1 | — |
 | CME_MINI:ES1! · 1D | 117 | 117 | — | — |
@@ -144,7 +144,7 @@ The fix has no strategy, symbol or date lookup. Sixteen TradingView controls cov
 | OANDA:EURUSD · 15m | 373 | 372 | 1 | — |
 | OANDA:XAUUSD · 15m | 376 | 375 | 1 | — |
 | OANDA:XAUUSD · 1D | 248 | 248 | — | — |
-| **Total** | **3,881** | **3,872** | **9** | **0** |
+| **Total** | **3,881** | **3,873** | **8** | **0** |
 
 ### How a probe is graded
 

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -79,8 +79,8 @@ enum class PositionSide { FLAT, LONG, SHORT };
 // 4583, the float-accumulated ledger's 4584.000000000001 or a 1e-6-nudged
 // floor gives 4584, one share the account cannot pay at the 238.78 fill), so
 // rule 1 sizes every lot-stepped instrument (tv_money_lot_sizing). Rule 2
-// additionally covers ordinary, fee-free high-value fractional lots (R24);
-// rule 5 stays scoped by tv_money_scope. Other admission keeps its existing
+// additionally covers ordinary, fee-free high-value fractional lots (R24),
+// as does the price-scale check in rule 5 (R39). Other admission keeps its existing
 // checks (1094521.681 -> Q 4584 dropped on AAPL). Rule 3
 // additionally covers ordinary MARKET-opened, fee/slippage-free single-position
 // fractional unit-pointvalue/same-currency books with lot value >=1 (R21 pins).
@@ -2269,10 +2269,10 @@ protected:
     // equity 1052170.9536054998 therefore keeps only a reversal's close leg.
     // XAU Q300 at 3443.625 likewise rejects capital cost-0.0001, while exact
     // cost and cost+0.0001 admit, despite the cheaper next opening price.
-    // This extends rule 2 alone; rule 5 and margin valuation keep their scope.
-    bool rounded_signal_cost_scope(const PendingOrder& order) const {
-        if (tv_money_scope(order.sizing_price)) return true;
-        if (rounded_pooc_flat_signal_cost_scope(order)) return true;
+    // R39 BTC/XAU controls also pin the independent price-scale check for
+    // this ordinary market book. Share its scope while keeping the separately
+    // pinned POOC signal-cost extension out of the price-scale extension.
+    bool ordinary_fractional_market_admission_scope(const PendingOrder& order) const {
         if (!(qty_step_ > 0.0 && qty_step_ < 1.0)
             || !std::isfinite(order.sizing_price) || order.sizing_price <= 0.0
             || !std::isfinite(order.sizing_equity)
@@ -2304,6 +2304,15 @@ protected:
             }
         }
         return true;
+    }
+    bool rounded_signal_cost_scope(const PendingOrder& order) const {
+        return tv_money_scope(order.sizing_price)
+            || rounded_pooc_flat_signal_cost_scope(order)
+            || ordinary_fractional_market_admission_scope(order);
+    }
+    bool rounded_price_admission_scope(const PendingOrder& order) const {
+        return tv_money_scope(order.sizing_price)
+            || ordinary_fractional_market_admission_scope(order);
     }
     // Rule 1's scope (round 10 family AE): the ten-digit equity and the raw
     // lot floor size EVERY lot-stepped instrument — integer shares included

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -5715,10 +5715,14 @@ void BacktestEngine::apply_filled_order_to_state(
                 }
                 order.affordability_close_only = true;
                 order.rounded_signal_cost_close_only = true;
-            } else if (!close_first_flat_open && tv_money_scope(order.sizing_price)) {
+            } else if (!close_first_flat_open && rounded_price_admission_scope(order)) {
                 // Rule 5: the price-scale margin check (comment above).
-                // The R24 high-value fractional-lot extension pins rule 2
-                // only; it does not widen this independent price-scale rule.
+                // R39 covered BTC/XAU controls extend it to the ordinary
+                // fractional market book even when one lot is worth >=1.
+                // At Q7.80692/P106318.18, rounded affordable price is one
+                // ulp below the tick-built sizing price: bare/entry-first
+                // and true-flat entries drop; funding +0.0003 admits.
+                // Close-first retains its independent exemption above.
                 const double notional_per_price =
                     order.frozen_default_qty * syminfo_.pointvalue * fx_s;
                 const double affordable_price = tv_money_round(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    test_high_value_price_admission
     test_integer_opening_budget
     test_script_run_prepare
     test_pooc_open_money_event

--- a/tests/test_high_value_price_admission.cpp
+++ b/tests/test_high_value_price_admission.cpp
@@ -1,0 +1,171 @@
+// R39 covered BTC/XAU TradingView controls pin price-scale admission for
+// ordinary fractional market books whose minimum lot is worth >=1. These
+// literal command fixtures use synthetic timestamps and constant fill bars
+// to isolate admission from the later intrabar margin trims. No corpus,
+// indicator, historical strategy or grader is executed by this test.
+#include <pineforge/engine.hpp>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+constexpr double na = std::numeric_limits<double>::quiet_NaN();
+constexpr double seed_price = 106909.09;
+constexpr double signal_price = 106318.18;
+constexpr double base_equity = 830017.5259234;
+int passed = 0, failed = 0;
+#define CHECK(x) do { if (x) ++passed; else { ++failed; std::printf("FAIL %d %s\n", __LINE__, #x); } } while (0)
+bool near(double a, double b) { return std::abs(a - b) < 1e-8; }
+enum class Ordering { Bare, EntryFirst, CloseFirst };
+
+class Reversal : public BacktestEngine {
+public:
+    Ordering ordering;
+    bool seed_long;
+    double literal_qty;
+    double frozen = na, after = na;
+    Reversal(Ordering order, bool direction, double extra = 0.0,
+             double literal = na, double percent = 100.0)
+        : ordering(order), seed_long(direction), literal_qty(literal) {
+        initial_capital_ = base_equity + extra
+            + (seed_long ? 590.91 : -590.91);
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = percent;
+        qty_step_ = 0.00001;
+        syminfo_mintick_ = 0.01;
+        syminfo_.pointvalue = 1.0;
+        margin_long_ = margin_short_ = 100.0;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        pyramiding_ = 0;
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) strategy_entry("Seed", seed_long, na, na, 1.0);
+        if (bar_index_ == 1) {
+            if (ordering == Ordering::CloseFirst) strategy_close("Seed");
+            strategy_entry("New", !seed_long, na, na, literal_qty);
+            for (const auto& order : pending_orders_)
+                if (order.id == "New") frozen = order.frozen_default_qty;
+            if (ordering == Ordering::EntryFirst) strategy_close("Seed");
+        }
+        if (bar_index_ == 2) { after = signed_position_size(); strategy_close_all(); }
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+};
+
+void execute(Reversal& engine) {
+    const Bar bars[] = {
+        {seed_price, seed_price, seed_price, seed_price, 1, 1000},
+        {seed_price, seed_price, signal_price, signal_price, 1, 2000},
+        {signal_price, signal_price, signal_price, signal_price, 1, 3000},
+        {signal_price, signal_price, signal_price, signal_price, 1, 4000},
+    };
+    engine.run(bars, 4);
+}
+
+void test_ordering_and_direction() {
+    for (bool seed_long : {false, true}) {
+        for (Ordering ordering : {Ordering::Bare, Ordering::EntryFirst, Ordering::CloseFirst}) {
+            Reversal engine(ordering, seed_long);
+            execute(engine);
+            const double sign = seed_long ? 1.0 : -1.0;
+            CHECK(near(engine.frozen, 7.80692));
+            if (ordering == Ordering::CloseFirst) {
+                CHECK(near(engine.after, -sign * 7.80692));
+                CHECK(engine.rows().size() == 2);
+            } else if (ordering == Ordering::EntryFirst) {
+                CHECK(near(engine.after, 0.0));
+                CHECK(engine.rows().size() == 1);
+            } else {
+                CHECK(near(engine.after, sign));
+                CHECK(engine.rows().size() == 1);
+            }
+            CHECK(!engine.rows().empty());
+            if (!engine.rows().empty()) {
+                CHECK(engine.rows()[0].entry_id == "Seed");
+                CHECK(engine.rows()[0].exit_time == (ordering == Ordering::Bare ? 4000 : 3000));
+            }
+        }
+    }
+}
+
+void test_funding_and_sizing_controls() {
+    for (double extra : {-0.0002, -0.0001, 0.0, 0.0002, 0.0003}) {
+        Reversal engine(Ordering::EntryFirst, true, extra);
+        execute(engine);
+        const bool admitted = extra < 0.0 || extra >= 0.0003;
+        const double qty = extra < 0.0 ? 7.80691 : 7.80692;
+        CHECK(near(engine.frozen, qty));
+        CHECK(near(engine.after, admitted ? -qty : 0.0));
+        CHECK(engine.rows().size() == (admitted ? 2u : 1u));
+    }
+    // The exact explicit-quantity reversal is a separately recorded TV
+    // mismatch in the existing explicit admission path. This default-sizing
+    // fix does not claim to repair it. The one-lot-less and 99% admissions
+    // below remain covered controls for unaffected sizing paths.
+    Reversal less(Ordering::EntryFirst, true, 0.0, 7.80691);
+    execute(less);
+    CHECK(near(less.after, -7.80691));
+    CHECK(less.rows().size() == 2);
+    Reversal fractional(Ordering::EntryFirst, true, 0.0, na, 99.0);
+    execute(fractional);
+    CHECK(near(fractional.after, -7.72885));
+    CHECK(fractional.rows().size() == 2);
+}
+
+class Flat : public BacktestEngine {
+public:
+    bool is_long;
+    double after = na;
+    Flat(double equity, double step, double tick, bool direction) : is_long(direction) {
+        initial_capital_ = equity;
+        default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
+        default_qty_value_ = 100.0;
+        qty_step_ = step;
+        syminfo_mintick_ = tick;
+        syminfo_.pointvalue = 1.0;
+        margin_long_ = margin_short_ = 100.0;
+        commission_value_ = 0.0;
+        slippage_ = 0;
+        pyramiding_ = 0;
+    }
+    void on_bar(const Bar&) override {
+        if (bar_index_ == 0) strategy_entry("New", is_long);
+        if (bar_index_ == 1) { after = signed_position_size(); strategy_close_all(); }
+    }
+    const std::vector<Trade>& rows() const { return trades_; }
+};
+
+void test_flat_across_price_scales() {
+    struct Case { double equity, funded_extra, price, step, tick, qty; };
+    const Case cases[] = {
+        {base_equity, 0.0003, signal_price, 0.00001, 0.01, 7.80692},
+        {1034160.0001, 0.0006, 3447.2, 0.01, 0.001, 300.0},
+    };
+    for (const auto& c : cases) {
+        for (bool is_long : {false, true}) {
+            for (bool funded : {false, true}) {
+                Flat engine(c.equity + (funded ? c.funded_extra : 0.0), c.step, c.tick, is_long);
+                const Bar bars[] = {
+                    {c.price, c.price, c.price, c.price, 1, 1000},
+                    {c.price, c.price, c.price, c.price, 1, 2000},
+                    {c.price, c.price, c.price, c.price, 1, 3000},
+                };
+                engine.run(bars, 3);
+                CHECK(near(engine.after, funded ? (is_long ? c.qty : -c.qty) : 0.0));
+                CHECK(engine.rows().size() == (funded ? 1u : 0u));
+            }
+        }
+    }
+}
+} // namespace
+
+int main() {
+    test_ordering_and_direction();
+    test_funding_and_sizing_controls();
+    test_flat_across_price_scales();
+    std::printf("%d passed, %d failed\n", passed, failed);
+    return failed ? 1 : 0;
+}


### PR DESCRIPTION
Default-sized 100% market entries could pass signal-cost admission but skip the price-scale check when a fractional minimum lot was worth at least one account unit. Share the existing ordinary-market scope with that price check, preserving close-first behavior, independent closes, and the existing exclusions for fees, FX, competing orders and other execution modes.

Two full Cloud Run sweeps measured all 4,190 probes: 4,182 excellent / 8 strong, with only Willow BTC 15m upgrading and no canonical metric regressions. All 704 hard probes and 4,189 trade CSVs are unchanged. Willow matches all 12,408 TV trade identities (side, times, prices, quantity). The README records the measured board and the separate unchanged explicit-quantity gap.

Validation: 251 native tests and ABI source check pass; exact final-head Grok review GREEN. The README-head sweep reproduced every grade, quantity metric, trade CSV, input and deterministic verifier field. PR gate `pineforge-pr-gate-w4bw2` PASS: target +1, zero hard regressions, no tolerated exceptions. The final snapshot and gate receipt are recorded in Postgres.
