### PR TITLE
refactor: make opening checkpoint ownership explicit

### DIFF
--- a/docs/pages/abi-stability.md
+++ b/docs/pages/abi-stability.md
@@ -113,12 +113,20 @@ notice:
 
 Rebuild generated C++ objects against matching engine headers and the runtime
 archive. The script-run preparation hook uses the internal
-`engine_script_run_v1` inline namespace, so an object compiled against the old
-`BacktestEngine` vtable cannot silently bind the new run loop. Newly generated
+`engine_script_run_v2` inline namespace, so an object compiled against the old
+`BacktestEngine` layout or vtable cannot silently bind the new runtime. Newly generated
 lifecycle-aware modules also require `PINEFORGE_HAS_SCRIPT_RUN_PREPARE_V1` at
 compile time. Regenerate and rebuild a strategy module to obtain complete
 script-state reset; replacing an archive does not retrofit an old module.
 These checks do not change the public C function signatures or POD layouts.
+
+The owned-opening model uses broker fingerprint domain
+`pineforge-broker-state/v2` and stream fingerprint version 2. Fingerprints must
+be compared only for the same pinned engine build and configuration; prior
+fingerprints are not compatible with this representation. They are replay
+checks, not serialized checkpoints. The model removes four obsolete hashed
+labels and hashes the opening receipt's producer, position and checkpoint
+identity instead. Rebuild native/generated modules against the new headers.
 
 If you find yourself reaching for any of these from outside the closed
 PineForge transpiler, you're holding it wrong — file an issue and we'll

--- a/docs/pages/fill-model.md
+++ b/docs/pages/fill-model.md
@@ -1,0 +1,110 @@
+# Broker state and fill ownership
+
+The broker processes a source-ordered command book against a price path. Its
+physical position, logical close claims, reserved quantities and pyramiding
+capacity are separate ledgers. A Pine entry ID is a reusable name; the order
+incarnation and position cycle identify the owners of those ledgers.
+
+This document describes the first extracted ownership model. Other order,
+reservation and path state is still represented in `BacktestEngine` and
+`PendingOrder`; their consolidation is ongoing. The current economic rules
+retain their tested domains. Moving a rule into a type does not establish
+that it describes every TradingView configuration.
+
+## What qualifies as a generic flag
+
+A retained flag must represent a defined user setting or a causal execution
+fact with an owner, a producer and an expiry rule. Examples are a requested
+execution mode or a stop leg that actually activated. Multiple overlapping
+facts describing one lifecycle need explicit states and transitions instead.
+An experimental interpretation switch is not a user setting merely because
+it can be passed through metadata.
+
+Review both the fact and its consumers. A generic fact such as "market fill
+at the open" does not justify every financial exception that reads it. Each
+consumer must have an economic, temporal or ownership explanation and a
+counterfactual that can refute it independently of the originating strategy.
+Changing the strategy's name, adding an unreachable order, splitting physical
+lots or varying price scale can reveal a condition that encodes a narrow
+example rather than the proposed rule; the comparison must hold the relevant
+economics and information constant.
+
+In particular, a conjunction of direction, commission, sizing and book shape
+does not become generic by being renamed as an enum or captured as a receipt.
+The opening extraction below fixes ownership; the surviving financial
+eligibility predicates still require that separate review. Existing parity
+scores are regression evidence, not a justification for keeping a compensating
+flag. Actual conflicting TradingView observations belong in an anomaly review
+record, separate from an unknown rule or an engine defect.
+
+## Opening checkpoint
+
+An accepted opening or add can create an opening-affordability checkpoint.
+`broker::OpeningReceipt` carries its producing broker fill, source order
+incarnation, position cycle, bar and timestamp, and the raw matched price.
+The booked entry price is separate: the financial check reads the current
+position book and uses the raw price only where the execution policy requires
+it. It does not reconstruct ownership from FIFO rows or entry names.
+
+The live states are absent, pending check, and pending exemption. A check can
+carry a remaining-adverse-path continuation; an exemption cannot. The
+decision is made by the successful-fill policy when it creates the receipt.
+There is no later transition that promotes an exemption into eligibility.
+
+| Operation | Transition |
+|---|---|
+| Qualifying successful opening/add | Replace with the new producer's check or exemption |
+| Rejected or zero-effect attempt | Preserve the pending receipt |
+| Accepted incompatible short opening/add | Invalidate the prior receipt |
+| Full close, reversal, fresh cycle, run reset | Invalidate prior-position ownership |
+| Ordinary margin checkpoint | Take the receipt before any early return or recursive check; reject a stale position-cycle owner |
+| Checkpoint before a priced exit | Inspect without consuming; after an actual margin slice, consume only the same producer's receipt |
+
+This is one coalescing checkpoint over the aggregate book. It is not a queue
+that retroactively settles every individual fill. A later qualifying add
+replaces the raw price and producer; a no-op cannot replace them. A partial
+FIFO close may leave the position cycle alive even if it drains the original
+physical lot, so the receipt owns the aggregate cycle rather than requiring
+that original lot to survive.
+
+Disabled margin, invalid financial data, exemption and no shortfall can all
+consume the ordinary checkpoint without generating a trade. A scoped short
+check may then visit the remaining adverse path once using its detached
+receipt. The pre-priced-exit consumer retains its different existing contract:
+a no-action inspection leaves the receipt pending for the ordinary check.
+
+Four historical long/short lifecycle labels had no economic consumers. They
+have been removed, along with their producers; the numerical floor-zero rules
+and their trade fixtures remain. Those labels are not alternate model states.
+
+## Distinct execution domains
+
+An opening receipt is broker-local. It is not an identity for every output:
+
+- A physical fill may produce several FIFO trade rows.
+- A COOF notification may group several resting-order fills.
+- A stream action is an observer projection with its own delivery sequence.
+- A range-end report row marks an open position for reporting; it does not
+  close the broker book or create a stream action.
+- Pine variables and source-series history have separate speculative and
+  committed states. A Pine rollback does not roll back committed broker fills.
+
+Historical OHLC, magnifier, confirmed-bar and actual-tick inputs expose
+different information. The opening ownership extraction changes none of their
+path, callback or warmup policies. Terminal-close deferral is still selected
+by the existing financial policy; it has not been generalized by this model.
+
+## Verification and compatibility
+
+Literal state tests exercise consume-before-use, exempt presence, replacement,
+stale-owner rejection, no-op preservation and independent copies. Existing
+trade fixtures retain their financial expectations. Cloud comparison of the
+fixed reference population is required before reporting parity preservation.
+Hashes supplement those comparisons; a matching fingerprint is not a proof
+that all hidden strategy state is equal.
+
+The new receipt replaces protected C++ members and changes the fingerprint
+representation. Rebuild generated and native modules against matching headers
+and runtime. The internal class namespace and fingerprint domain are versioned;
+public C function signatures and POD layouts remain unchanged. See
+[ABI stability](abi-stability.md).

--- a/include/pineforge/broker_events.hpp
+++ b/include/pineforge/broker_events.hpp
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <utility>
+#include <variant>
+
+namespace pineforge::broker {
+
+// Stable causal identity, independent of a reusable Pine entry ID, FIFO trade
+// rows and observer delivery. Zero IDs are reserved for native test fixtures;
+// the production fill dispatcher supplies the committed cycle/fill/order IDs.
+struct OpeningOwner {
+    int64_t positionCycle;
+    uint64_t producerFill;
+    uint64_t orderIncarnation;
+    int barIndex;
+    int64_t timestamp;
+
+    bool operator==(const OpeningOwner& other) const {
+        return positionCycle == other.positionCycle
+            && producerFill == other.producerFill
+            && orderIncarnation == other.orderIncarnation
+            && barIndex == other.barIndex && timestamp == other.timestamp;
+    }
+};
+
+enum class OpeningDecision { Check, Exempt };
+enum class OpeningContinuation { None, RemainingAdversePath };
+
+// The decision is made when a real opening fill commits. An exempt event is
+// still present until its checkpoint; it cannot carry an adverse continuation.
+// Taking a receipt never promotes an exemption into a check.
+class OpeningReceipt {
+    struct Check { OpeningContinuation continuation; };
+    struct Exempt {};
+    using Decision = std::variant<Check, Exempt>;
+
+public:
+    static OpeningReceipt check(
+            OpeningOwner owner, double raw_fill_base,
+            OpeningContinuation continuation = OpeningContinuation::None) {
+        return OpeningReceipt(owner, raw_fill_base, Check{continuation});
+    }
+    static OpeningReceipt exempt(OpeningOwner owner, double raw_fill_base) {
+        return OpeningReceipt(owner, raw_fill_base, Exempt{});
+    }
+
+    const OpeningOwner& owner() const { return owner_; }
+    double raw_fill_base() const { return raw_fill_base_; }
+    OpeningDecision decision() const {
+        return std::holds_alternative<Check>(decision_)
+            ? OpeningDecision::Check : OpeningDecision::Exempt;
+    }
+    bool requires_adverse_pass() const {
+        const auto* check = std::get_if<Check>(&decision_);
+        return check
+            && check->continuation == OpeningContinuation::RemainingAdversePath;
+    }
+
+private:
+    OpeningReceipt(OpeningOwner owner, double raw_fill_base, Decision decision)
+        : owner_(owner), raw_fill_base_(raw_fill_base), decision_(decision) {}
+
+    OpeningOwner owner_;
+    double raw_fill_base_;
+    Decision decision_;
+};
+
+// One coalescing checkpoint for the live position. Successful qualifying fills
+// replace it; rejected/no-op attempts have no transition. Full close, reversal
+// and accepted incompatible fills invalidate it. This is not a queue of all
+// past fills: the checkpoint evaluates the current aggregate position using
+// the latest eligible producer's raw match price.
+class OpeningObligations {
+public:
+    bool pending() const { return pending_.has_value(); }
+    bool actionable() const {
+        return pending_ && pending_->decision() == OpeningDecision::Check;
+    }
+    bool requires_adverse_pass() const {
+        return pending_ && pending_->requires_adverse_pass();
+    }
+    double raw_fill_base() const {
+        return pending_ ? pending_->raw_fill_base()
+            : std::numeric_limits<double>::quiet_NaN();
+    }
+    const std::optional<OpeningReceipt>& peek() const { return pending_; }
+
+    void replace(OpeningReceipt receipt) { pending_ = std::move(receipt); }
+    void invalidate() { pending_.reset(); }
+
+    // Consume before the financial consumer can return, recurse or book a
+    // close. A receipt from a different position cycle cannot reach it.
+    std::optional<OpeningReceipt> take(int64_t live_position_cycle) {
+        auto receipt = std::exchange(pending_, std::nullopt);
+        if (receipt && receipt->owner().positionCycle != live_position_cycle)
+            return std::nullopt;
+        return receipt;
+    }
+
+    // The pre-priced-exit checkpoint commits consumption only after it books
+    // a slice. It cannot erase an event that a later producer has replaced.
+    bool consume(const OpeningOwner& owner) {
+        if (!pending_ || !(pending_->owner() == owner)) return false;
+        pending_.reset();
+        return true;
+    }
+
+private:
+    std::optional<OpeningReceipt> pending_;
+};
+
+} // namespace pineforge::broker

--- a/include/pineforge/broker_events.hpp
+++ b/include/pineforge/broker_events.hpp
@@ -18,13 +18,14 @@ struct OpeningOwner {
     int barIndex;
     int64_t timestamp;
 
-    bool operator==(const OpeningOwner& other) const {
-        return positionCycle == other.positionCycle
-            && producerFill == other.producerFill
-            && orderIncarnation == other.orderIncarnation
-            && barIndex == other.barIndex && timestamp == other.timestamp;
-    }
 };
+
+inline bool operator==(const OpeningOwner& owner, const OpeningOwner& other) {
+    return owner.positionCycle == other.positionCycle
+        && owner.producerFill == other.producerFill
+        && owner.orderIncarnation == other.orderIncarnation
+        && owner.barIndex == other.barIndex && owner.timestamp == other.timestamp;
+}
 
 enum class OpeningDecision { Check, Exempt };
 enum class OpeningContinuation { None, RemainingAdversePath };

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -12,6 +12,7 @@
 #include <unordered_set>
 #include "na.hpp"
 #include "bar.hpp"
+#include "broker_events.hpp"
 #include "series.hpp"
 #include "timeframe.hpp"
 #include "magnifier.hpp"
@@ -1094,66 +1095,20 @@ struct StrategyOverrides {
 };
 
 // The C++ subclass contract is internal, unlike pineforge.h's stable C ABI.
-// Changing its vtable requires all generated/native C++ objects to be rebuilt.
+// Changing its layout or vtable requires all generated/native C++ objects to be rebuilt.
 // Version the mangled class name so an object using the old vtable cannot
 // silently link to the new run loop and dispatch the wrong virtual slot.
-inline namespace engine_script_run_v1 {
+inline namespace engine_script_run_v2 {
 class BacktestEngine {
 protected:
     // --- Position state ---
     // @broker-state begin
     PositionSide position_side_ = PositionSide::FLAT;
     double position_entry_price_ = 0.0;   // volume-weighted average (for strategy calculations)
-    // One-shot post-fill affordability event. Every 100%-margin LONG opening /
-    // accepted add queues it as before; SHORT queues it only for a high-level
-    // explicit-qty MARKET strategy.entry opening/add at margin_short=100.
-    // The event carries the raw matched-price base and is eligible unless a
-    // LONG fill proves the narrow frozen-all-in true-flat MARKET exemption.
-    // Rejected/no-op attempts leave an existing event untouched; a later
-    // successful SHORT opening/add with any non-scoped shape invalidates prior
-    // short provenance rather than letting end-of-bar reuse its stale fill.
-    // process_margin_call consumes and clears it on the current script bar.
-    // Do not reconstruct it from trade rows or
-    // position_entry_count_: a paired close/reentry can create zero-PnL rows,
-    // and FIFO can reduce a real pyramid back to one live lot.
-    bool opening_affordability_pending_ = false;
-    bool opening_affordability_eligible_ = false;
-    // The queued event came from a successful, commissioned, omitted-qty
-    // percent_of_equity=100 high-level MARKET long that filled from flat.
-    // It covers the proven true-flat form and the separately proven
-    // close-then-open form. process_margin_call combines this one-shot
-    // provenance with the actual margin/commission arithmetic before applying
-    // TV's fee-created, floor-zero one-contract fallback. Adds,
-    // explicit/priced/RAW orders and zero/CASH commission stay outside it.
-    bool commissioned_all_in_market_long_opening_affordability_ = false;
-    // The queued event came from a successful omitted-qty, 100%-of-equity
-    // MARKET reversal from SHORT to LONG at 100% long margin with zero opening
-    // commission. TV applies a one-contract post-fill affordability trim when
-    // this exact reversal has a positive but sub-lot restore amount.
-    bool opening_affordability_default_long_reversal_ = false;
-    // An eligible omitted 100%-of-equity MARKET short opening. This covers
-    // both the close-then-open shape that reaches the fill from FLAT and the
-    // direct LONG-to-SHORT auto-reversal shape. The one-shot bit queues the
-    // fill-price affordability pass and then one ordinary adverse-price pass
-    // on that same bar, even when the opening check itself is a no-op.
-    bool close_then_short_opening_requires_adverse_retry_ = false;
-    // Position-lifecycle provenance for a commissioned, omitted-qty,
-    // percent-of-equity=100 MARKET short that fills from flat at 100% short
-    // margin. Unlike the one-shot close-then-short opening event, this remains
-    // live across partial margin trims and clears when the position lifecycle
-    // ends or a later add changes its shape.
-    bool commissioned_all_in_market_short_lifecycle_ = false;
-    // Position-lifecycle provenance for an omitted-qty,
-    // percent-of-equity=100 MARKET short opened by a direct LONG-to-SHORT
-    // auto-reversal at 100% short margin. It carries no commission or
-    // flat-admission requirement. Broker margin-call reductions preserve the
-    // lifecycle; a script-driven reduction, add, full close, or fresh position
-    // clears it. At a later finite-price floor-zero margin call, this lifecycle
-    // selects the one-contract fallback only when the configured full-residual
-    // interpretation is off.
-    bool default_market_direct_short_reversal_lifecycle_ = false;
-    double opening_affordability_raw_fill_base_ =
-        std::numeric_limits<double>::quiet_NaN();
+    // Owned, consumable post-fill checkpoint. The shared successful-fill
+    // dispatcher supplies its producer and position identities; economic
+    // eligibility is decided there, independently of this lifecycle model.
+    broker::OpeningObligations opening_obligations_;
     int64_t position_entry_time_ = 0;
     // Position is FLAT until the first entry fires; the canonical
     // accessor ``signed_position_size`` already reads as 0 when FLAT
@@ -4384,7 +4339,7 @@ private:
     double account_currency_fx_at(int64_t timestamp_ms) const;
     double active_account_currency_fx() const;
     void settle_position_after_partial_exit(
-        double qty_before, PositionReductionCause cause);
+        PositionReductionCause cause);
     void enter_market_from_flat(const std::string& id, bool is_long,
                                 double fill_price, double explicit_qty,
                                 int explicit_qty_type,
@@ -5209,5 +5164,5 @@ public:
     void trace(const std::string& name, int value)   { trace(name, static_cast<double>(value)); }
 };
 
-} // inline namespace engine_script_run_v1
+} // inline namespace engine_script_run_v2
 } // namespace pineforge

--- a/include/pineforge/pineforge.h
+++ b/include/pineforge/pineforge.h
@@ -641,7 +641,8 @@ PF_API void strategy_stream_order_actions_clear(pf_strategy_t s);
 /** Versioned deterministic fingerprint of observable broker/stream state.
  *  Excludes the consumable queue and arbitrary private strategy members.
  *  This is a replay check, not a complete state snapshot or cryptographic hash.
- *  Fresh replay must use deterministic strategy code and pinned configuration.
+ *  Fresh replay must use deterministic strategy code, the same pinned engine
+ *  build and configuration. Fingerprint representations may change between builds.
  *  Returns 0 for NULL. */
 PF_API uint64_t strategy_stream_state_hash(pf_strategy_t s);
 
@@ -833,7 +834,9 @@ PF_API void strategy_set_broker_state_hash_recording(pf_strategy_t s, int on);
 /** Return the broker-state hash of the FINAL state after the most recent
  *  run() (see #strategy_set_broker_state_hash_recording's doc and
  *  pf_report_t::broker_state_hash for the per-bar recording; this accessor
- *  works whether or not recording was enabled). Returns 0 when @p s is
+ *  works whether or not recording was enabled). Compare only within the same
+ *  pinned engine build and configuration; this is not a serialized checkpoint.
+ *  Returns 0 when @p s is
  *  NULL. */
 PF_API uint64_t strategy_broker_state_hash(pf_strategy_t s);
 /** Number of orders resting in the engine's pending-order book after the

--- a/scripts/broker_state_hash_waivers.txt
+++ b/scripts/broker_state_hash_waivers.txt
@@ -148,3 +148,12 @@ dual_entry_path_              # per-PASS arbitration working state; last_bar_dua
 # by scripts/gen_pending_order_mirror.py, so a new member fails the check
 # until it is decided about.
 pending_order.comment         # trade-report label only: copied into the Trade row's entry/exit comment at fill and never read by any fill, admission, sizing or eligibility path -- it cannot change a future fill
+
+# --- struct PyramidEntry: every field is explicitly folded, zero waivers.
+# entry_comment/max_runup/max_drawdown are exposed through Pine open/closed
+# trade accessors. Entry-bar masks/path/add provenance can affect a later
+# event in the same broker bar and the excursions Pine reads afterward.
+# Commission, slot shadow and opening origin select financial transitions.
+# Do not waive a field merely because it is not a direct fill-price input.
+# Any future exception must be named pyramid_entry.<member> with its lifetime
+# or report-only proof; the recursive checker rejects missing/stale waivers.

--- a/scripts/check_broker_state_hash_coverage.py
+++ b/scripts/check_broker_state_hash_coverage.py
@@ -13,17 +13,27 @@ review): every scalar/string member -- the list is reflected by
 scripts/gen_pending_order_mirror.py's parser, the one source of truth for
 what PendingOrder declares -- must be referenced as ``o.<name>`` inside the
 hash function's ``for (const auto& o : pending_orders_)`` loop or waived as
-``pending_order.<name>  # reason`` in the waivers file."""
+``pending_order.<name>  # reason`` in the waivers file.
+
+Nested physical lots are checked separately: every PyramidEntry member must
+have its type-appropriate f.<fold>(e.<name>) inside the pyramid_entries_ loop,
+or a justified pyramid_entry.<name> waiver. Merely hashing the container name,
+mentioning a member, or hashing it outside its owning loop does not cover it.
+Both member lists use the same fail-closed named-struct parser."""
 from __future__ import annotations
 import re, sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from gen_pending_order_mirror import members as pending_order_members  # noqa: E402
+from gen_pending_order_mirror import members as struct_members  # noqa: E402
 
-PENDING_ORDER_LOOP_RE = re.compile(r"for\s*\(\s*const\s+auto&\s+o\s*:\s*pending_orders_\s*\)\s*\{")
 PENDING_WAIVER_PREFIX = "pending_order."
+PYRAMID_WAIVER_PREFIX = "pyramid_entry."
+PYRAMID_FOLD = {
+    "double": "d", "int": "i", "int64_t": "i", "uint64_t": "u",
+    "bool": "b", "std::string": "s",
+}
 
 MEMBER_RE = re.compile(r"^\s+[\w:<>, ]+?\s+(\w+_)\s*(?:=|;|\{)", re.M)
 # The marker must be the whole (trimmed) line -- not merely a substring, so a
@@ -88,20 +98,21 @@ def _load_waivers(path: Path) -> dict[str, str]:
     return waivers
 
 
-def _pending_order_loop_body(src: str) -> str:
-    """The brace-balanced body of broker_state_hash()'s resting-order loop
-    (comments already stripped). Only an ``o.<name>`` inside THIS loop counts
-    as hashing PendingOrder::<name>."""
-    matches = list(PENDING_ORDER_LOOP_RE.finditer(src))
+def _collection_loop_body(src: str, collection: str, variable: str) -> str:
+    """Brace-balanced body of one owning collection loop, comments stripped."""
+    loop_re = re.compile(
+        rf"for\s*\(\s*const\s+auto&\s+{re.escape(variable)}\s*:\s*"
+        rf"{re.escape(collection)}\s*\)\s*\{{")
+    matches = list(loop_re.finditer(src))
     if not matches:
         print("check_broker_state_hash_coverage: could not find "
-              "`for (const auto& o : pending_orders_) {` in engine_state_hash.cpp",
+              f"`for (const auto& {variable} : {collection}) {{` in engine_state_hash.cpp",
               file=sys.stderr)
         sys.exit(2)
     if len(matches) > 1:
         print("check_broker_state_hash_coverage: found "
-              f"{len(matches)} `for (const auto& o : pending_orders_) {{` loops in "
-              "engine_state_hash.cpp; expected exactly one (the PendingOrder coverage "
+              f"{len(matches)} `for (const auto& {variable} : {collection}) {{` loops in "
+              "engine_state_hash.cpp; expected exactly one (the nested coverage "
               "rule inspects a single loop body)", file=sys.stderr)
         sys.exit(2)
     depth, start = 1, matches[0].end()
@@ -113,22 +124,37 @@ def _pending_order_loop_body(src: str) -> str:
             depth -= 1
             if depth == 0:
                 return src[start:i]
-    print("check_broker_state_hash_coverage: unbalanced pending_orders_ loop", file=sys.stderr)
+    print(f"check_broker_state_hash_coverage: unbalanced {collection} loop", file=sys.stderr)
     sys.exit(2)
 
 
-def main() -> int:
-    hpp = (ROOT / "include/pineforge/engine.hpp").read_text(encoding="utf-8")
+def _pyramid_folded(loop: str, cpp_type: str, member: str) -> bool:
+    fold = PYRAMID_FOLD.get(cpp_type)
+    if fold is None:
+        return False
+    # Require an actual typed serialization call, not a read/assignment or an
+    # unrelated reference in the same source. Existing integer casts are fine.
+    value = rf"e\.{re.escape(member)}"
+    if fold == "i":
+        value = rf"(?:{value}|static_cast<int64_t>\(\s*{value}\s*\))"
+    return re.search(rf"\bf\.{fold}\(\s*{value}\s*\)\s*;", loop) is not None
+
+
+def main(root: Path = ROOT) -> int:
+    hpp = (root / "include/pineforge/engine.hpp").read_text(encoding="utf-8")
     regions = _regions(hpp)
     members = _members(regions)
 
-    src_raw = (ROOT / "src/engine_state_hash.cpp").read_text(encoding="utf-8")
+    src_raw = (root / "src/engine_state_hash.cpp").read_text(encoding="utf-8")
     src = _strip_cpp_comments(src_raw)
 
-    all_waivers = _load_waivers(ROOT / "scripts/broker_state_hash_waivers.txt")
-    waivers = {k: v for k, v in all_waivers.items() if not k.startswith(PENDING_WAIVER_PREFIX)}
+    all_waivers = _load_waivers(root / "scripts/broker_state_hash_waivers.txt")
+    waivers = {k: v for k, v in all_waivers.items()
+               if not k.startswith((PENDING_WAIVER_PREFIX, PYRAMID_WAIVER_PREFIX))}
     po_waivers = {k[len(PENDING_WAIVER_PREFIX):]: v
                   for k, v in all_waivers.items() if k.startswith(PENDING_WAIVER_PREFIX)}
+    pe_waivers = {k[len(PYRAMID_WAIVER_PREFIX):]: v
+                  for k, v in all_waivers.items() if k.startswith(PYRAMID_WAIVER_PREFIX)}
 
     orphans = sorted(w for w in waivers if w not in members)
     if orphans:
@@ -145,13 +171,13 @@ def main() -> int:
         return 1
 
     # --- struct PendingOrder: every scalar/string member, o.<name> in the loop ---
-    po_members = [n for _t, n in pending_order_members(hpp)]
+    po_members = [n for _t, n in struct_members(hpp)]
     po_orphans = sorted(w for w in po_waivers if w not in po_members)
     if po_orphans:
         print("check_broker_state_hash_coverage: pending_order.* waiver(s) naming a "
               f"member not in struct PendingOrder: {po_orphans}", file=sys.stderr)
         return 1
-    loop = _pending_order_loop_body(src)
+    loop = _collection_loop_body(src, "pending_orders_", "o")
     po_missing = sorted(
         m for m in po_members
         if not re.search(rf"\bo\.{re.escape(m)}\b", loop) and m not in po_waivers
@@ -161,9 +187,27 @@ def main() -> int:
               "(o.<name> in the pending_orders_ loop) nor waived (pending_order.<name>):",
               po_missing)
         return 1
+    # --- struct PyramidEntry: inspect every physical-lot field recursively ---
+    pe_members = struct_members(hpp, "PyramidEntry")
+    pe_orphans = sorted(set(pe_waivers) - {n for _t, n in pe_members})
+    if pe_orphans:
+        print("check_broker_state_hash_coverage: pyramid_entry.* waiver(s) naming a "
+              f"member not in struct PyramidEntry: {pe_orphans}", file=sys.stderr)
+        return 1
+    pe_loop = _collection_loop_body(src, "pyramid_entries_", "e")
+    pe_missing = sorted(n for t, n in pe_members
+                        if n not in pe_waivers and not _pyramid_folded(pe_loop, t, n))
+    pe_redundant = sorted(n for t, n in pe_members
+                          if n in pe_waivers and _pyramid_folded(pe_loop, t, n))
+    if pe_missing or pe_redundant:
+        print("check_broker_state_hash_coverage: PyramidEntry requires one typed fold "
+              "inside its loop or a justified pyramid_entry.* waiver; "
+              f"missing={pe_missing}, redundant_waivers={pe_redundant}")
+        return 1
     print(f"check_broker_state_hash_coverage: {len(members)} members in {len(regions)} "
           f"region(s), {len(waivers)} waived, OK; PendingOrder {len(po_members)} members, "
-          f"{len(po_waivers)} waived, OK")
+          f"{len(po_waivers)} waived, OK; PyramidEntry {len(pe_members)} members, "
+          f"{len(pe_waivers)} waived, OK")
     return 0
 
 

--- a/scripts/check_broker_state_hash_coverage.py
+++ b/scripts/check_broker_state_hash_coverage.py
@@ -27,6 +27,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from gen_pending_order_mirror import members as struct_members  # noqa: E402
+from gen_pending_order_mirror import struct_body  # noqa: E402
 
 PENDING_WAIVER_PREFIX = "pending_order."
 PYRAMID_WAIVER_PREFIX = "pyramid_entry."
@@ -140,6 +141,109 @@ def _pyramid_folded(loop: str, cpp_type: str, member: str) -> bool:
     return re.search(rf"\bf\.{fold}\(\s*{value}\s*\)\s*;", loop) is not None
 
 
+def _one_braced_body(src: str, pattern: str, label: str) -> str:
+    matches = list(re.finditer(pattern, src))
+    if len(matches) != 1:
+        raise ValueError(f"{label}: expected exactly one body, got {len(matches)}")
+    start = matches[0].end()
+    depth = 1
+    for i in range(start, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start:i]
+    raise ValueError(f"{label}: unbalanced body")
+
+
+def _class_fields(src: str, name: str) -> dict[str, str]:
+    """Classify the small value classes; refuse unfamiliar declaration shapes.
+
+    Inline method/nested-type bodies are skipped by balanced braces. Every
+    remaining data declaration must be one TYPE NAME; adding a new field is
+    visible even when its name has no trailing underscore.
+    """
+    body = _one_braced_body(src, rf"\bclass\s+{name}\s*\{{", name)
+    fields = {}
+    statement = ""
+    i = 0
+    while i < len(body):
+        ch = body[i]
+        if ch == "{":
+            prefix = statement.strip()
+            nested = re.match(r"(?:struct|class)\s+\w+$", prefix)
+            method = "(" in prefix and "=" not in prefix.split("(", 1)[0]
+            if not nested and not method:
+                raise ValueError(f"{name}: unclassified braced declaration {prefix!r}")
+            depth = 1
+            i += 1
+            while i < len(body) and depth:
+                depth += (body[i] == "{") - (body[i] == "}")
+                i += 1
+            if depth:
+                raise ValueError(f"{name}: unbalanced member body")
+            statement = ""
+            continue
+        if ch == ";":
+            decl = " ".join(statement.split())
+            statement = ""
+            if decl and not decl.startswith("using "):
+                match = re.fullmatch(r"([\w:<>]+)\s+(\w+)(?:\s*=\s*[^,]+)?", decl)
+                if not match or match[2] in fields:
+                    raise ValueError(f"{name}: unclassified data declaration {decl!r}")
+                fields[match[2]] = match[1]
+        else:
+            statement += ch
+            if statement.strip() in ("public:", "private:", "protected:"):
+                statement = ""
+        i += 1
+    if statement.strip():
+        raise ValueError(f"{name}: unterminated declaration")
+    return fields
+
+
+def _opening_coverage(events: str, src: str) -> None:
+    """No waiver: the opening model has only causal state, all explicitly folded."""
+    events = _strip_cpp_comments(events)
+    owner_members = struct_members(events, "OpeningOwner")
+    if _class_fields(events, "OpeningReceipt") != {
+            "owner_": "OpeningOwner", "raw_fill_base_": "double", "decision_": "Decision"}:
+        raise ValueError("OpeningReceipt fields changed; classify every field in the hash contract")
+    if _class_fields(events, "OpeningObligations") != {
+            "pending_": "std::optional<OpeningReceipt>"}:
+        raise ValueError("OpeningObligations fields changed; classify every field in the hash contract")
+    if struct_members(events, "Check") != [("OpeningContinuation", "continuation")]:
+        raise ValueError("OpeningReceipt Check fields changed; update the hash contract")
+    if struct_body(events, "Exempt").strip():
+        raise ValueError("OpeningReceipt Exempt gained state; update the hash contract")
+    if not re.search(r"using\s+Decision\s*=\s*std::variant<Check,\s*Exempt>\s*;", events):
+        raise ValueError("OpeningReceipt Decision alternatives changed; update the hash contract")
+    for enum, expected in [("OpeningDecision", ["Check", "Exempt"]),
+                           ("OpeningContinuation", ["None", "RemainingAdversePath"])]:
+        body = _one_braced_body(events, rf"enum\s+class\s+{enum}\s*\{{", enum)
+        if [x.strip() for x in body.split(",")] != expected:
+            raise ValueError(f"{enum} alternatives changed; update the hash encoding")
+
+    body = _one_braced_body(src,
+        r"if\s*\(const auto& receipt = opening_obligations_\.peek\(\)\)\s*\{",
+        "opening receipt hash")
+    if "{" in body or "}" in body or re.search(r"\b(?:if|switch|for|while)\s*\(", body):
+        raise ValueError("opening receipt folds must cover Check and Exempt unconditionally")
+    for cpp_type, member in owner_members:
+        fold = PYRAMID_FOLD.get(cpp_type)
+        if not fold or not re.search(rf"\bf\.{fold}\(owner\.{member}\);", body):
+            raise ValueError(f"OpeningOwner.{member} missing its typed fold in the receipt body")
+    required = [r"f\.i\(static_cast<int64_t>\(receipt->decision\(\)\)\);",
+                r"f\.b\(receipt->requires_adverse_pass\(\)\);",
+                r"f\.d\(receipt->raw_fill_base\(\)\);",
+                r"const auto& owner = receipt->owner\(\);" ]
+    if not all(re.search(pattern, body) for pattern in required):
+        raise ValueError("opening receipt is missing decision/continuation/raw/owner binding")
+    if not re.search(r"f\.b\(opening_obligations_\.pending\(\)\);\s*if", src):
+        raise ValueError("opening receipt presence fold must precede its body")
+
+
 def main(root: Path = ROOT) -> int:
     hpp = (root / "include/pineforge/engine.hpp").read_text(encoding="utf-8")
     regions = _regions(hpp)
@@ -147,6 +251,11 @@ def main(root: Path = ROOT) -> int:
 
     src_raw = (root / "src/engine_state_hash.cpp").read_text(encoding="utf-8")
     src = _strip_cpp_comments(src_raw)
+    try:
+        _opening_coverage((root / "include/pineforge/broker_events.hpp").read_text(), src)
+    except (ValueError, OSError) as exc:
+        print(f"check_broker_state_hash_coverage: {exc}", file=sys.stderr)
+        return 1
 
     all_waivers = _load_waivers(root / "scripts/broker_state_hash_waivers.txt")
     waivers = {k: v for k, v in all_waivers.items()

--- a/scripts/gen_pending_order_mirror.py
+++ b/scripts/gen_pending_order_mirror.py
@@ -97,15 +97,15 @@ def struct_body(text: str, name: str = STRUCT_NAME) -> str:
     _fail(f"struct {name}: unbalanced braces")
 
 
-def members(text: str | None = None) -> list[tuple[str, str]]:
-    """Return [(cpp_type, name)] for every data member of PendingOrder, in
+def members(text: str | None = None, name: str = STRUCT_NAME) -> list[tuple[str, str]]:
+    """Return [(cpp_type, name)] for every data member of the named struct, in
     declaration order. Comments are stripped and multi-line declarations
     (a member whose initialiser wraps onto the next line) are joined before
     parsing. Any declaration that is not exactly ``TYPE NAME [= init];``
     aborts."""
     if text is None:
         text = HPP.read_text(encoding="utf-8")
-    body = struct_body(text)   # already comment-stripped
+    body = struct_body(text, name)   # already comment-stripped
     out: list[tuple[str, str]] = []
     seen: set[str] = set()
     for raw in body.split(";"):
@@ -114,7 +114,7 @@ def members(text: str | None = None) -> list[tuple[str, str]]:
             continue
         m = DECL_RE.match(decl)
         if not m:
-            _fail(f"cannot classify declaration in struct {STRUCT_NAME}: {decl!r} "
+            _fail(f"cannot classify declaration in struct {name}: {decl!r} "
                   "(expected exactly `TYPE NAME [= init];`; split multi-name "
                   "declarations, and mirror-waive methods/templates explicitly)")
         t, n = m.group(1), m.group(2)
@@ -123,7 +123,7 @@ def members(text: str | None = None) -> list[tuple[str, str]]:
         seen.add(n)
         out.append((t, n))
     if not out:
-        _fail(f"struct {STRUCT_NAME} has no members?")
+        _fail(f"struct {name} has no members?")
     return out
 
 

--- a/scripts/gen_pending_order_mirror.py
+++ b/scripts/gen_pending_order_mirror.py
@@ -113,7 +113,7 @@ def members(text: str | None = None, name: str = STRUCT_NAME) -> list[tuple[str,
         if not decl:
             continue
         m = DECL_RE.match(decl)
-        if not m:
+        if not m or "," in decl:
             _fail(f"cannot classify declaration in struct {name}: {decl!r} "
                   "(expected exactly `TYPE NAME [= init];`; split multi-name "
                   "declarations, and mirror-waive methods/templates explicitly)")

--- a/scripts/test_broker_state_hash_coverage.py
+++ b/scripts/test_broker_state_hash_coverage.py
@@ -15,16 +15,18 @@ from gen_pending_order_mirror import members
 
 ROOT = Path(__file__).resolve().parents[1]
 HEADER = (ROOT / "include/pineforge/engine.hpp").read_text()
+EVENTS = (ROOT / "include/pineforge/broker_events.hpp").read_text()
 SOURCE = (ROOT / "src/engine_state_hash.cpp").read_text()
 WAIVERS = (ROOT / "scripts/broker_state_hash_waivers.txt").read_text()
 
 
 class PhysicalLotCoverage(unittest.TestCase):
-    def check(self, header=HEADER, source=SOURCE, waivers=WAIVERS):
+    def check(self, header=HEADER, source=SOURCE, waivers=WAIVERS, events=EVENTS):
         with tempfile.TemporaryDirectory(prefix="pf-lot-hash-check-") as temp:
             root = Path(temp)
             for name, content in [
                 ("include/pineforge/engine.hpp", header),
+                ("include/pineforge/broker_events.hpp", events),
                 ("src/engine_state_hash.cpp", source),
                 ("scripts/broker_state_hash_waivers.txt", waivers),
             ]:
@@ -93,7 +95,8 @@ class PhysicalLotCoverage(unittest.TestCase):
         self.assertEqual(self.check(waivers=WAIVERS + "\npyramid_entry.market_pyramid_add #\n")[0], 1)
 
     def test_unclassified_nested_declaration_refuses(self):
-        for declaration in ["double first, second;", "std::vector<double> state;", "double value() const;"]:
+        for declaration in ["double first, second;", "double first = 0, second = 0;",
+                            "std::vector<double> state;", "double value() const;"]:
             with self.subTest(declaration=declaration):
                 header = HEADER.replace("struct PyramidEntry {", "struct PyramidEntry {\n    " + declaration)
                 self.assertNotEqual(self.check(header=header)[0], 0)
@@ -104,6 +107,44 @@ class PhysicalLotCoverage(unittest.TestCase):
         code, output = self.check(source=source)
         self.assertEqual(code, 1, output)
         self.assertIn("stop_price", output)
+
+    def test_every_opening_owner_field_requires_its_own_fold(self):
+        for _type, name in members(EVENTS, "OpeningOwner"):
+            with self.subTest(member=name):
+                source = SOURCE.replace(f"owner.{name}", f"owner.missing_{name}")
+                code, output = self.check(source=source)
+                self.assertEqual(code, 1, output)
+                self.assertIn(name, output)
+        events = EVENTS.replace("struct OpeningOwner {", "struct OpeningOwner {\n int64_t extra;")
+        code, output = self.check(events=events)
+        self.assertEqual(code, 1, output)
+        self.assertIn("extra", output)
+
+    def test_new_receipt_state_or_decision_alternative_requires_review(self):
+        mutations = [
+            ("OpeningOwner owner_;", "OpeningOwner owner_;\n double extra;"),
+            ("std::optional<OpeningReceipt> pending_;", "std::optional<OpeningReceipt> pending_;\n bool extra_ = false;"),
+            ("struct Check {", "struct Check { double extra;"),
+            ("struct Exempt {}", "struct Exempt { double extra; }"),
+            ("std::variant<Check, Exempt>", "std::variant<Check, Exempt, int>"),
+            ("OpeningDecision { Check, Exempt }", "OpeningDecision { Check, Exempt, Extra }"),
+            ("OpeningContinuation { None, RemainingAdversePath }", "OpeningContinuation { None, RemainingAdversePath, Extra }"),
+        ]
+        for before, after in mutations:
+            with self.subTest(mutation=after):
+                self.assertIn(before, EVENTS)
+                self.assertNotEqual(self.check(events=EVENTS.replace(before, after))[0], 0)
+
+    def test_opening_receipt_folds_are_unconditional_and_owned(self):
+        fold = "f.d(receipt->raw_fill_base());"
+        for replacement in ["// " + fold, "const auto ignored = receipt->raw_fill_base();",
+                            "f.u(receipt->raw_fill_base());",
+                            "if (receipt->decision() == broker::OpeningDecision::Check) " + fold]:
+            with self.subTest(replacement=replacement):
+                self.assertEqual(self.check(source=SOURCE.replace(fold, replacement))[0], 1)
+        self.assertEqual(self.check(source=SOURCE.replace(fold, "") + "\n" + fold)[0], 1)
+        self.assertEqual(self.check(source=SOURCE.replace("f.b(opening_obligations_.pending());", ""))[0], 1)
+        self.assertEqual(self.check(source=SOURCE.replace("f.b(receipt->requires_adverse_pass());", ""))[0], 1)
 
 
 if __name__ == "__main__":

--- a/scripts/test_broker_state_hash_coverage.py
+++ b/scripts/test_broker_state_hash_coverage.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Metadata-only mutation tests for nested physical-lot hash coverage.
+
+Every mutation is written under TemporaryDirectory; engine source is read only.
+No compile, engine execution, strategy, corpus, feed or grader is involved.
+"""
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+import tempfile
+import unittest
+
+import check_broker_state_hash_coverage as checker
+from gen_pending_order_mirror import members
+
+ROOT = Path(__file__).resolve().parents[1]
+HEADER = (ROOT / "include/pineforge/engine.hpp").read_text()
+SOURCE = (ROOT / "src/engine_state_hash.cpp").read_text()
+WAIVERS = (ROOT / "scripts/broker_state_hash_waivers.txt").read_text()
+
+
+class PhysicalLotCoverage(unittest.TestCase):
+    def check(self, header=HEADER, source=SOURCE, waivers=WAIVERS):
+        with tempfile.TemporaryDirectory(prefix="pf-lot-hash-check-") as temp:
+            root = Path(temp)
+            for name, content in [
+                ("include/pineforge/engine.hpp", header),
+                ("src/engine_state_hash.cpp", source),
+                ("scripts/broker_state_hash_waivers.txt", waivers),
+            ]:
+                target = root / name
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(content)
+            output = StringIO()
+            with redirect_stdout(output), redirect_stderr(output):
+                try:
+                    code = checker.main(root)
+                except SystemExit as exc:
+                    code = exc.code if isinstance(exc.code, int) else 2
+                    output.write(str(exc.code))
+            return code, output.getvalue()
+
+    def test_actual_source_and_named_parser(self):
+        self.assertEqual(self.check()[0], 0)
+        self.assertEqual(len(members(HEADER, "PyramidEntry")), 18)
+        self.assertEqual(members(HEADER), members(HEADER, "PendingOrder"))
+
+    def test_each_lot_field_requires_its_own_fold(self):
+        # A correct container loop is insufficient if any child is omitted.
+        start = SOURCE.index("for (const auto& e : pyramid_entries_) {")
+        end = SOURCE.index("\n    }", start)
+        loop = SOURCE[start:end]
+        for _type, name in members(HEADER, "PyramidEntry"):
+            with self.subTest(member=name):
+                altered = loop.replace(f"e.{name}", f"e.missing_{name}")
+                code, output = self.check(source=SOURCE[:start] + altered + SOURCE[end:])
+                self.assertEqual(code, 1, output)
+                self.assertIn(name, output)
+
+    def test_new_field_refuses_until_explicit_decision(self):
+        header = HEADER.replace("struct PyramidEntry {", "struct PyramidEntry {\n    double future_margin_basis = 0;")
+        code, output = self.check(header=header)
+        self.assertEqual(code, 1, output)
+        self.assertIn("future_margin_basis", output)
+
+    def test_comments_reads_wrong_types_and_external_folds_do_not_cover(self):
+        fold = "f.d(e.entry_commission_account);"
+        for replacement in [
+            "// " + fold,
+            "const double ignored = e.entry_commission_account;",
+            "f.u(e.entry_commission_account);",
+        ]:
+            with self.subTest(replacement=replacement):
+                self.assertEqual(self.check(source=SOURCE.replace(fold, replacement))[0], 1)
+        source = SOURCE.replace(fold, "") + "\nvoid unrelated() { f.d(e.entry_commission_account); }\n"
+        self.assertEqual(self.check(source=source)[0], 1)
+
+    def test_missing_duplicate_or_unbalanced_owner_loop_refuses(self):
+        opening = "for (const auto& e : pyramid_entries_) {"
+        self.assertEqual(self.check(source=SOURCE.replace(opening, "if (false) {"))[0], 2)
+        self.assertEqual(self.check(source=SOURCE + "\n" + opening + "}\n")[0], 2)
+        output = StringIO()
+        with redirect_stderr(output), self.assertRaises(SystemExit) as stopped:
+            checker._collection_loop_body(opening, "pyramid_entries_", "e")
+        self.assertEqual(stopped.exception.code, 2)
+
+    def test_explicit_waiver_is_checked_and_cannot_hide_typos(self):
+        source = SOURCE.replace("f.b(e.market_pyramid_add);", "")
+        waiver = "\npyramid_entry.market_pyramid_add # test-only lifecycle decision\n"
+        self.assertEqual(self.check(source=source, waivers=WAIVERS + waiver)[0], 0)
+        self.assertEqual(self.check(waivers=WAIVERS + waiver)[0], 1)  # now redundant
+        self.assertEqual(self.check(waivers=WAIVERS + "\npyramid_entry.typo # no such field\n")[0], 1)
+        self.assertEqual(self.check(waivers=WAIVERS + "\npyramid_entry.market_pyramid_add #\n")[0], 1)
+
+    def test_unclassified_nested_declaration_refuses(self):
+        for declaration in ["double first, second;", "std::vector<double> state;", "double value() const;"]:
+            with self.subTest(declaration=declaration):
+                header = HEADER.replace("struct PyramidEntry {", "struct PyramidEntry {\n    " + declaration)
+                self.assertNotEqual(self.check(header=header)[0], 0)
+
+    def test_pending_order_coverage_still_refuses_omission(self):
+        source = SOURCE.replace("f.d(o.stop_price);", "")
+        self.assertNotEqual(source, SOURCE)
+        code, output = self.check(source=source)
+        self.assertEqual(code, 1, output)
+        self.assertIn("stop_price", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -703,7 +703,7 @@ BacktestEngine::CoofFillResult BacktestEngine::process_next_pending_order(
                 || max_intraday_filled_orders_ > 0
                 || risk_max_intraday_loss_ != 0 || risk_max_drawdown_ != 0
                 || risk_max_cons_loss_days_ > 0
-                || margin_long_ != 100 || opening_affordability_pending_
+                || margin_long_ != 100 || opening_obligations_.pending()
                 || !(bar.close < bar.open)) return false;
             const std::string& entry_id = pyramid_entries_.front().entry_id;
             double reserved = 0;
@@ -1357,19 +1357,15 @@ void BacktestEngine::process_margin_call(const Bar& bar) {
     // Consume first, including on disabled/degenerate paths. This is an event
     // attached to the just-completed fill cycle, never durable per-position
     // state that a later bar may reconstruct or reuse.
-    const bool opening_event_pending = opening_affordability_pending_;
-    const bool opening_event_eligible = opening_affordability_eligible_;
-    const bool opening_event_default_short_reversal =
-        close_then_short_opening_requires_adverse_retry_;
-    const double opening_event_raw_fill_base =
-        opening_affordability_raw_fill_base_;
-    opening_affordability_pending_ = false;
-    opening_affordability_eligible_ = false;
-    commissioned_all_in_market_long_opening_affordability_ = false;
-    opening_affordability_default_long_reversal_ = false;
-    close_then_short_opening_requires_adverse_retry_ = false;
-    opening_affordability_raw_fill_base_ =
-        std::numeric_limits<double>::quiet_NaN();
+    const auto opening_event = opening_obligations_.take(position_cycle_seq_);
+    const bool opening_event_pending = opening_event.has_value();
+    const bool opening_event_eligible = opening_event
+        && opening_event->decision() == broker::OpeningDecision::Check;
+    const bool opening_event_default_short_reversal = opening_event
+        && opening_event->requires_adverse_pass();
+    const double opening_event_raw_fill_base = opening_event
+        ? opening_event->raw_fill_base()
+        : std::numeric_limits<double>::quiet_NaN();
 
     if (!margin_call_enabled_) return;
     if (position_side_ == PositionSide::FLAT) return;
@@ -1999,7 +1995,7 @@ bool BacktestEngine::tv_money_long_margin_call(const Bar& bar,
         if (!carried_pooc_pre_close || position_open_bar_ < 0
             || position_open_bar_ >= bar_index_
             || (!pending_orders_.empty() && !before_trail_exit)
-            || opening_affordability_pending_
+            || opening_obligations_.pending()
             || (pyramiding_ != 0 && !slipped_pooc_open && !before_trail_exit)
             || position_entry_count_ != 1 || pyramid_entries_.size() != 1
             || pyramid_entries_.front().entry_bar_index >= bar_index_
@@ -2550,10 +2546,13 @@ bool BacktestEngine::margin_call_1x_long_opening_slice_before_priced_exit(
     // chronology; the opening check keeps its end-of-bar placement there.
     if (process_orders_on_close_) return false;
     // The one-shot event queued by this bar's successful opening/add fill.
-    if (!opening_affordability_pending_ || !opening_affordability_eligible_) {
+    const auto opening_event = opening_obligations_.peek();
+    if (!opening_event
+        || opening_event->owner().positionCycle != position_cycle_seq_
+        || opening_event->decision() != broker::OpeningDecision::Check) {
         return false;
     }
-    const double raw_fill_base = opening_affordability_raw_fill_base_;
+    const double raw_fill_base = opening_event->raw_fill_base();
     if (!std::isfinite(raw_fill_base) || !(raw_fill_base > 0.0)) return false;
 
     const double pv = syminfo_.pointvalue;
@@ -2669,13 +2668,7 @@ bool BacktestEngine::margin_call_1x_long_opening_slice_before_priced_exit(
     intrabar_exit_margin_call_bar_ = bar_index_;
     // The one-shot event is consumed by this chronological slice; the
     // end-of-bar process_margin_call must not replay it.
-    opening_affordability_pending_ = false;
-    opening_affordability_eligible_ = false;
-    commissioned_all_in_market_long_opening_affordability_ = false;
-    opening_affordability_default_long_reversal_ = false;
-    close_then_short_opening_requires_adverse_retry_ = false;
-    opening_affordability_raw_fill_base_ =
-        std::numeric_limits<double>::quiet_NaN();
+    opening_obligations_.consume(opening_event->owner());
     return true;
 }
 
@@ -6775,68 +6768,6 @@ void BacktestEngine::apply_filled_order_to_state(
             && order.created_bar < bar_index_
             && order.oca_name.empty()
             && order.oca_type == 0;
-        const bool default_market_long_close_then_open_after_fill =
-            successful_fresh_open
-            && position_side_before_fill == PositionSide::FLAT
-            && position_side_ == PositionSide::LONG
-            && order.type == OrderType::MARKET
-            && order.is_long
-            && std::isnan(order.qty)
-            && order.created_position_side == PositionSide::SHORT
-            && order.created_after_position_close_in_bar
-            && std::abs(order.tv_carry_qty) <= kQtyEpsilon
-            && admitted_flat_on_frozen_sizing_price
-            && default_qty_type_ == QtyType::PERCENT_OF_EQUITY
-            && std::abs(default_qty_value_ - 100.0) < 1e-12
-            && std::isfinite(margin_long_)
-            && std::abs(margin_long_ / 100.0 - 1.0) < 1e-12
-            && commission_type_ == CommissionType::PERCENT
-            && std::isfinite(commission_value_)
-            && commission_value_ > 0.0
-            && std::isfinite(new_opening_commission)
-            && new_opening_commission > 0.0
-            && std::isfinite(order.frozen_default_qty)
-            && order.frozen_default_qty > kQtyEpsilon
-            && std::isfinite(order.sizing_equity)
-            && order.sizing_equity > 0.0
-            && std::isfinite(order.sizing_price)
-            && order.sizing_price > 0.0
-            && std::isfinite(order.sizing_mark)
-            && order.sizing_mark > 0.0
-            && std::isfinite(order.sizing_fx)
-            && order.sizing_fx > 0.0
-            && slippage_ == 0
-            && !process_orders_on_close_
-            && !calc_on_order_fills_
-            && !bar_magnifier_enabled_
-            && !stream_warmup_mode_
-            && stream_phase_ == StreamPhase::IDLE
-            && !order.created_during_coof_recalc
-            && order.created_bar < bar_index_
-            && order.oca_name.empty()
-            && order.oca_type == 0;
-        // The lifecycle tag keeps its commissioned meaning (no reader
-        // today; test_margin_call pins the zero-fee flat short untagged).
-        const bool commissioned_opening_fee =
-            commission_type_ == CommissionType::PERCENT
-            && std::isfinite(commission_value_)
-            && commission_value_ > 0.0
-            && std::isfinite(new_opening_commission)
-            && new_opening_commission > 0.0;
-        if (successful_fresh_open) {
-            commissioned_all_in_market_short_lifecycle_ =
-                (default_market_short_close_then_open_after_fill
-                 || default_market_flat_short_after_fill)
-                && commissioned_opening_fee;
-            default_market_direct_short_reversal_lifecycle_ =
-                default_market_direct_short_reversal_after_fill;
-        } else if (accepted_additional_entry) {
-            // A later add changes the exact position lifecycle whose TV
-            // zero-cover behavior is pinned by the source tape. Fail closed
-            // rather than lending the original provenance to the new shape.
-            commissioned_all_in_market_short_lifecycle_ = false;
-            default_market_direct_short_reversal_lifecycle_ = false;
-        }
         const bool positive_raw_base =
             std::isfinite(fill_price) && fill_price > 0.0;
         const bool successful_short_open_or_add =
@@ -6858,13 +6789,7 @@ void BacktestEngine::apply_filled_order_to_state(
              || default_market_direct_short_reversal_after_fill)
             && positive_raw_base;
         if (successful_short_open_or_add && !scoped_short_opening_fill) {
-            opening_affordability_pending_ = false;
-            opening_affordability_eligible_ = false;
-            commissioned_all_in_market_long_opening_affordability_ = false;
-            opening_affordability_default_long_reversal_ = false;
-            close_then_short_opening_requires_adverse_retry_ = false;
-            opening_affordability_raw_fill_base_ =
-                std::numeric_limits<double>::quiet_NaN();
+            opening_obligations_.invalidate();
         }
         if ((long_full_margin_after_fill
              || explicit_market_short_full_margin_after_fill
@@ -6905,51 +6830,21 @@ void BacktestEngine::apply_filled_order_to_state(
                 && std::isfinite(new_opening_commission)
                 && new_opening_commission == 0.0;
 
-            opening_affordability_pending_ = true;
-            opening_affordability_eligible_ =
-                accepted_additional_entry
-                || !frozen_all_in_true_flat_exemption;
-            commissioned_all_in_market_long_opening_affordability_ =
-                (successful_fresh_open
-                 && order.opening_affordability_exemption_candidate
-                 && order.type == OrderType::MARKET
-                 && order.is_long
-                 && std::isnan(order.qty)
-                 && order.created_position_side == PositionSide::FLAT
-                 && !order.created_after_position_close_in_bar
-                 && position_side_before_fill == PositionSide::FLAT
-                 && admitted_flat_on_frozen_sizing_price
-                 && commission_type_ == CommissionType::PERCENT
-                 && commission_value_ > 0.0
-                 && std::isfinite(new_opening_commission)
-                 && new_opening_commission > 0.0)
-                || (default_market_long_close_then_open_after_fill
-                    && std::isfinite(new_opening_commission)
-                    && new_opening_commission > 0.0);
-            opening_affordability_default_long_reversal_ =
-                successful_fresh_open
-                && position_side_before_fill == PositionSide::SHORT
-                && order.created_position_side == PositionSide::SHORT
-                && !order.created_after_position_close_in_bar
-                && order.type == OrderType::MARKET
-                && order.is_long
-                && std::isnan(order.qty)
-                && default_qty_type_ == QtyType::PERCENT_OF_EQUITY
-                && std::abs(default_qty_value_ - 100.0) < 1e-12
-                && std::isfinite(order.frozen_default_qty)
-                && order.frozen_default_qty > kQtyEpsilon
-                && std::isfinite(order.sizing_equity)
-                && order.sizing_equity > 0.0
-                && std::isfinite(order.sizing_price)
-                && order.sizing_price > 0.0
-                && std::isfinite(order.sizing_fx)
-                && order.sizing_fx > 0.0
-                && std::isfinite(new_opening_commission)
-                && new_opening_commission == 0.0;
-            close_then_short_opening_requires_adverse_retry_ =
+            const broker::OpeningOwner owner{
+                position_cycle_seq_, broker_fill_event_seq_, order.incarnation,
+                bar_index_, current_bar_.timestamp};
+            const auto continuation =
                 default_market_short_close_then_open_after_fill
-                || default_market_direct_short_reversal_after_fill;
-            opening_affordability_raw_fill_base_ = fill_price;
+                || default_market_direct_short_reversal_after_fill
+                    ? broker::OpeningContinuation::RemainingAdversePath
+                    : broker::OpeningContinuation::None;
+            if (accepted_additional_entry || !frozen_all_in_true_flat_exemption) {
+                opening_obligations_.replace(
+                    broker::OpeningReceipt::check(owner, fill_price, continuation));
+            } else {
+                opening_obligations_.replace(
+                    broker::OpeningReceipt::exempt(owner, fill_price));
+            }
         }
     }
 
@@ -8025,15 +7920,7 @@ void BacktestEngine::apply_raw_order_fill(PendingOrder& order, double fill_price
         // The shared post-dispatch hook queues the new fill's event. Clear any
         // prior-cycle provenance first; RAW_ORDER opens do not route through
         // open_fresh_position.
-        opening_affordability_pending_ = false;
-        opening_affordability_eligible_ = false;
-        commissioned_all_in_market_long_opening_affordability_ = false;
-        opening_affordability_default_long_reversal_ = false;
-        close_then_short_opening_requires_adverse_retry_ = false;
-        commissioned_all_in_market_short_lifecycle_ = false;
-        default_market_direct_short_reversal_lifecycle_ = false;
-        opening_affordability_raw_fill_base_ =
-            std::numeric_limits<double>::quiet_NaN();
+        opening_obligations_.invalidate();
         position_entry_time_ = current_bar_.timestamp;
         position_qty_ = qty;
         position_entry_count_ = 1;

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -339,7 +339,6 @@ double BacktestEngine::fifo_drain(const std::string* from_entry, double qty_limi
 void BacktestEngine::execute_partial_exit_qty(
         double fill_price, double qty_to_close, PositionReductionCause cause) {
     if (position_side_ == PositionSide::FLAT || pyramid_entries_.empty()) return;
-    const double qty_before = position_qty_;
     qty_to_close = std::clamp(qty_to_close, 0.0, position_qty_);
     if (qty_to_close <= kQtyEpsilon) return;
 
@@ -349,7 +348,7 @@ void BacktestEngine::execute_partial_exit_qty(
 
     // Close FIFO across all pyramid entries, creating trade records.
     fifo_drain(/*from_entry=*/nullptr, qty_to_close, fill_price, was_long);
-    settle_position_after_partial_exit(qty_before, cause);
+    settle_position_after_partial_exit(cause);
 }
 
 
@@ -376,7 +375,6 @@ void BacktestEngine::execute_partial_exit_by_entry(double fill_price,
                                                    const std::string& from_entry,
                                                    PositionReductionCause cause) {
     if (position_side_ == PositionSide::FLAT || pyramid_entries_.empty()) return;
-    const double qty_before = position_qty_;
 
     bool is_buy = (position_side_ == PositionSide::SHORT);
     fill_price = apply_fill_slippage(fill_price, is_buy);
@@ -393,7 +391,7 @@ void BacktestEngine::execute_partial_exit_by_entry(double fill_price,
     }
 
     pyramid_entries_ = std::move(remaining);
-    settle_position_after_partial_exit(qty_before, cause);
+    settle_position_after_partial_exit(cause);
 }
 
 
@@ -406,14 +404,13 @@ void BacktestEngine::execute_partial_exit_by_entry_qty(
         PositionReductionCause cause) {
     if (position_side_ == PositionSide::FLAT || pyramid_entries_.empty()) return;
     if (!std::isfinite(qty_to_close) || qty_to_close <= kQtyEpsilon) return;
-    const double qty_before = position_qty_;
 
     bool is_buy = (position_side_ == PositionSide::SHORT);
     fill_price = apply_fill_slippage(fill_price, is_buy);
     bool was_long = (position_side_ == PositionSide::LONG);
 
     fifo_drain(&from_entry, qty_to_close, fill_price, was_long);
-    settle_position_after_partial_exit(qty_before, cause);
+    settle_position_after_partial_exit(cause);
 }
 
 
@@ -463,7 +460,6 @@ double BacktestEngine::cover_samebar_market_adds_on_exit(const PendingOrder& ord
         || !std::isnan(order.trail_price);
     if (!priced_bracket) return 0.0;
 
-    const double qty_before = position_qty_;
     bool is_buy = (position_side_ == PositionSide::SHORT);
     double slipped = apply_fill_slippage(fill_price, is_buy);
     bool was_long = (position_side_ == PositionSide::LONG);
@@ -484,7 +480,7 @@ double BacktestEngine::cover_samebar_market_adds_on_exit(const PendingOrder& ord
     if (closed <= kQtyEpsilon) return 0.0;   // nothing covered
     pyramid_entries_ = std::move(remaining);
     position_qty_ -= closed;
-    settle_position_after_partial_exit(qty_before, cause);
+    settle_position_after_partial_exit(cause);
     return closed;
 }
 
@@ -742,15 +738,7 @@ void BacktestEngine::reset_position_state_to_flat() {
     position_side_ = PositionSide::FLAT;
     position_cycle_seq_ = 0;
     position_entry_price_ = 0.0;
-    opening_affordability_pending_ = false;
-    opening_affordability_eligible_ = false;
-    commissioned_all_in_market_long_opening_affordability_ = false;
-    opening_affordability_default_long_reversal_ = false;
-    close_then_short_opening_requires_adverse_retry_ = false;
-    commissioned_all_in_market_short_lifecycle_ = false;
-    default_market_direct_short_reversal_lifecycle_ = false;
-    opening_affordability_raw_fill_base_ =
-        std::numeric_limits<double>::quiet_NaN();
+    opening_obligations_.invalidate();
     position_entry_time_ = 0;
     position_qty_ = 0.0;
     position_entry_count_ = 0;
@@ -777,7 +765,7 @@ void BacktestEngine::reset_position_state_to_flat() {
 // Body was previously inlined identically at the end of every partial-exit
 // path.
 void BacktestEngine::settle_position_after_partial_exit(
-        double qty_before, PositionReductionCause cause) {
+        PositionReductionCause cause) {
     if (position_qty_ <= kQtyEpsilon || pyramid_entries_.empty()) {
         reset_position_state_to_flat();
     } else {
@@ -803,16 +791,7 @@ void BacktestEngine::settle_position_after_partial_exit(
         } else {
             position_entry_count_ = (int)pyramid_entries_.size();
         }
-        // The one-contract floor-zero rule belongs to an otherwise unmodified
-        // commissioned all-in short lifecycle. Any script-driven surviving
-        // reduction changes that shape. Broker margin-call reductions are the
-        // sole exception: TV preserves the lifecycle across its own cascade.
-        if (cause != PositionReductionCause::MARGIN_CALL
-            && position_side_ == PositionSide::SHORT
-            && position_qty_ + kQtyEpsilon < qty_before) {
-            commissioned_all_in_market_short_lifecycle_ = false;
-            default_market_direct_short_reversal_lifecycle_ = false;
-        }
+
     }
 }
 
@@ -830,15 +809,7 @@ void BacktestEngine::open_fresh_position(PositionSide requested, double fill_pri
     // The shared post-dispatch lifecycle hook queues the new fill's event.
     // Clear prior-cycle provenance now so reversals cannot expose it even
     // transiently.
-    opening_affordability_pending_ = false;
-    opening_affordability_eligible_ = false;
-    commissioned_all_in_market_long_opening_affordability_ = false;
-    opening_affordability_default_long_reversal_ = false;
-    close_then_short_opening_requires_adverse_retry_ = false;
-    commissioned_all_in_market_short_lifecycle_ = false;
-    default_market_direct_short_reversal_lifecycle_ = false;
-    opening_affordability_raw_fill_base_ =
-        std::numeric_limits<double>::quiet_NaN();
+    opening_obligations_.invalidate();
     position_entry_time_ = current_bar_.timestamp;
     position_qty_ = qty;
     position_entry_count_ = 1;

--- a/src/engine_state_hash.cpp
+++ b/src/engine_state_hash.cpp
@@ -86,6 +86,7 @@ void hash_str_set(Fnv& f, const std::unordered_set<std::string>& s) {
 
 uint64_t BacktestEngine::broker_state_hash() const {
     Fnv f;
+    f.s("pineforge-broker-state/v2");
 
     // --- Position core ---
     f.i(static_cast<int64_t>(position_side_));
@@ -97,29 +98,43 @@ uint64_t BacktestEngine::broker_state_hash() const {
     f.i(position_cycle_seq_);
     f.i(next_position_cycle_seq_);
 
-    // --- One-shot / lifecycle post-fill affordability provenance (KI-61) ---
-    // Consumed by process_margin_call / the affordability re-checks to decide
-    // a future forced-liquidation or trim event.
-    f.b(opening_affordability_pending_);
-    f.b(opening_affordability_eligible_);
-    f.b(commissioned_all_in_market_long_opening_affordability_);
-    f.b(opening_affordability_default_long_reversal_);
-    f.b(close_then_short_opening_requires_adverse_retry_);
-    f.b(commissioned_all_in_market_short_lifecycle_);
-    f.b(default_market_direct_short_reversal_lifecycle_);
-    f.d(opening_affordability_raw_fill_base_);
+    // Owned opening checkpoint. Serialize semantic fields, never variant
+    // storage or padding. Version 2 deliberately retires four dead labels.
+    f.b(opening_obligations_.pending());
+    if (const auto& receipt = opening_obligations_.peek()) {
+        const auto& owner = receipt->owner();
+        f.i(owner.positionCycle);
+        f.u(owner.producerFill);
+        f.u(owner.orderIncarnation);
+        f.i(owner.barIndex);
+        f.i(owner.timestamp);
+        f.i(static_cast<int64_t>(receipt->decision()));
+        f.b(receipt->requires_adverse_pass());
+        f.d(receipt->raw_fill_base());
+    }
 
-    // --- Pyramid book: price, time, qty, entry_id, entry_bar_index ---
+    // --- Physical lots: every PyramidEntry field is continuation state ---
+    // Comments/excursions are Pine-readable; the other provenance fields
+    // choose financial or same-bar path transitions. Preserve explicit typed
+    // folds: never hash struct padding, string storage or native object bytes.
     f.u(pyramid_entries_.size());
     for (const auto& e : pyramid_entries_) {
         f.d(e.price); f.i(e.time); f.d(e.qty); f.s(e.entry_id);
         f.i(static_cast<int64_t>(e.entry_bar_index));
+        f.s(e.entry_comment);
+        f.d(e.max_runup); f.d(e.max_drawdown);
+        f.b(e.skip_entry_bar_high); f.b(e.skip_entry_bar_low);
+        f.b(e.market_pyramid_add);
+        f.d(e.entry_path_position);
+        f.d(e.entry_commission_account);
         // Physical-lot provenance (task-7 carried ruling): bracket
         // ownership and same-id replacement rules match lots by the
         // incarnation of the PendingOrder that filled them, not by entry_id.
         f.u(e.entry_incarnation);
-        // This physical-lot flag selects a future opening money event.
+        f.b(e.bracket_slot_shadowed);
+        f.b(e.ordinary_market_open);
         f.b(e.pooc_terminal_market_entry);
+        f.b(e.ordinary_stop_open);
     }
 
     // cycle_filled_entry_ids_ is std::set<string>: already ordered.

--- a/src/engine_stream.cpp
+++ b/src/engine_stream.cpp
@@ -665,7 +665,7 @@ uint64_t BacktestEngine::stream_state_hash() const {
         integer(static_cast<uint64_t>(bar.timestamp));
         real(bar.open); real(bar.high); real(bar.low); real(bar.close); real(bar.volume);
     };
-    integer(1); integer(broker_state_hash());
+    integer(2); integer(broker_state_hash());
     integer(static_cast<uint64_t>(stream_phase_));
     integer(static_cast<uint64_t>(stream_input_mode_));
     integer(static_cast<uint64_t>(stream_input_tf_ms_));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(TEST_SOURCES
+    test_opening_obligation
+    test_gross_bucket_accounting
     test_high_value_price_admission
     test_integer_opening_budget
     test_script_run_prepare
@@ -229,6 +231,7 @@ set(TEST_SOURCES
     test_live_probe_suppress_tail
     test_live_path_order
     test_live_state_hash
+    test_pyramid_entry_state_hash
     test_live_state_hash_recording
     test_live_pending_order_mirror
     test_live_order_derived
@@ -350,6 +353,11 @@ add_test(
     NAME test_broker_state_hash_coverage
     COMMAND ${Python3_EXECUTABLE}
             ${PROJECT_SOURCE_DIR}/scripts/check_broker_state_hash_coverage.py
+)
+add_test(
+    NAME test_broker_state_hash_coverage_mutations
+    COMMAND ${Python3_EXECUTABLE}
+            ${PROJECT_SOURCE_DIR}/scripts/test_broker_state_hash_coverage.py
 )
 
 # When PINEFORGE_ENABLE_COVERAGE is ON we also instrument the test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(TEST_SOURCES
     test_opening_obligation
-    test_gross_bucket_accounting
     test_high_value_price_admission
     test_integer_opening_budget
     test_script_run_prepare

--- a/tests/test_direct_short_reversal_affordability.cpp
+++ b/tests/test_direct_short_reversal_affordability.cpp
@@ -3,8 +3,8 @@
  *
  * An omitted-qty, percent-of-equity=100 MARKET LONG-to-SHORT reversal at
  * margin_short=100 receives a fill-price affordability pass followed by one
- * bounded adverse-high retry. Its position-lifecycle bit also participates in
- * the established one-contract finite-price floor-zero fallback; the optional
+ * bounded adverse-high retry. The established one-contract finite-price
+ * floor-zero fallback depends on the budget and lot grid. The optional
  * full-residual interpretation yields to that settled slice whenever the
  * one-contract fallback is expressible (finding 279: TV slices and holds at
  * eps-scale deficits, it never full-liquidates there).
@@ -67,14 +67,19 @@ Bar bar(int64_t timestamp, double open, double high, double low, double close) {
 class DirectShortReversalProbe : public BacktestEngine {
 public:
     double position_size() const { return signed_position_size(); }
-    bool direct_lifecycle_active() const {
-        return default_market_direct_short_reversal_lifecycle_;
+    bool has_live_short_position() const {
+        return position_side_ == PositionSide::SHORT
+            && position_qty_ > 1e-9
+            && position_cycle_seq_ != 0
+            && !pyramid_entries_.empty()
+            && pyramid_entries_.front().qty > 1e-9
+            && pyramid_entries_.front().entry_incarnation != 0;
     }
     bool opening_event_cleared() const {
-        return !opening_affordability_pending_
-            && !opening_affordability_eligible_
-            && !close_then_short_opening_requires_adverse_retry_
-            && std::isnan(opening_affordability_raw_fill_base_);
+        return !opening_obligations_.pending()
+            && !opening_obligations_.actionable()
+            && !opening_obligations_.requires_adverse_pass()
+            && std::isnan(opening_obligations_.raw_fill_base());
     }
 
     std::vector<double> margin_quantities() const {
@@ -98,6 +103,12 @@ public:
     }
 
 protected:
+    bool opening_owner_matches_position() const {
+        const auto& receipt = opening_obligations_.peek();
+        return receipt && position_cycle_seq_ != 0
+            && receipt->owner().positionCycle == position_cycle_seq_;
+    }
+
     void seed_position(PositionSide side,
                        double entry,
                        double qty,
@@ -166,7 +177,7 @@ void test_direct_reversal_runs_opening_check_and_one_adverse_retry() {
         CHECK_NEAR(price[1], 3154.20, 1e-9);
     }
     CHECK_NEAR(probe.position_size(), -30.8219, 1e-9);
-    CHECK(probe.direct_lifecycle_active());
+    CHECK(probe.has_live_short_position());
     CHECK(probe.opening_event_cleared());
 }
 
@@ -197,9 +208,9 @@ public:
     }
 };
 
-void test_direct_lifecycle_floor_zero_full_residual_yields_to_slice() {
+void test_direct_reversal_floor_zero_full_residual_yields_to_slice() {
     std::printf(
-        "test_direct_lifecycle_floor_zero_full_residual_yields_to_slice\n");
+        "test_direct_reversal_floor_zero_full_residual_yields_to_slice\n");
     const std::vector<Bar> bars = {
         bar(1000, 4506.71, 4506.71, 4506.71, 4506.71),
         bar(2000, 4506.70, 4514.70, 4500.00, 4506.70),
@@ -222,7 +233,8 @@ void test_direct_lifecycle_floor_zero_full_residual_yields_to_slice() {
         CHECK_NEAR(one_contract_price[1], 4539.00, 1e-9);
     }
     CHECK_NEAR(one_contract.position_size(), -1.7346, 1e-9);
-    CHECK(one_contract.direct_lifecycle_active());
+    CHECK(one_contract.has_live_short_position());
+    CHECK(one_contract.opening_event_cleared());
 
     // The full-residual opt-in yields to the settled one-contract slice at
     // the floor-zero discontinuity: both cells now take the identical lots
@@ -244,7 +256,8 @@ void test_direct_lifecycle_floor_zero_full_residual_yields_to_slice() {
         CHECK_NEAR(full_residual_price[1], 4539.00, 1e-9);
     }
     CHECK_NEAR(full_residual.position_size(), -1.7346, 1e-9);
-    CHECK(full_residual.direct_lifecycle_active());
+    CHECK(full_residual.has_live_short_position());
+    CHECK(full_residual.opening_event_cleared());
 }
 
 class TrueFlatFullResidualControlProbe final
@@ -273,7 +286,6 @@ public:
         net_profit_sum_ =
             (qty - raw_q_min) * adverse - initial_capital_ + open_fee
             + (adverse - entry) * qty;
-        commissioned_all_in_market_short_lifecycle_ = true;
     }
 
     void on_bar(const Bar&) override {}
@@ -286,9 +298,8 @@ public:
     }
 };
 
-// Control: the commissioned true-flat lifecycle bit does not alter the
-// floor-zero outcome — with the full-residual opt-in set, the settled
-// one-contract slice still applies and the remainder is HELD.
+// Control: a commissioned short with the full-residual opt-in still takes
+// the settled one-contract slice and holds its remaining physical lot.
 void test_true_flat_floor_zero_control_slices_one_contract() {
     std::printf("test_true_flat_floor_zero_control_slices_one_contract\n");
     TrueFlatFullResidualControlProbe probe;
@@ -299,7 +310,8 @@ void test_true_flat_floor_zero_control_slices_one_contract() {
         CHECK_NEAR(qty[0], 1.0, 1e-9);
     }
     CHECK_NEAR(probe.position_size(), -2.6930, 1e-9);
-    CHECK(!probe.direct_lifecycle_active());
+    CHECK(probe.has_live_short_position());
+    CHECK(probe.opening_event_cleared());
 }
 
 class DirectPathExclusionProbe final : public DirectShortReversalProbe {
@@ -395,10 +407,10 @@ public:
             position_side_ == PositionSide::SHORT
             && position_qty_ > 1e-9;
         direct_opening_path_armed =
-            opening_affordability_pending_
-            && opening_affordability_eligible_
-            && close_then_short_opening_requires_adverse_retry_
-            && std::isfinite(opening_affordability_raw_fill_base_);
+            opening_obligations_.pending()
+            && opening_obligations_.actionable()
+            && opening_obligations_.requires_adverse_pass()
+            && std::isfinite(opening_obligations_.raw_fill_base());
     }
 
     bool reversal_filled = false;
@@ -435,7 +447,6 @@ void test_direct_path_exclusion_matrix() {
         DirectPathExclusionProbe probe(test_case.mechanism);
         probe.exercise();
         CHECK(probe.reversal_filled);
-        CHECK(!probe.direct_lifecycle_active());
         CHECK(!probe.direct_opening_path_armed);
     }
 }
@@ -476,9 +487,20 @@ public:
         current_bar_ = bar(2000, 100.0, 100.0, 100.0, 100.0);
         bar_index_ = 1;
         process_pending_orders(current_bar_);
-        captured_before_attempt = direct_lifecycle_active();
+        captured_before_attempt = opening_obligations_.actionable()
+            && opening_obligations_.requires_adverse_pass()
+            && opening_owner_matches_position();
+        // A disabled margin pass still consumes the opening checkpoint.
+        // A later rejected/no-op order must not create another receipt.
         process_margin_call(current_bar_);
+        consumed_before_attempt = opening_event_cleared();
         qty_before_attempt = position_qty_;
+        const int64_t cycle_before_attempt = position_cycle_seq_;
+        const uint64_t fills_before_attempt = broker_fill_event_seq_;
+        const uint64_t incarnation_before_attempt = pyramid_entries_.empty()
+            ? 0 : pyramid_entries_.front().entry_incarnation;
+        const double lot_qty_before_attempt = pyramid_entries_.empty()
+            ? 0.0 : pyramid_entries_.front().qty;
 
         const double requested_qty =
             attempt_ == Attempt::QuantizedToZero ? 0.5 : 1.0;
@@ -489,21 +511,31 @@ public:
 
         quantity_unchanged =
             std::abs(position_qty_ - qty_before_attempt) <= 1e-9;
-        provenance_preserved = direct_lifecycle_active();
+        owner_preserved = has_live_short_position()
+            && position_cycle_seq_ == cycle_before_attempt
+            && pyramid_entries_.front().entry_incarnation
+                == incarnation_before_attempt
+            && std::abs(pyramid_entries_.front().qty - lot_qty_before_attempt)
+                <= 1e-9;
+        no_fill_committed = broker_fill_event_seq_ == fills_before_attempt;
+        no_new_obligation = opening_event_cleared();
     }
 
     bool captured_before_attempt = false;
+    bool consumed_before_attempt = false;
     bool quantity_unchanged = false;
-    bool provenance_preserved = false;
+    bool owner_preserved = false;
+    bool no_fill_committed = false;
+    bool no_new_obligation = false;
     double qty_before_attempt = 0.0;
 
 private:
     Attempt attempt_;
 };
 
-void test_no_effect_same_side_add_preserves_direct_provenance() {
+void test_no_effect_same_side_add_keeps_owner_without_new_obligation() {
     std::printf(
-        "test_no_effect_same_side_add_preserves_direct_provenance\n");
+        "test_no_effect_same_side_add_keeps_owner_without_new_obligation\n");
     for (const NoEffectAddProbe::Attempt attempt : {
              NoEffectAddProbe::Attempt::RejectedByPyramiding,
              NoEffectAddProbe::Attempt::QuantizedToZero,
@@ -511,8 +543,11 @@ void test_no_effect_same_side_add_preserves_direct_provenance() {
         NoEffectAddProbe probe(attempt);
         probe.exercise();
         CHECK(probe.captured_before_attempt);
+        CHECK(probe.consumed_before_attempt);
         CHECK(probe.quantity_unchanged);
-        CHECK(probe.provenance_preserved);
+        CHECK(probe.owner_preserved);
+        CHECK(probe.no_fill_committed);
+        CHECK(probe.no_new_obligation);
     }
 }
 
@@ -536,7 +571,14 @@ public:
     void exercise() {
         current_bar_ = bar(1000, 100.0, 100.0, 100.0, 100.0);
         bar_index_ = 0;
-        default_market_direct_short_reversal_lifecycle_ = true;
+        const broker::OpeningOwner previous_owner{
+            position_cycle_seq_, broker_fill_event_seq_, 0,
+            bar_index_, current_bar_.timestamp};
+        opening_obligations_.replace(broker::OpeningReceipt::check(
+            previous_owner, 90.0,
+            broker::OpeningContinuation::RemainingAdversePath));
+        stale_obligation_seeded = opening_obligations_.actionable()
+            && opening_obligations_.requires_adverse_pass();
         if (opening_ == Opening::HighLevelEntry) {
             strategy_entry("N", true, kNaN, kNaN, 1.0);
         } else {
@@ -548,33 +590,47 @@ public:
         process_pending_orders(current_bar_);
         fresh_open_filled =
             position_side_ == PositionSide::LONG
-            && position_qty_ > 1e-9;
-        provenance_cleared =
-            !default_market_direct_short_reversal_lifecycle_;
+            && position_qty_ > 1e-9
+            && position_cycle_seq_ != 0;
+        const auto& receipt = opening_obligations_.peek();
+        obligation_replaced = receipt
+            && receipt->decision() == broker::OpeningDecision::Check
+            && receipt->owner().positionCycle == position_cycle_seq_
+            && receipt->owner().positionCycle != previous_owner.positionCycle
+            && receipt->owner().producerFill > previous_owner.producerFill
+            && !pyramid_entries_.empty()
+            && receipt->owner().orderIncarnation
+                == pyramid_entries_.back().entry_incarnation
+            && receipt->owner().barIndex == bar_index_
+            && receipt->owner().timestamp == current_bar_.timestamp
+            && std::abs(receipt->raw_fill_base() - 100.0) <= 1e-9
+            && !receipt->requires_adverse_pass();
     }
 
+    bool stale_obligation_seeded = false;
     bool fresh_open_filled = false;
-    bool provenance_cleared = false;
+    bool obligation_replaced = false;
 
 private:
     Opening opening_;
 };
 
-void test_fresh_entry_and_raw_order_clear_direct_provenance() {
+void test_fresh_entry_and_raw_order_replace_stale_obligation() {
     std::printf(
-        "test_fresh_entry_and_raw_order_clear_direct_provenance\n");
+        "test_fresh_entry_and_raw_order_replace_stale_obligation\n");
     for (const FreshOpeningResetProbe::Opening opening : {
              FreshOpeningResetProbe::Opening::HighLevelEntry,
              FreshOpeningResetProbe::Opening::RawOrder,
          }) {
         FreshOpeningResetProbe probe(opening);
         probe.exercise();
+        CHECK(probe.stale_obligation_seeded);
         CHECK(probe.fresh_open_filled);
-        CHECK(probe.provenance_cleared);
+        CHECK(probe.obligation_replaced);
     }
 }
 
-class LifecycleMutationProbe final : public DirectShortReversalProbe {
+class OpeningMutationProbe final : public DirectShortReversalProbe {
 public:
     enum class Mutation {
         AcceptedAdd,
@@ -582,7 +638,7 @@ public:
         FullClose,
     };
 
-    explicit LifecycleMutationProbe(Mutation mutation)
+    explicit OpeningMutationProbe(Mutation mutation)
         : mutation_(mutation) {
         initial_capital_ = 10000.0;
         default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
@@ -604,7 +660,16 @@ public:
                 /*realized_net_profit=*/0.0);
             strategy_entry("S", false, kNaN, kNaN, kNaN);
         } else if (bar_index_ == 1) {
-            captured_after_reversal = direct_lifecycle_active();
+            captured_after_reversal = opening_obligations_.actionable()
+                && opening_obligations_.requires_adverse_pass()
+                && opening_owner_matches_position();
+            original_cycle_ = position_cycle_seq_;
+            original_qty_ = position_qty_;
+            original_incarnation_ = pyramid_entries_.empty()
+                ? 0 : pyramid_entries_.front().entry_incarnation;
+            if (opening_obligations_.peek()) {
+                original_fill_ = opening_obligations_.peek()->owner().producerFill;
+            }
             if (mutation_ == Mutation::AcceptedAdd) {
                 // Placed on bar 2 instead (see below): the all-in short has no
                 // free equity at its own fill price, so an add costed as
@@ -615,14 +680,22 @@ public:
                     "S", "", 1.0, kNaN, /*immediately=*/true);
                 mutation_applied =
                     position_side_ == PositionSide::SHORT
-                    && position_qty_ > 1.0;
-                cleared_after_mutation = !direct_lifecycle_active();
+                    && position_qty_ > 1.0
+                    && std::abs(position_qty_ - (original_qty_ - 1.0)) <= 1e-9;
+                valid_after_mutation = position_cycle_seq_ == original_cycle_
+                    && pyramid_entries_.size() == 1
+                    && pyramid_entries_.front().entry_incarnation
+                        == original_incarnation_
+                    && opening_owner_matches_position()
+                    && opening_obligations_.peek()->owner().producerFill
+                        == original_fill_;
             } else {
                 strategy_close(
                     "S", "", kNaN, kNaN, /*immediately=*/true);
                 mutation_applied =
                     position_side_ == PositionSide::FLAT;
-                cleared_after_mutation = !direct_lifecycle_active();
+                valid_after_mutation = position_cycle_seq_ == 0
+                    && opening_event_cleared();
             }
         } else if (bar_index_ == 2
                    && mutation_ == Mutation::AcceptedAdd) {
@@ -632,21 +705,33 @@ public:
                    && mutation_ == Mutation::AcceptedAdd) {
             mutation_applied =
                 position_side_ == PositionSide::SHORT
-                && position_entry_count_ == 2;
-            cleared_after_mutation = !direct_lifecycle_active();
+                && position_entry_count_ == 2
+                && std::abs(position_qty_ - (original_qty_ + 1.0)) <= 1e-9;
+            valid_after_mutation = position_cycle_seq_ == original_cycle_
+                && opening_obligations_.actionable()
+                && opening_owner_matches_position()
+                && opening_obligations_.peek()->owner().producerFill > original_fill_
+                && pyramid_entries_.size() == 2
+                && pyramid_entries_.front().entry_incarnation == original_incarnation_
+                && opening_obligations_.peek()->owner().orderIncarnation
+                    == pyramid_entries_.back().entry_incarnation;
         }
     }
 
     bool captured_after_reversal = false;
     bool mutation_applied = false;
-    bool cleared_after_mutation = false;
+    bool valid_after_mutation = false;
 
 private:
     Mutation mutation_;
+    int64_t original_cycle_ = 0;
+    uint64_t original_incarnation_ = 0;
+    uint64_t original_fill_ = 0;
+    double original_qty_ = 0.0;
 };
 
-void test_direct_lifecycle_clears_on_script_mutations() {
-    std::printf("test_direct_lifecycle_clears_on_script_mutations\n");
+void test_direct_reversal_owner_and_obligation_follow_script_mutations() {
+    std::printf("test_direct_reversal_owner_and_obligation_follow_script_mutations\n");
     const std::vector<Bar> bars = {
         bar(1000, 100.0, 100.0, 100.0, 100.0),
         bar(2000, 100.0, 100.0, 100.0, 100.0),
@@ -654,16 +739,16 @@ void test_direct_lifecycle_clears_on_script_mutations() {
         bar(4000, 90.0, 90.0, 90.0, 90.0),
     };
 
-    for (const LifecycleMutationProbe::Mutation mutation : {
-             LifecycleMutationProbe::Mutation::AcceptedAdd,
-             LifecycleMutationProbe::Mutation::ScriptPartialReduction,
-             LifecycleMutationProbe::Mutation::FullClose,
+    for (const OpeningMutationProbe::Mutation mutation : {
+             OpeningMutationProbe::Mutation::AcceptedAdd,
+             OpeningMutationProbe::Mutation::ScriptPartialReduction,
+             OpeningMutationProbe::Mutation::FullClose,
          }) {
-        LifecycleMutationProbe probe(mutation);
+        OpeningMutationProbe probe(mutation);
         probe.run(bars.data(), static_cast<int>(bars.size()));
         CHECK(probe.captured_after_reversal);
         CHECK(probe.mutation_applied);
-        CHECK(probe.cleared_after_mutation);
+        CHECK(probe.valid_after_mutation);
     }
 }
 
@@ -673,25 +758,28 @@ public:
 
     void on_bar(const Bar&) override {}
 
-    void prime_direct_lifecycle() {
-        default_market_direct_short_reversal_lifecycle_ = true;
+    void prime_opening_obligation() {
+        opening_obligations_.replace(broker::OpeningReceipt::check(
+            {position_cycle_seq_, broker_fill_event_seq_, 0,
+             bar_index_, current_bar_.timestamp}, 100.0,
+            broker::OpeningContinuation::RemainingAdversePath));
     }
 
-    bool direct_lifecycle_active() const {
-        return default_market_direct_short_reversal_lifecycle_;
+    bool opening_pending() const {
+        return opening_obligations_.pending();
     }
 };
 
-void test_run_reset_clears_direct_lifecycle() {
-    std::printf("test_run_reset_clears_direct_lifecycle\n");
+void test_run_reset_clears_opening_obligation() {
+    std::printf("test_run_reset_clears_opening_obligation\n");
     const std::vector<Bar> bars = {
         bar(1000, 100.0, 100.0, 100.0, 100.0),
     };
     RunResetControlProbe probe;
-    probe.prime_direct_lifecycle();
-    CHECK(probe.direct_lifecycle_active());
+    probe.prime_opening_obligation();
+    CHECK(probe.opening_pending());
     probe.run(bars.data(), static_cast<int>(bars.size()));
-    CHECK(!probe.direct_lifecycle_active());
+    CHECK(!probe.opening_pending());
 }
 
 }  // namespace
@@ -699,13 +787,13 @@ void test_run_reset_clears_direct_lifecycle() {
 int main() {
     std::printf("--- direct short reversal affordability ---\n");
     test_direct_reversal_runs_opening_check_and_one_adverse_retry();
-    test_direct_lifecycle_floor_zero_full_residual_yields_to_slice();
+    test_direct_reversal_floor_zero_full_residual_yields_to_slice();
     test_true_flat_floor_zero_control_slices_one_contract();
     test_direct_path_exclusion_matrix();
-    test_no_effect_same_side_add_preserves_direct_provenance();
-    test_fresh_entry_and_raw_order_clear_direct_provenance();
-    test_direct_lifecycle_clears_on_script_mutations();
-    test_run_reset_clears_direct_lifecycle();
+    test_no_effect_same_side_add_keeps_owner_without_new_obligation();
+    test_fresh_entry_and_raw_order_replace_stale_obligation();
+    test_direct_reversal_owner_and_obligation_follow_script_mutations();
+    test_run_reset_clears_opening_obligation();
     std::printf(
         "=== Results: %d passed, %d failed ===\n",
         tests_passed, tests_failed);

--- a/tests/test_live_state_hash.cpp
+++ b/tests/test_live_state_hash.cpp
@@ -35,6 +35,40 @@ public:
     // "every hashed member changes the hash" -- task-5-review.md Important
     // #3). Kept in the same order as engine_state_hash.cpp so a future
     // reviewer can diff the two lists directly.
+    void seed_opening() {
+        opening_obligations_.replace(broker::OpeningReceipt::check(
+            {position_cycle_seq_, 17, 19, 2, 120000}, 102.0));
+    }
+    void mutate_opening_owner(const std::function<void(broker::OpeningOwner&)>& mutate) {
+        auto owner = opening_obligations_.peek()->owner();
+        mutate(owner);
+        opening_obligations_.replace(broker::OpeningReceipt::check(
+            owner, opening_obligations_.raw_fill_base()));
+    }
+    static std::vector<Pin> OpeningPins() {
+        return {
+            {"presence", [](Probe& s) { s.opening_obligations_.invalidate(); }},
+            {"positionCycle", [](Probe& s) { s.mutate_opening_owner([](auto& o) { ++o.positionCycle; }); }},
+            {"producerFill", [](Probe& s) { s.mutate_opening_owner([](auto& o) { ++o.producerFill; }); }},
+            {"orderIncarnation", [](Probe& s) { s.mutate_opening_owner([](auto& o) { ++o.orderIncarnation; }); }},
+            {"barIndex", [](Probe& s) { s.mutate_opening_owner([](auto& o) { ++o.barIndex; }); }},
+            {"timestamp", [](Probe& s) { s.mutate_opening_owner([](auto& o) { ++o.timestamp; }); }},
+            {"decision", [](Probe& s) {
+                s.opening_obligations_.replace(broker::OpeningReceipt::exempt(
+                    s.opening_obligations_.peek()->owner(), s.opening_obligations_.raw_fill_base()));
+            }},
+            {"continuation", [](Probe& s) {
+                s.opening_obligations_.replace(broker::OpeningReceipt::check(
+                    s.opening_obligations_.peek()->owner(), s.opening_obligations_.raw_fill_base(),
+                    broker::OpeningContinuation::RemainingAdversePath));
+            }},
+            {"raw_fill_base", [](Probe& s) {
+                s.opening_obligations_.replace(broker::OpeningReceipt::check(
+                    s.opening_obligations_.peek()->owner(), 103.0));
+            }},
+        };
+    }
+
     static std::vector<Pin> ScalarPins() {
         return {
             // Position core
@@ -49,16 +83,6 @@ public:
             {"position_open_bar_", [](Probe& s) { s.position_open_bar_ += 1; }},
             {"position_cycle_seq_", [](Probe& s) { s.position_cycle_seq_ += 1; }},
             {"next_position_cycle_seq_", [](Probe& s) { s.next_position_cycle_seq_ += 1; }},
-
-            // KI-61 affordability provenance
-            {"opening_affordability_pending_", [](Probe& s) { s.opening_affordability_pending_ = !s.opening_affordability_pending_; }},
-            {"opening_affordability_eligible_", [](Probe& s) { s.opening_affordability_eligible_ = !s.opening_affordability_eligible_; }},
-            {"commissioned_all_in_market_long_opening_affordability_", [](Probe& s) { s.commissioned_all_in_market_long_opening_affordability_ = !s.commissioned_all_in_market_long_opening_affordability_; }},
-            {"opening_affordability_default_long_reversal_", [](Probe& s) { s.opening_affordability_default_long_reversal_ = !s.opening_affordability_default_long_reversal_; }},
-            {"close_then_short_opening_requires_adverse_retry_", [](Probe& s) { s.close_then_short_opening_requires_adverse_retry_ = !s.close_then_short_opening_requires_adverse_retry_; }},
-            {"commissioned_all_in_market_short_lifecycle_", [](Probe& s) { s.commissioned_all_in_market_short_lifecycle_ = !s.commissioned_all_in_market_short_lifecycle_; }},
-            {"default_market_direct_short_reversal_lifecycle_", [](Probe& s) { s.default_market_direct_short_reversal_lifecycle_ = !s.default_market_direct_short_reversal_lifecycle_; }},
-            {"opening_affordability_raw_fill_base_", [](Probe& s) { s.opening_affordability_raw_fill_base_ = 424242.5; }},
 
             // KI-64 POOC freeze snapshot + same-bar close carry
             {"pos_view_freeze_bar_", [](Probe& s) { s.pos_view_freeze_bar_ += 1; }},
@@ -480,6 +504,19 @@ int main() {
         p.mutate(s);
         if (s.broker_state_hash() == before) {
             std::fprintf(stderr, "FAIL scalar pin %s: hash unchanged\n", p.name);
+            ++failures;
+        }
+    }
+
+    // Start from the same present receipt for every pin. Seeding presence
+    // inside a mutation would conceal a missing nested field from this test.
+    for (const auto& p : Probe::OpeningPins()) {
+        Probe s = Build3Bars();
+        s.seed_opening();
+        const uint64_t before = s.broker_state_hash();
+        p.mutate(s);
+        if (s.broker_state_hash() == before) {
+            std::fprintf(stderr, "FAIL opening receipt pin %s: hash unchanged\n", p.name);
             ++failures;
         }
     }

--- a/tests/test_margin_call.cpp
+++ b/tests/test_margin_call.cpp
@@ -77,15 +77,30 @@ public:
     int exit_bar(int i) const { return closed_trade_exit_bar_index(i); }
     double position_size() const { return signed_position_size(); }
     double liq_price() const { return margin_liquidation_price(); }
-    bool opening_pending() const { return opening_affordability_pending_; }
-    bool opening_eligible() const { return opening_affordability_eligible_; }
+    bool opening_pending() const { return opening_obligations_.pending(); }
+    bool opening_eligible() const { return opening_obligations_.actionable(); }
     bool opening_default_short_reversal() const {
-        return close_then_short_opening_requires_adverse_retry_;
+        return opening_obligations_.requires_adverse_pass();
     }
     double opening_raw_base() const {
-        return opening_affordability_raw_fill_base_;
+        return opening_obligations_.raw_fill_base();
     }
     int live_entry_count() const { return position_entry_count_; }
+
+protected:
+    void seed_opening_check(double raw_base,
+                           broker::OpeningContinuation continuation) {
+        const uint64_t incarnation = pyramid_entries_.empty()
+            ? 0 : pyramid_entries_.back().entry_incarnation;
+        opening_obligations_.replace(broker::OpeningReceipt::check(
+            {position_cycle_seq_, broker_fill_event_seq_, incarnation,
+             bar_index_, current_bar_.timestamp}, raw_base, continuation));
+    }
+
+    bool opening_owner_matches_position() const {
+        const auto& receipt = opening_obligations_.peek();
+        return receipt && receipt->owner().positionCycle == position_cycle_seq_;
+    }
 };
 
 // ---- A: 100%-equity short force-liquidated by a rising market --------------
@@ -615,9 +630,9 @@ public:
             // The next-open fill precedes this callback. Prove this fixture
             // actually reaches the opening-affordability branch before its
             // one-shot event is consumed at bar end.
-            saw_actionable_opening_event = opening_affordability_pending_
-                && opening_affordability_eligible_
-                && std::isfinite(opening_affordability_raw_fill_base_);
+            saw_actionable_opening_event = opening_obligations_.pending()
+                && opening_obligations_.actionable()
+                && std::isfinite(opening_obligations_.raw_fill_base());
         }
     }
 };
@@ -1525,9 +1540,9 @@ public:
                     && near(position_qty_, 2.0)
                     && !pyramid_entries_.empty()
                     && near(pyramid_entries_.back().price, 110.0);
-                widened_event = opening_affordability_pending_
-                    || opening_affordability_eligible_
-                    || std::isfinite(opening_affordability_raw_fill_base_);
+                widened_event = opening_obligations_.pending()
+                    || opening_obligations_.actionable()
+                    || std::isfinite(opening_obligations_.raw_fill_base());
             }
             return;
         }
@@ -1548,9 +1563,9 @@ public:
                 break;
         }
         process_pending_orders(current_bar_);
-        widened_event = opening_affordability_pending_
-            || opening_affordability_eligible_
-            || std::isfinite(opening_affordability_raw_fill_base_);
+        widened_event = opening_obligations_.pending()
+            || opening_obligations_.actionable()
+            || std::isfinite(opening_obligations_.raw_fill_base());
     }
 
 private:
@@ -1608,11 +1623,11 @@ public:
             strategy_close("Long");
             strategy_entry("Short", false, kNaN, kNaN, kNaN);
         } else if (bar_index_ == 2) {
-            captured_short_event = opening_affordability_pending_
-                && opening_affordability_eligible_
-                && close_then_short_opening_requires_adverse_retry_
-                && commissioned_all_in_market_short_lifecycle_
-                && near(opening_affordability_raw_fill_base_, 1798.09);
+            captured_short_event = opening_obligations_.pending()
+                && opening_obligations_.actionable()
+                && opening_obligations_.requires_adverse_pass()
+                && opening_owner_matches_position()
+                && near(opening_obligations_.raw_fill_base(), 1798.09);
         }
     }
 
@@ -1694,9 +1709,9 @@ public:
                 ? frozen_default_market_qty(/*is_buy=*/true) : kNaN;
             strategy_entry("Long", true, kNaN, kNaN, qty);
         } else if (bar_index_ == 2) {
-            captured = opening_affordability_pending_
-                && opening_affordability_eligible_
-                && commissioned_all_in_market_long_opening_affordability_
+            captured = opening_obligations_.pending()
+                && opening_obligations_.actionable()
+                && opening_owner_matches_position()
                 && position_side_ == PositionSide::LONG;
         }
     }
@@ -1707,9 +1722,9 @@ private:
     bool explicit_qty_;
 };
 
-// The commissioned-default-long PROVENANCE BIT is still scoped to an
-// omitted-quantity entry, but it no longer gates the floor-zero lot: both
-// shapes reach the same broker discontinuity and both close one contract.
+// Omitted and explicit quantities both create a live opening check and reach
+// the same floor-zero discontinuity. No obsolete commissioned-shape tag is
+// needed to distinguish their identical one-contract liquidation outcome.
 static void test_commissioned_close_then_long_floor_zero_scope() {
     std::printf("test_commissioned_close_then_long_floor_zero_scope\n");
     std::vector<Bar> bars = {
@@ -1723,14 +1738,14 @@ static void test_commissioned_close_then_long_floor_zero_scope() {
     explicit_control.run(bars.data(), static_cast<int>(bars.size()));
 
     CHECK(omitted.captured);
-    CHECK(!explicit_control.captured);
+    CHECK(explicit_control.captured);
     CHECK(omitted.trade_count() == 2);  // short close + long margin trim
     CHECK(margin_call_rows(omitted) == 1);
     CHECK(omitted.exit_comment(1) == std::string("Margin call"));
     CHECK(near(omitted.entry_price(1), 2967.80));
     CHECK(near(omitted.exit_price(1), 2967.80));
     CHECK(near(omitted.trade_size(1), 1.0, 1e-9));
-    // Same discontinuity, same lot: only the provenance bit differs.
+    // Same discontinuity and lot under the independently sized explicit call.
     CHECK(explicit_control.trade_count() == 2);
     CHECK(margin_call_rows(explicit_control) == 1);
     CHECK(near(explicit_control.trade_size(1), 1.0, 1e-9));
@@ -1739,8 +1754,8 @@ static void test_commissioned_close_then_long_floor_zero_scope() {
 // After the close-then-short fill-price trim, its bounded ordinary adverse
 // retry can require a positive restore quantity smaller than one configured
 // lot. TV's source-bound tape closes one whole contract at that exact
-// discontinuity, whether or not the position carries entry-lifecycle
-// provenance — the two arms below are now expected to agree.
+// discontinuity. The former tagged/untagged arms below are retained as
+// identical-input repeat controls after removal of the unused lifecycle bit.
 class DefaultShortLaterFloorZeroProbe : public MCEngine {
 public:
     explicit DefaultShortLaterFloorZeroProbe(bool full_residual = false) {
@@ -1778,30 +1793,30 @@ public:
 
     void on_bar(const Bar&) override {}
 
-    void trigger(bool carry_s_provenance) {
+    void trigger() {
         current_bar_ = mk_bar(
             2000, 1800.00, 1801.26, 1799.50, 1800.50, 1.0);
         bar_index_ = 1;
-        commissioned_all_in_market_short_lifecycle_ = carry_s_provenance;
         process_margin_call(current_bar_);
     }
 
-    bool lifecycle_active() const {
-        return commissioned_all_in_market_short_lifecycle_;
+    bool has_live_short_position() const {
+        return position_side_ == PositionSide::SHORT
+            && position_cycle_seq_ != 0 && position_qty_ > 0.0;
     }
 };
 
 static void test_default_short_lifecycle_floor_zero_one_contract() {
     std::printf("test_default_short_lifecycle_floor_zero_one_contract\n");
     DefaultShortLaterFloorZeroProbe top_level;
-    top_level.trigger(/*carry_s_provenance=*/false);
+    top_level.trigger();
     DefaultShortLaterFloorZeroProbe one_contract;
-    one_contract.trigger(/*carry_s_provenance=*/true);
+    one_contract.trigger();
     DefaultShortLaterFloorZeroProbe full_residual(/*full_residual=*/true);
-    full_residual.trigger(/*carry_s_provenance=*/true);
+    full_residual.trigger();
 
-    // A normal short without default-opening lifecycle provenance gets the
-    // SAME one whole contract: the fallback is not lifecycle-conditioned.
+    // Retain both former provenance arms as same-economics repeat controls.
+    // The fallback is not conditioned on an entry-lifecycle label.
     CHECK(top_level.trade_count() == 1);
     CHECK(near(top_level.trade_size(0), 1.0, 1e-9));
     CHECK(near(top_level.position_size(), -2.6930, 1e-9));
@@ -1811,7 +1826,8 @@ static void test_default_short_lifecycle_floor_zero_one_contract() {
     CHECK(near(one_contract.exit_price(0), 1801.26));
     CHECK(near(one_contract.trade_size(0), 1.0, 1e-9));
     CHECK(near(one_contract.position_size(), -2.6930, 1e-9));
-    CHECK(one_contract.lifecycle_active());
+    CHECK(one_contract.has_live_short_position());
+    CHECK(!one_contract.opening_pending());
 
     // The opt-in whole-residual interpretation no longer overrides the
     // settled floor-zero slice: when the one-contract fallback is
@@ -1822,15 +1838,16 @@ static void test_default_short_lifecycle_floor_zero_one_contract() {
     CHECK(near(full_residual.exit_price(0), 1801.26));
     CHECK(near(full_residual.trade_size(0), 1.0, 1e-9));
     CHECK(near(full_residual.position_size(), -2.6930, 1e-9));
-    CHECK(full_residual.lifecycle_active());
+    CHECK(full_residual.has_live_short_position());
+    CHECK(!full_residual.opening_pending());
 }
 
-// The commissioned lifecycle covers the opening checkpoint too. The positive
-// restore quantity below is half one lot: without lifecycle provenance the
-// event is a dust no-op; with it TV closes one contract at the raw fill base.
+// A positive opening restore below one lot closes one contract at the raw
+// fill base. The old lifecycle-tag variants are identical economic controls;
+// preserve both executions without seeding an unused Boolean.
 class DefaultShortOpeningFloorZeroProbe : public MCEngine {
 public:
-    explicit DefaultShortOpeningFloorZeroProbe(bool carry_lifecycle) {
+    DefaultShortOpeningFloorZeroProbe() {
         initial_capital_ = 1000.0;
         commission_type_ = CommissionType::PERCENT;
         commission_value_ = 0.05;
@@ -1853,11 +1870,8 @@ public:
         pyramid_entries_.back().entry_incarnation = 1;
         snapshot_entry_commission(pyramid_entries_.back());
         id_unclosed_qty_["S"] = qty;
-        opening_affordability_pending_ = true;
-        opening_affordability_eligible_ = true;
-        close_then_short_opening_requires_adverse_retry_ = true;
-        opening_affordability_raw_fill_base_ = entry;
-        commissioned_all_in_market_short_lifecycle_ = carry_lifecycle;
+        seed_opening_check(entry,
+            broker::OpeningContinuation::RemainingAdversePath);
     }
 
     void on_bar(const Bar&) override {}
@@ -1871,24 +1885,26 @@ public:
 
 static void test_default_short_opening_floor_zero_one_contract() {
     std::printf("test_default_short_opening_floor_zero_one_contract\n");
-    DefaultShortOpeningFloorZeroProbe baseline(/*carry_lifecycle=*/false);
+    DefaultShortOpeningFloorZeroProbe baseline;
     baseline.trigger();
-    DefaultShortOpeningFloorZeroProbe enabled(/*carry_lifecycle=*/true);
-    enabled.trigger();
+    DefaultShortOpeningFloorZeroProbe repeated;
+    repeated.trigger();
 
     // Fee-net equity is 1000 + .495 - .5 = 999.995, so the positive 0.00005
     // restore amount floors below one 0.0001 lot. The opening checkpoint acts
-    // on it identically with or without lifecycle provenance.
+    // on it identically in the two preserved repeat controls.
     CHECK(baseline.trade_count() == 1);
     CHECK(baseline.exit_comment(0) == std::string("Margin call"));
     CHECK(near(baseline.trade_size(0), 1.0, 1e-9));
     CHECK(near(baseline.position_size(), -9.0, 1e-9));
-    CHECK(enabled.trade_count() == 1);
-    CHECK(enabled.exit_comment(0) == std::string("Margin call"));
-    CHECK(near(enabled.entry_price(0), 100.0));
-    CHECK(near(enabled.exit_price(0), 100.0));
-    CHECK(near(enabled.trade_size(0), 1.0, 1e-9));
-    CHECK(near(enabled.position_size(), -9.0, 1e-9));
+    CHECK(repeated.trade_count() == 1);
+    CHECK(repeated.exit_comment(0) == std::string("Margin call"));
+    CHECK(near(repeated.entry_price(0), 100.0));
+    CHECK(near(repeated.exit_price(0), 100.0));
+    CHECK(near(repeated.trade_size(0), 1.0, 1e-9));
+    CHECK(near(repeated.position_size(), -9.0, 1e-9));
+    CHECK(!baseline.opening_pending());
+    CHECK(!repeated.opening_pending());
 }
 
 // A close-then-short fill-price opening check can be affordable while the same
@@ -1921,11 +1937,8 @@ public:
         pyramid_entries_.back().entry_incarnation = 1;
         snapshot_entry_commission(pyramid_entries_.back());
         id_unclosed_qty_["S"] = qty;
-        opening_affordability_pending_ = true;
-        opening_affordability_eligible_ = true;
-        close_then_short_opening_requires_adverse_retry_ = true;
-        opening_affordability_raw_fill_base_ = entry;
-        commissioned_all_in_market_short_lifecycle_ = true;
+        seed_opening_check(entry,
+            broker::OpeningContinuation::RemainingAdversePath);
     }
 
     void on_bar(const Bar&) override {}
@@ -1934,10 +1947,10 @@ public:
         current_bar_ = mk_bar(2000, 100.0, 105.0, 99.0, 100.0, 1.0);
         bar_index_ = 1;
         process_margin_call(current_bar_);
-        event_cleared = !opening_affordability_pending_
-            && !opening_affordability_eligible_
-            && !close_then_short_opening_requires_adverse_retry_
-            && std::isnan(opening_affordability_raw_fill_base_);
+        event_cleared = !opening_obligations_.pending()
+            && !opening_obligations_.actionable()
+            && !opening_obligations_.requires_adverse_pass()
+            && std::isnan(opening_obligations_.raw_fill_base());
     }
 
     bool event_cleared = false;
@@ -1962,13 +1975,12 @@ static void test_default_short_affordable_opening_retries_adverse_once() {
     CHECK(probe.event_cleared);
 }
 
-// A default-sized commissioned short opened from true flat has its own
-// lifecycle provenance. It must not inherit the prior close-then-short token,
-// and an ordinary add or fresh position will clear it through the shared
-// lifecycle reset sites.
-class CommissionedDefaultFlatShortLifecycleProbe : public MCEngine {
+// True-flat default shorts queue either a check (paid commission) or an
+// exemption (zero commission). Both receipts belong to the actual position,
+// and neither requires the direct-reversal adverse continuation.
+class DefaultFlatShortOpeningDecisionProbe : public MCEngine {
 public:
-    explicit CommissionedDefaultFlatShortLifecycleProbe(bool commissioned) {
+    explicit DefaultFlatShortOpeningDecisionProbe(bool commissioned) {
         initial_capital_ = 1000.0;
         default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
         default_qty_value_ = 100.0;
@@ -1983,30 +1995,39 @@ public:
         if (bar_index_ == 0) {
             strategy_entry("Short", false, kNaN, kNaN, kNaN);
         } else if (bar_index_ == 1) {
-            captured = position_side_ == PositionSide::SHORT
-                && commissioned_all_in_market_short_lifecycle_;
+            captured_pending = position_side_ == PositionSide::SHORT
+                && opening_obligations_.pending()
+                && opening_owner_matches_position();
+            captured = captured_pending && opening_obligations_.actionable();
+            captured_adverse = opening_obligations_.requires_adverse_pass();
         }
     }
 
     bool captured = false;
+    bool captured_pending = false;
+    bool captured_adverse = false;
 };
 
-static void test_commissioned_default_flat_short_lifecycle_tag() {
-    std::printf("test_commissioned_default_flat_short_lifecycle_tag\n");
+static void test_default_flat_short_opening_decision_tracks_commission() {
+    std::printf("test_default_flat_short_opening_decision_tracks_commission\n");
     std::vector<Bar> bars = {
         mk_bar(1000, 100.0, 100.0, 100.0, 100.0, 1.0),
         mk_bar(2000, 100.0, 100.0, 100.0, 100.0, 1.0),
         mk_bar(3000, 100.0, 100.0, 100.0, 100.0, 1.0),
     };
-    CommissionedDefaultFlatShortLifecycleProbe uncommissioned(
+    DefaultFlatShortOpeningDecisionProbe uncommissioned(
         /*commissioned=*/false);
     uncommissioned.run(bars.data(), static_cast<int>(bars.size()));
-    CommissionedDefaultFlatShortLifecycleProbe commissioned(
+    DefaultFlatShortOpeningDecisionProbe commissioned(
         /*commissioned=*/true);
     commissioned.run(bars.data(), static_cast<int>(bars.size()));
 
     CHECK(!uncommissioned.captured);
     CHECK(commissioned.captured);
+    CHECK(uncommissioned.captured_pending);
+    CHECK(commissioned.captured_pending);
+    CHECK(!uncommissioned.captured_adverse);
+    CHECK(!commissioned.captured_adverse);
     CHECK(uncommissioned.trade_count() == 0);
     CHECK(commissioned.trade_count() == 0);
     CHECK(uncommissioned.position_size() < -1e-9);
@@ -2019,7 +2040,7 @@ static void test_commissioned_default_flat_short_lifecycle_tag() {
 // fallback to the entire 0.3383-contract residual.
 class DefaultFlatShortFloorZeroProbe : public MCEngine {
 public:
-    explicit DefaultFlatShortFloorZeroProbe(bool carry_flat_lifecycle) {
+    DefaultFlatShortFloorZeroProbe() {
         initial_capital_ = 10000.0;
         default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
         default_qty_value_ = 100.0;
@@ -2045,7 +2066,6 @@ public:
         pyramid_entries_.back().entry_incarnation = 1;
         snapshot_entry_commission(pyramid_entries_.back());
         id_unclosed_qty_["Short"] = qty;
-        commissioned_all_in_market_short_lifecycle_ = carry_flat_lifecycle;
     }
 
     void on_bar(const Bar&) override {}
@@ -2060,35 +2080,32 @@ public:
 
 static void test_default_flat_short_floor_zero_caps_to_residual() {
     std::printf("test_default_flat_short_floor_zero_caps_to_residual\n");
-    DefaultFlatShortFloorZeroProbe baseline(
-        /*carry_flat_lifecycle=*/false);
+    DefaultFlatShortFloorZeroProbe baseline;
     baseline.trigger();
-    DefaultFlatShortFloorZeroProbe enabled(
-        /*carry_flat_lifecycle=*/true);
-    enabled.trigger();
+    DefaultFlatShortFloorZeroProbe repeated;
+    repeated.trigger();
 
     // 0.3383 contracts is below one, so the min(1.0, qty) cap closes the whole
-    // residual on both arms.
+    // residual in both former lifecycle-tag arms, now repeat controls.
     CHECK(baseline.trade_count() == 1);
     CHECK(near(baseline.exit_price(0), 3735.52));
     CHECK(near(baseline.trade_size(0), 0.3383, 1e-9));
     CHECK(near(baseline.position_size(), 0.0, 1e-9));
 
-    CHECK(enabled.trade_count() == 1);
-    CHECK(enabled.exit_comment(0) == std::string("Margin call"));
-    CHECK(near(enabled.entry_price(0), 3734.88));
-    CHECK(near(enabled.exit_price(0), 3735.52));
-    CHECK(near(enabled.trade_size(0), 0.3383, 1e-9));
-    CHECK(near(enabled.position_size(), 0.0, 1e-9));
+    CHECK(repeated.trade_count() == 1);
+    CHECK(repeated.exit_comment(0) == std::string("Margin call"));
+    CHECK(near(repeated.entry_price(0), 3734.88));
+    CHECK(near(repeated.exit_price(0), 3735.52));
+    CHECK(near(repeated.trade_size(0), 0.3383, 1e-9));
+    CHECK(near(repeated.position_size(), 0.0, 1e-9));
 }
 
-// A commissioned omitted-qty 100%-equity SHORT acquires lifecycle provenance
-// from its real entry shape. A user-requested partial exit changes that shape
-// and must invalidate the one-contract floor-zero provenance. Broker margin
-// reductions are covered separately above and intentionally preserve it.
-class CommissionedDefaultShortPartialLifecycleProbe : public MCEngine {
+// A script partial and a later margin partial preserve the physical short's
+// position identity while changing its quantity. The later floor-zero rule
+// does not depend on the removed commissioned-lifecycle label.
+class CommissionedDefaultShortPartialOwnerProbe : public MCEngine {
 public:
-    CommissionedDefaultShortPartialLifecycleProbe() {
+    CommissionedDefaultShortPartialOwnerProbe() {
         initial_capital_ = 1000.0;
         default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
         default_qty_value_ = 100.0;
@@ -2104,16 +2121,21 @@ public:
         if (bar_index_ == 0) {
             strategy_entry("Short", false, kNaN, kNaN, kNaN);
         } else if (bar_index_ == 1) {
-            lifecycle_after_open =
-                commissioned_all_in_market_short_lifecycle_;
+            opening_after_open = opening_obligations_.actionable()
+                && opening_owner_matches_position();
+            original_cycle_ = position_cycle_seq_;
+            original_incarnation_ = pyramid_entries_.empty()
+                ? 0 : pyramid_entries_.front().entry_incarnation;
             strategy_close(
                 "Short", "partial lifecycle close", /*qty=*/1.0,
                 /*qty_percent=*/kNaN, /*immediately=*/true);
             qty_after_partial = position_qty_;
-            lifecycle_after_partial =
+            owner_after_partial =
                 position_side_ == PositionSide::SHORT
                 && position_qty_ > 1.0
-                && commissioned_all_in_market_short_lifecycle_;
+                && position_cycle_seq_ == original_cycle_
+                && pyramid_entries_.size() == 1
+                && pyramid_entries_.front().entry_incarnation == original_incarnation_;
         }
     }
 
@@ -2129,28 +2151,36 @@ public:
             3000, 100.0, adverse, 99.0, 100.0, 1.0);
         bar_index_ = 2;
         process_margin_call(current_bar_);
-        lifecycle_after_margin_partial =
-            commissioned_all_in_market_short_lifecycle_;
+        owner_after_margin_partial = position_side_ == PositionSide::SHORT
+            && position_cycle_seq_ == original_cycle_
+            && pyramid_entries_.size() == 1
+            && pyramid_entries_.front().entry_incarnation == original_incarnation_;
+        opening_consumed = !opening_obligations_.pending();
     }
 
-    bool lifecycle_after_open = false;
-    bool lifecycle_after_partial = false;
-    bool lifecycle_after_margin_partial = false;
+    bool opening_after_open = false;
+    bool owner_after_partial = false;
+    bool owner_after_margin_partial = false;
+    bool opening_consumed = false;
     double qty_after_partial = 0.0;
+
+private:
+    int64_t original_cycle_ = 0;
+    uint64_t original_incarnation_ = 0;
 };
 
-static void test_user_partial_invalidates_commissioned_short_lifecycle() {
+static void test_short_partials_preserve_position_owner() {
     std::printf(
-        "test_user_partial_invalidates_commissioned_short_lifecycle\n");
+        "test_short_partials_preserve_position_owner\n");
     std::vector<Bar> bars = {
         mk_bar(1000, 100.0, 100.0, 100.0, 100.0, 1.0),
         mk_bar(2000, 100.0, 100.0, 100.0, 100.0, 1.0),
     };
-    CommissionedDefaultShortPartialLifecycleProbe probe;
+    CommissionedDefaultShortPartialOwnerProbe probe;
     probe.run(bars.data(), static_cast<int>(bars.size()));
 
-    CHECK(probe.lifecycle_after_open);
-    CHECK(!probe.lifecycle_after_partial);
+    CHECK(probe.opening_after_open);
+    CHECK(probe.owner_after_partial);
     CHECK(probe.trade_count() == 1);
     CHECK(near(probe.trade_size(0), 1.0, 1e-9));
     const double qty_before_margin = probe.qty_after_partial;
@@ -2159,21 +2189,20 @@ static void test_user_partial_invalidates_commissioned_short_lifecycle() {
     CHECK(probe.trade_count() == 2);
     CHECK(probe.exit_comment(1) == std::string("Margin call"));
     CHECK(near(probe.exit_price(1), 105.0));
-    // The invalidated lifecycle no longer changes the LOT (the fallback is
-    // unconditional); it is still asserted below as provenance state.
+    // The unchanged lot fallback depends on the actual budget, not a label.
     CHECK(near(probe.trade_size(1), 1.0, 1e-9));
     CHECK(near(probe.position_size(), -(qty_before_margin - 1.0), 1e-9));
-    CHECK(!probe.lifecycle_after_margin_partial);
+    CHECK(probe.owner_after_margin_partial);
+    CHECK(probe.opening_consumed);
 }
 
-// The scoped lifecycle belongs to one unmodified position cycle. A genuine
-// accepted add invalidates it, while a full close clears it through the shared
-// flat-position reset path.
-class CommissionedDefaultShortLifecycleMutationProbe : public MCEngine {
+// A genuine add replaces the opening obligation with its own committed-fill
+// receipt in the same position cycle. A full close invalidates the obligation.
+class CommissionedDefaultShortOpeningMutationProbe : public MCEngine {
 public:
     enum class Mutation { AcceptedAdd, FullClose };
 
-    explicit CommissionedDefaultShortLifecycleMutationProbe(Mutation mutation)
+    explicit CommissionedDefaultShortOpeningMutationProbe(Mutation mutation)
         : mutation_(mutation) {
         initial_capital_ = 1000.0;
         default_qty_type_ = QtyType::PERCENT_OF_EQUITY;
@@ -2191,8 +2220,12 @@ public:
         if (bar_index_ == 0) {
             strategy_entry("Short", false, kNaN, kNaN, kNaN);
         } else if (bar_index_ == 1) {
-            lifecycle_after_open =
-                commissioned_all_in_market_short_lifecycle_;
+            opening_after_open = opening_obligations_.actionable()
+                && opening_owner_matches_position();
+            original_cycle_ = position_cycle_seq_;
+            if (opening_obligations_.peek()) {
+                original_fill_ = opening_obligations_.peek()->owner().producerFill;
+            }
             if (mutation_ == Mutation::AcceptedAdd) {
                 strategy_entry("Add", false, kNaN, kNaN, /*qty=*/1.0);
             } else {
@@ -2200,28 +2233,36 @@ public:
                     "Short", "full lifecycle close", /*qty=*/kNaN,
                     /*qty_percent=*/kNaN, /*immediately=*/true);
                 full_close_cleared = position_side_ == PositionSide::FLAT
-                    && !commissioned_all_in_market_short_lifecycle_;
+                    && position_cycle_seq_ == 0
+                    && !opening_obligations_.pending();
             }
         } else if (bar_index_ == 2
                    && mutation_ == Mutation::AcceptedAdd) {
             add_filled = position_side_ == PositionSide::SHORT
                 && position_entry_count_ == 2;
-            accepted_add_cleared = add_filled
-                && !commissioned_all_in_market_short_lifecycle_;
+            accepted_add_replaced = add_filled
+                && position_cycle_seq_ == original_cycle_
+                && opening_obligations_.actionable()
+                && opening_owner_matches_position()
+                && opening_obligations_.peek()->owner().producerFill > original_fill_
+                && opening_obligations_.peek()->owner().orderIncarnation
+                    == pyramid_entries_.back().entry_incarnation;
         }
     }
 
-    bool lifecycle_after_open = false;
+    bool opening_after_open = false;
     bool add_filled = false;
-    bool accepted_add_cleared = false;
+    bool accepted_add_replaced = false;
     bool full_close_cleared = false;
 
 private:
     Mutation mutation_;
+    int64_t original_cycle_ = 0;
+    uint64_t original_fill_ = 0;
 };
 
-static void test_commissioned_default_short_lifecycle_mutations() {
-    std::printf("test_commissioned_default_short_lifecycle_mutations\n");
+static void test_short_add_replaces_obligation_and_full_close_invalidates() {
+    std::printf("test_short_add_replaces_obligation_and_full_close_invalidates\n");
     // Bar 1 closes at 90 so the explicit 1-lot add is affordable as held + add
     // (design-market-entry-affordability): the all-in short is in profit,
     // MTM ~1,099 >= (9.99 + 1) * 90. At the former close of 100 the all-in
@@ -2231,17 +2272,17 @@ static void test_commissioned_default_short_lifecycle_mutations() {
         mk_bar(2000, 100.0, 100.0,  90.0,  90.0, 1.0),
         mk_bar(3000,  90.0,  90.0,  90.0,  90.0, 1.0),
     };
-    CommissionedDefaultShortLifecycleMutationProbe add(
-        CommissionedDefaultShortLifecycleMutationProbe::Mutation::AcceptedAdd);
+    CommissionedDefaultShortOpeningMutationProbe add(
+        CommissionedDefaultShortOpeningMutationProbe::Mutation::AcceptedAdd);
     add.run(bars.data(), static_cast<int>(bars.size()));
-    CommissionedDefaultShortLifecycleMutationProbe close(
-        CommissionedDefaultShortLifecycleMutationProbe::Mutation::FullClose);
+    CommissionedDefaultShortOpeningMutationProbe close(
+        CommissionedDefaultShortOpeningMutationProbe::Mutation::FullClose);
     close.run(bars.data(), static_cast<int>(bars.size()));
 
-    CHECK(add.lifecycle_after_open);
+    CHECK(add.opening_after_open);
     CHECK(add.add_filled);
-    CHECK(add.accepted_add_cleared);
-    CHECK(close.lifecycle_after_open);
+    CHECK(add.accepted_add_replaced);
+    CHECK(close.opening_after_open);
     CHECK(close.full_close_cleared);
 }
 
@@ -2273,9 +2314,9 @@ public:
 
         strategy_entry("BASE", false, kNaN, kNaN, /*qty=*/2.0);
         process_pending_orders(current_bar_);
-        base_event_captured = opening_affordability_pending_
-            && opening_affordability_eligible_
-            && near(opening_affordability_raw_fill_base_, 100.0);
+        base_event_captured = opening_obligations_.pending()
+            && opening_obligations_.actionable()
+            && near(opening_obligations_.raw_fill_base(), 100.0);
 
         if (later_fill_ == LaterFill::PricedEntry) {
             strategy_entry("ADD", false, /*limit=*/110.0, kNaN,
@@ -2291,9 +2332,9 @@ public:
             && near(position_qty_, 4.0)
             && pyramid_entries_.size() == 2
             && near(pyramid_entries_.back().price, 110.0);
-        stale_event_cleared = !opening_affordability_pending_
-            && !opening_affordability_eligible_
-            && std::isnan(opening_affordability_raw_fill_base_);
+        stale_event_cleared = !opening_obligations_.pending()
+            && !opening_obligations_.actionable()
+            && std::isnan(opening_obligations_.raw_fill_base());
     }
 
 private:
@@ -2360,18 +2401,18 @@ public:
 
         strategy_entry("OPEN", true, kNaN, kNaN, /*qty=*/10.0);
         process_pending_orders(current_bar_);
-        captured_after_open = opening_affordability_pending_
-            && opening_affordability_eligible_
-            && near(opening_affordability_raw_fill_base_, 100.0);
+        captured_after_open = opening_obligations_.pending()
+            && opening_obligations_.actionable()
+            && near(opening_obligations_.raw_fill_base(), 100.0);
 
         // A priced explicit entry bypasses the market-only signal admission
         // gate and is a genuine accepted append (10 -> 25), not a rejected
         // over-allocation attempt. It is immediately marketable at this close.
         strategy_entry("ADD", true, /*limit=*/100.0, kNaN, /*qty=*/15.0);
         process_pending_orders(current_bar_);
-        eligible_after_add = opening_affordability_pending_
-            && opening_affordability_eligible_
-            && near(opening_affordability_raw_fill_base_, 100.0);
+        eligible_after_add = opening_obligations_.pending()
+            && opening_obligations_.actionable()
+            && near(opening_obligations_.raw_fill_base(), 100.0);
 
         // FIFO removes the opening lot, leaving only ADD as a live pyramid
         // leg. This drain is a CLOSE-PATH retirement (strategy.close), so TV
@@ -2382,9 +2423,9 @@ public:
                        /*qty_percent=*/kNaN, /*immediately=*/true);
         count_after_fifo = position_entry_count_;
         legs_after_fifo = (int)pyramid_entries_.size();
-        eligible_after_fifo = opening_affordability_pending_
-            && opening_affordability_eligible_
-            && near(opening_affordability_raw_fill_base_, 100.0);
+        eligible_after_fifo = opening_obligations_.pending()
+            && opening_obligations_.actionable()
+            && near(opening_obligations_.raw_fill_base(), 100.0);
     }
 };
 
@@ -2440,9 +2481,9 @@ public:
         process_pending_orders(current_bar_);
         strategy_entry("REJECTED_ADD", true, kNaN, kNaN, /*qty=*/1.0);
         process_pending_orders(current_bar_);  // rejected by pyramiding=1
-        preserved_after_rejection = opening_affordability_pending_
-            && opening_affordability_eligible_
-            && near(opening_affordability_raw_fill_base_, 100.0)
+        preserved_after_rejection = opening_obligations_.pending()
+            && opening_obligations_.actionable()
+            && near(opening_obligations_.raw_fill_base(), 100.0)
             && position_entry_count_ == 1
             && near(position_qty_, 10.0);
     }
@@ -2495,9 +2536,9 @@ public:
         // zero-qty bookkeeping lot but live position quantity stays exactly 10.
         strategy_entry("ZERO_ADD", true, kNaN, kNaN, /*qty=*/0.5);
         process_pending_orders(current_bar_);
-        preserved_after_zero_add = opening_affordability_pending_
-            && opening_affordability_eligible_
-            && near(opening_affordability_raw_fill_base_, 100.0)
+        preserved_after_zero_add = opening_obligations_.pending()
+            && opening_obligations_.actionable()
+            && near(opening_obligations_.raw_fill_base(), 100.0)
             && near(position_qty_, 10.0);
     }
 };
@@ -2544,8 +2585,8 @@ public:
         process_pending_orders(current_bar_);
         strategy_entry("ZERO_ADD", true, kNaN, kNaN, /*qty=*/0.5);
         process_pending_orders(current_bar_);
-        preserved_after_zero_add = opening_affordability_pending_
-            && opening_affordability_eligible_
+        preserved_after_zero_add = opening_obligations_.pending()
+            && opening_obligations_.actionable()
             && near(position_qty_, 10.0);
     }
 };
@@ -2596,26 +2637,26 @@ public:
         if (bar_index_ != 0) return;
         strategy_entry("OPEN", true, kNaN, kNaN, /*qty=*/10.0);
         process_pending_orders(current_bar_);
-        first_captured = opening_affordability_pending_
-            && opening_affordability_eligible_;
+        first_captured = opening_obligations_.pending()
+            && opening_obligations_.actionable();
 
         strategy_order("ADD", true, /*qty=*/15.0);
         process_pending_orders(current_bar_);
-        add_eligible = opening_affordability_pending_
-            && opening_affordability_eligible_
-            && near(opening_affordability_raw_fill_base_, 100.0);
+        add_eligible = opening_obligations_.pending()
+            && opening_obligations_.actionable()
+            && near(opening_obligations_.raw_fill_base(), 100.0);
 
         strategy_close_all();
         flat_cleared = position_side_ == PositionSide::FLAT
-            && !opening_affordability_pending_
-            && !opening_affordability_eligible_
-            && std::isnan(opening_affordability_raw_fill_base_);
+            && !opening_obligations_.pending()
+            && !opening_obligations_.actionable()
+            && std::isnan(opening_obligations_.raw_fill_base());
 
         strategy_order("RAW_FRESH", true, /*qty=*/12.0);
         process_pending_orders(current_bar_);
-        raw_fresh_captured = opening_affordability_pending_
-            && opening_affordability_eligible_
-            && near(opening_affordability_raw_fill_base_, 100.0);
+        raw_fresh_captured = opening_obligations_.pending()
+            && opening_obligations_.actionable()
+            && near(opening_obligations_.raw_fill_base(), 100.0);
     }
 };
 
@@ -2862,9 +2903,7 @@ public:
         pyramid_entries_.back().entry_incarnation = 1;
         snapshot_entry_commission(pyramid_entries_.back());
         id_unclosed_qty_["L"] = qty;
-        opening_affordability_pending_ = true;
-        opening_affordability_eligible_ = true;
-        opening_affordability_raw_fill_base_ = entry;
+        seed_opening_check(entry, broker::OpeningContinuation::None);
     }
 
     void on_bar(const Bar&) override {}
@@ -3086,9 +3125,9 @@ public:
     void on_bar(const Bar& /*bar*/) override {
         if (bar_index_ != 0) return;
         saw_clean_run_start = position_side_ == PositionSide::FLAT
-            && !opening_affordability_pending_
-            && !opening_affordability_eligible_
-            && std::isnan(opening_affordability_raw_fill_base_);
+            && !opening_obligations_.pending()
+            && !opening_obligations_.actionable()
+            && std::isnan(opening_obligations_.raw_fill_base());
         if (second_mode) {
             strategy_order("RAW", true, /*qty=*/10.0);
         } else {
@@ -3213,10 +3252,10 @@ int main() {
     test_default_short_lifecycle_floor_zero_one_contract();
     test_default_short_opening_floor_zero_one_contract();
     test_default_short_affordable_opening_retries_adverse_once();
-    test_commissioned_default_flat_short_lifecycle_tag();
+    test_default_flat_short_opening_decision_tracks_commission();
     test_default_flat_short_floor_zero_caps_to_residual();
-    test_user_partial_invalidates_commissioned_short_lifecycle();
-    test_commissioned_default_short_lifecycle_mutations();
+    test_short_partials_preserve_position_owner();
+    test_short_add_replaces_obligation_and_full_close_invalidates();
     test_priced_short_add_invalidates_scoped_opening_event();
     test_raw_short_add_invalidates_scoped_opening_event();
     test_accepted_add_fifo_keeps_add_affordability_event();

--- a/tests/test_opening_obligation.cpp
+++ b/tests/test_opening_obligation.cpp
@@ -1,0 +1,243 @@
+// Literal value-state tests only. No engine, strategy, market data or grading.
+#include <pineforge/broker_events.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+using pineforge::broker::OpeningContinuation;
+using pineforge::broker::OpeningDecision;
+using pineforge::broker::OpeningObligations;
+using pineforge::broker::OpeningOwner;
+using pineforge::broker::OpeningReceipt;
+
+namespace {
+int failures = 0;
+int checks = 0;
+#define CHECK(condition) do {                                                   \
+    ++checks;                                                                  \
+    if (!(condition)) {                                                        \
+        std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+        ++failures;                                                            \
+    }                                                                          \
+} while (false)
+
+static_assert(std::is_same_v<
+    decltype(std::declval<const OpeningObligations&>().peek()),
+    const std::optional<OpeningReceipt>&>,
+    "inspection must not expose a mutable pending receipt");
+
+bool same_owner(const OpeningOwner& a, const OpeningOwner& b) {
+    return a.positionCycle == b.positionCycle
+        && a.producerFill == b.producerFill
+        && a.orderIncarnation == b.orderIncarnation
+        && a.barIndex == b.barIndex
+        && a.timestamp == b.timestamp;
+}
+
+void absent(const OpeningObligations& obligations) {
+    CHECK(!obligations.pending());
+    CHECK(!obligations.actionable());
+    CHECK(!obligations.requires_adverse_pass());
+    CHECK(!obligations.peek().has_value());
+}
+
+void check_receipt(const OpeningReceipt& receipt, const OpeningOwner& owner,
+                   OpeningDecision decision, double raw, bool adverse) {
+    CHECK(same_owner(receipt.owner(), owner));
+    CHECK(receipt.decision() == decision);
+    CHECK(std::isnan(raw) ? std::isnan(receipt.raw_fill_base())
+                          : receipt.raw_fill_base() == raw);
+    CHECK(receipt.requires_adverse_pass() == adverse);
+}
+
+void test_absent_and_check_take() {
+    OpeningObligations obligations;
+    absent(obligations);
+    CHECK(!obligations.take(11).has_value());
+    absent(obligations);
+
+    const OpeningOwner owner{11, 7, 3, 42, 123456};
+    obligations.replace(OpeningReceipt::check(owner, 19.25,
+                                             OpeningContinuation::None));
+    CHECK(obligations.pending());
+    CHECK(obligations.actionable());
+    CHECK(!obligations.requires_adverse_pass());
+    CHECK(obligations.raw_fill_base() == 19.25);
+    const auto taken = obligations.take(11);
+    CHECK(taken.has_value());
+    absent(obligations);  // consumed before the caller can inspect the result
+    if (taken) check_receipt(*taken, owner, OpeningDecision::Check, 19.25, false);
+    CHECK(!obligations.take(11).has_value());
+}
+
+void test_exempt_is_pending_but_never_promoted() {
+    const OpeningOwner owner{12, 8, 4, 43, 123457};
+    OpeningObligations obligations;
+    obligations.replace(OpeningReceipt::exempt(owner, 20.5));
+    for (int read = 0; read < 3; ++read) {
+        CHECK(obligations.pending());
+        CHECK(!obligations.actionable());
+        CHECK(!obligations.requires_adverse_pass());
+        CHECK(obligations.raw_fill_base() == 20.5);
+        CHECK(obligations.peek().has_value());
+        if (obligations.peek())
+            check_receipt(*obligations.peek(), owner, OpeningDecision::Exempt, 20.5, false);
+    }
+    const auto taken = obligations.take(12);
+    CHECK(taken.has_value());
+    if (taken) check_receipt(*taken, owner, OpeningDecision::Exempt, 20.5, false);
+    absent(obligations);
+}
+
+void test_latest_receipt_replaces_owner_and_continuation() {
+    const OpeningOwner old_owner{13, 1, 10, 50, 200000};
+    const OpeningOwner new_owner{13, 2, 11, 50, 200000};
+    OpeningObligations obligations;
+    obligations.replace(OpeningReceipt::check(old_owner, 30.0,
+                           OpeningContinuation::RemainingAdversePath));
+    CHECK(obligations.requires_adverse_pass());
+    obligations.replace(OpeningReceipt::exempt(new_owner, 31.0));
+    CHECK(obligations.pending());
+    CHECK(!obligations.actionable());
+    CHECK(!obligations.requires_adverse_pass());
+    obligations.consume(old_owner);
+    CHECK(obligations.pending());  // stale cleanup cannot erase the replacement
+    if (obligations.peek())
+        check_receipt(*obligations.peek(), new_owner, OpeningDecision::Exempt, 31.0, false);
+
+    obligations.replace(OpeningReceipt::check(new_owner, 32.0,
+                           OpeningContinuation::RemainingAdversePath));
+    CHECK(obligations.actionable());
+    CHECK(obligations.requires_adverse_pass());
+    const auto taken = obligations.take(13);
+    CHECK(taken.has_value());
+    if (taken) check_receipt(*taken, new_owner, OpeningDecision::Check, 32.0, true);
+    absent(obligations);
+}
+
+void test_noop_and_every_owner_dimension() {
+    const OpeningOwner owner{14, 3, 12, 51, 200001};
+    const auto receipt = OpeningReceipt::check(owner, 40.0,
+                           OpeningContinuation::RemainingAdversePath);
+    OpeningObligations obligations;
+    obligations.replace(receipt);
+    // A rejected/no-op producer performs no replacement. Repeated inspection
+    // must preserve the receipt without reconstructing eligibility from state.
+    for (int read = 0; read < 3; ++read) {
+        CHECK(obligations.actionable());
+        CHECK(obligations.requires_adverse_pass());
+        if (obligations.peek())
+            check_receipt(*obligations.peek(), owner, OpeningDecision::Check, 40.0, true);
+    }
+
+    OpeningOwner others[] = {
+        {15, 3, 12, 51, 200001}, {14, 4, 12, 51, 200001},
+        {14, 3, 13, 51, 200001}, {14, 3, 12, 52, 200001},
+        {14, 3, 12, 51, 200002},
+    };
+    for (const auto& other : others) {
+        obligations.consume(other);
+        CHECK(obligations.pending());
+        if (obligations.peek()) CHECK(same_owner(obligations.peek()->owner(), owner));
+    }
+    obligations.consume(owner);
+    absent(obligations);
+    obligations.consume(owner);  // repeated consumption is a no-op
+    absent(obligations);
+}
+
+void test_stale_cycle_and_explicit_invalidation() {
+    const OpeningOwner previous_cycle{20, 6, 8, 60, 300000};
+    OpeningObligations obligations;
+    obligations.replace(OpeningReceipt::check(previous_cycle, 50.0,
+                           OpeningContinuation::RemainingAdversePath));
+    CHECK(!obligations.take(21).has_value());
+    absent(obligations);  // stale owner is discarded, not left pending forever
+    obligations.replace(OpeningReceipt::exempt(previous_cycle, 51.0));
+    CHECK(!obligations.take(19).has_value());
+    absent(obligations);
+    obligations.replace(OpeningReceipt::check(previous_cycle, 52.0,
+                                             OpeningContinuation::None));
+    obligations.invalidate();
+    absent(obligations);
+    obligations.invalidate();
+    absent(obligations);
+}
+
+void test_reused_id_is_a_new_incarnation() {
+    // No Pine string belongs to OpeningOwner. Two fills bearing the same
+    // external label are distinguished by physical cycle/incarnation identity.
+    const OpeningOwner first{25, 40, 100, 70, 400000};
+    const OpeningOwner replacement{26, 41, 101, 70, 400000};
+    OpeningObligations obligations;
+    obligations.replace(OpeningReceipt::check(first, 61.0,
+                           OpeningContinuation::RemainingAdversePath));
+    obligations.replace(OpeningReceipt::check(replacement, 62.0,
+                                             OpeningContinuation::None));
+    obligations.consume(first);
+    CHECK(obligations.pending());
+    CHECK(!obligations.requires_adverse_pass());
+    const auto taken = obligations.take(26);
+    CHECK(taken.has_value());
+    if (taken) check_receipt(*taken, replacement, OpeningDecision::Check, 62.0, false);
+    absent(obligations);
+}
+
+void test_copy_is_independent() {
+    const OpeningOwner owner{30, 50, 110, 80, 500000};
+    OpeningObligations original;
+    original.replace(OpeningReceipt::check(owner, 70.0,
+                       OpeningContinuation::RemainingAdversePath));
+    OpeningObligations copy = original;
+    const auto copied_receipt = copy.take(30);
+    CHECK(copied_receipt.has_value());
+    absent(copy);
+    CHECK(original.pending());
+    CHECK(original.actionable());
+    CHECK(original.requires_adverse_pass());
+    const auto detached_snapshot = original.peek();
+    original.invalidate();
+    absent(original);
+    CHECK(detached_snapshot.has_value());
+    if (detached_snapshot)
+        check_receipt(*detached_snapshot, owner, OpeningDecision::Check, 70.0, true);
+}
+
+void test_invalid_prices_are_data_and_still_consumed() {
+    const OpeningOwner owner{40, 60, 120, 90, 600000};
+    const double prices[] = {std::numeric_limits<double>::quiet_NaN(),
+        std::numeric_limits<double>::infinity(),
+        -std::numeric_limits<double>::infinity(), 0.0, -1.0};
+    for (const double price : prices) {
+        OpeningObligations obligations;
+        obligations.replace(OpeningReceipt::check(owner, price,
+                           OpeningContinuation::RemainingAdversePath));
+        CHECK(obligations.pending());
+        const auto taken = obligations.take(40);
+        CHECK(taken.has_value());
+        absent(obligations);
+        if (taken) check_receipt(*taken, owner, OpeningDecision::Check, price, true);
+        // Price validity is the financial consumer's decision; the value
+        // container neither normalizes the price nor retries the old event.
+        CHECK(!obligations.take(40).has_value());
+    }
+}
+}  // namespace
+
+int main() {
+    test_absent_and_check_take();
+    test_exempt_is_pending_but_never_promoted();
+    test_latest_receipt_replaces_owner_and_continuation();
+    test_noop_and_every_owner_dimension();
+    test_stale_cycle_and_explicit_invalidation();
+    test_reused_id_is_a_new_incarnation();
+    test_copy_is_independent();
+    test_invalid_prices_are_data_and_still_consumed();
+    std::printf("opening obligation: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_pooc_open_money_event.cpp
+++ b/tests/test_pooc_open_money_event.cpp
@@ -101,8 +101,8 @@ public:
         entry.entry_commission_account = 0;
         entry.pooc_terminal_market_entry = true;
         pyramid_entries_.push_back(entry);
-        opening_affordability_pending_ = opening_affordability_eligible_ = true;
-        opening_affordability_raw_fill_base_ = 1.13593;
+        opening_obligations_.replace(broker::OpeningReceipt::check(
+                {position_cycle_seq_, broker_fill_event_seq_, 0, bar_index_, current_bar_.timestamp}, 1.13593));
         process_margin_call(current_bar_);
     }
 };

--- a/tests/test_pyramid_entry_state_hash.cpp
+++ b/tests/test_pyramid_entry_state_hash.cpp
@@ -1,0 +1,146 @@
+#include <pineforge/engine.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <vector>
+
+// Literal state construction only. No on_bar, run, stream input, strategy
+// command, corpus, Pine or grading execution is used by this fixture.
+using namespace pineforge;
+
+namespace {
+class LiteralBook final : public BacktestEngine {
+public:
+    LiteralBook() {
+        position_side_ = PositionSide::LONG;
+        position_entry_price_ = 100;
+        position_entry_time_ = 1000;
+        position_qty_ = 2;
+        position_entry_count_ = 1;
+        position_open_bar_ = 3;
+        position_cycle_seq_ = 1;
+        next_position_cycle_seq_ = 2;
+        PyramidEntry entry{};
+        entry.price = 100;
+        entry.time = 1000;
+        entry.qty = 2;
+        entry.entry_id = "entry";
+        entry.entry_bar_index = 3;
+        entry.entry_comment = "literal";
+        entry.max_runup = 4;
+        entry.max_drawdown = 2;
+        entry.entry_path_position = 0.5;
+        entry.entry_commission_account = 0.25;
+        entry.entry_incarnation = 7;
+        pyramid_entries_.push_back(entry);
+    }
+
+    void on_bar(const Bar&) override {
+        // This hook must never be reached by a hash-only fixture.
+        std::abort();
+    }
+    PyramidEntry& lot() { return pyramid_entries_.front(); }
+    const PyramidEntry& lot() const { return pyramid_entries_.front(); }
+    double paid_entry_fee() const { return open_entry_commission(lot()); }
+    std::string pine_comment() const { return open_trade_entry_comment(0); }
+    double pine_runup() const { return open_trade_max_runup(0); }
+    double pine_drawdown() const { return open_trade_max_drawdown(0); }
+};
+
+struct Mutation {
+    const char* name;
+    void (*apply)(PyramidEntry&);
+};
+const Mutation kMutations[] = {
+    {"price", [](PyramidEntry& e) { e.price = 101; }},
+    {"time", [](PyramidEntry& e) { ++e.time; }},
+    {"qty", [](PyramidEntry& e) { e.qty = 3; }},
+    {"entry_id", [](PyramidEntry& e) { e.entry_id = "other"; }},
+    {"entry_bar_index", [](PyramidEntry& e) { ++e.entry_bar_index; }},
+    {"entry_comment", [](PyramidEntry& e) { e.entry_comment = "different"; }},
+    {"max_runup", [](PyramidEntry& e) { e.max_runup = 5; }},
+    {"max_drawdown", [](PyramidEntry& e) { e.max_drawdown = 3; }},
+    {"skip_entry_bar_high", [](PyramidEntry& e) { e.skip_entry_bar_high = true; }},
+    {"skip_entry_bar_low", [](PyramidEntry& e) { e.skip_entry_bar_low = true; }},
+    {"market_pyramid_add", [](PyramidEntry& e) { e.market_pyramid_add = true; }},
+    {"entry_path_position", [](PyramidEntry& e) { e.entry_path_position = 1.5; }},
+    {"entry_commission_account", [](PyramidEntry& e) { e.entry_commission_account = 0.5; }},
+    {"entry_incarnation", [](PyramidEntry& e) { ++e.entry_incarnation; }},
+    {"bracket_slot_shadowed", [](PyramidEntry& e) { e.bracket_slot_shadowed = true; }},
+    {"ordinary_market_open", [](PyramidEntry& e) { e.ordinary_market_open = true; }},
+    {"pooc_terminal_market_entry", [](PyramidEntry& e) { e.pooc_terminal_market_entry = true; }},
+    {"ordinary_stop_open", [](PyramidEntry& e) { e.ordinary_stop_open = true; }},
+};
+
+bool same_hashes(const LiteralBook& a, const LiteralBook& b) {
+    // stream_state_hash also reads initialized stream aggregators. This
+    // fixture has never begun a stream: compare the broker surface only.
+    return a.broker_state_hash() == b.broker_state_hash();
+}
+
+double from_bits(uint64_t bits) {
+    double value;
+    static_assert(sizeof(value) == sizeof(bits), "binary64 required");
+    std::memcpy(&value, &bits, sizeof(value));
+    return value;
+}
+}  // namespace
+
+int main() {
+    int failures = 0;
+    const LiteralBook base;
+    for (const auto& mutation : kMutations) {
+        LiteralBook changed;
+        if (!same_hashes(base, changed)) {
+            std::printf("FAIL literal identical books do not hash equally\n");
+            ++failures;
+        }
+        mutation.apply(changed.lot());
+        const bool broker_changed = base.broker_state_hash() != changed.broker_state_hash();
+        if (!broker_changed) {
+            std::printf("FAIL PyramidEntry.%s: broker hash unchanged\n", mutation.name);
+            ++failures;
+        }
+    }
+
+    // These omitted fields are directly observable without running a bar.
+    LiteralBook visible;
+    visible.lot().entry_commission_account = 0.5;
+    visible.lot().entry_comment = "different";
+    visible.lot().max_runup = 8;
+    visible.lot().max_drawdown = 7;
+    if (base.paid_entry_fee() == visible.paid_entry_fee()
+        || base.pine_comment() == visible.pine_comment()
+        || base.pine_runup() == visible.pine_runup()
+        || base.pine_drawdown() == visible.pine_drawdown()) {
+        std::printf("FAIL fixture did not change exposed physical-lot facts\n");
+        ++failures;
+    }
+
+    // Normalization remains the established FNV scalar contract, not raw
+    // object bytes. NaN payload/sign and negative zero are canonicalized.
+    const std::vector<double PyramidEntry::*> doubles = {
+        &PyramidEntry::price, &PyramidEntry::qty, &PyramidEntry::max_runup,
+        &PyramidEntry::max_drawdown, &PyramidEntry::entry_path_position,
+        &PyramidEntry::entry_commission_account,
+    };
+    for (auto field : doubles) {
+        LiteralBook a, b;
+        a.lot().*field = 0.0;
+        b.lot().*field = -0.0;
+        if (!same_hashes(a, b)) { ++failures; std::printf("FAIL signed-zero normalization\n"); }
+        a.lot().*field = from_bits(0x7ff8000000000001ULL);
+        b.lot().*field = from_bits(0xfff8000000000011ULL);
+        if (!same_hashes(a, b)) { ++failures; std::printf("FAIL NaN normalization\n"); }
+    }
+    LiteralBook a, b;
+    a.lot().entry_comment = std::string(128, 'x') + "a";
+    b.lot().entry_comment = std::string(128, 'x') + "b";
+    if (same_hashes(a, b)) { ++failures; std::printf("FAIL full string suffix not hashed\n"); }
+    std::printf("physical-lot hash: %zu fields, %d failed; no bars executed\n",
+                sizeof(kMutations) / sizeof(kMutations[0]), failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Opening checkpoints were spread across independent fields, making their
ownership and lifetime difficult to verify. Replace them with a Check/Exempt
receipt owned by the producing fill, order incarnation and position cycle.
Qualifying fills replace it, rejected attempts preserve it, and consumers take
or invalidate it at explicit boundaries. Remove four obsolete lifecycle labels
and their unused producers.

This is a first state-ownership cleanup for the standalone C++ execution core.
PineScript remains a codegen/frontend concern; this change does not claim the
remaining financial predicates or frontend compatibility policies are unified.
Part of #227.

All 18 physical-lot fields and opening receipt fields now contribute to versioned
fingerprints, with checks for unclassified nested state. The internal C++
namespace changes to require rebuilding native/generated strategy modules.
Public C function signatures and POD layouts are unchanged.

Validation of 38dc73e5503fe5395458e5f8df2a2ad78054a1ae:

- Full build;260 CTest cases:259 passed, 1 skipped because the local libcurl lacks
  WebSocket support. The unsupported-build refusal was checked.
- Independent exact-candidate Grok review:0 P0 / 0 P1 / 0 P2.
- Maintainer-controlled Cloud regression:72/72 cases, 4,190/4,190 probes. All raw
  trade CSV bytes, counts, grades and deterministic verifier fields match
  measured main 95aeb9c and official baseline 56. Zero improvement and regression.
- The unchanged parity gate returned **FAIL: `target.not-positive`** because
  this structural change has zero target improvement. The owner explicitly
  approved **"Allow this neutral refactor"** after the full equality evidence,
  authorizing this exact candidate for publication and merge after green CI.
  The actual FAIL remains recorded; grading rules and baseline-promotion
  requirements are unchanged.
