### PR TITLE
fix: validate native inputs and preserve order lifetimes

### DIFF
--- a/docs/pages/streaming.md
+++ b/docs/pages/streaming.md
@@ -93,6 +93,17 @@ strategy_free(strategy);
 Every stream function returns `0` on success and `-1` on failure. Read
 #strategy_get_last_error immediately after a failure.
 
+An attempt to begin a stream that is already realtime is rejected without
+replaying warmup, ending the active lifecycle, or disabling its action
+observations. An overflowing tick-volume accumulation is rejected before
+changing the forming bar's OHLCV or consuming the tick's timestamp/sequence.
+
+These validation checks do not make every failure transactional. Errors after
+processing starts can leave partially advanced state; discard/recover the
+instance according to the input-processing failure contract. A plural tick
+call retains repeated single-call semantics: an accepted prefix remains
+applied if a later tick fails.
+
 ## Tick and bar semantics
 
 - Warmup bars must be strictly increasing, confirmed, and use a fixed-duration

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -1698,8 +1698,10 @@ protected:
     std::unordered_set<std::string> scratch_skip_ids_;
 
     // Reusable scratch for process_pending_orders (capacity persists across
-    // calls, mirroring scratch_skip_ids_). Always cleared before use.
-    std::vector<size_t> scratch_filled_indices_;
+    // calls, mirroring scratch_skip_ids_). Incarnations survive OCA erasure;
+    // vector indices and retained replacement priorities do not identify an
+    // object. Always cleared before use; never persistent cancellation state.
+    std::vector<uint64_t> scratch_filled_incarnations_;
 
     // Per-PASS dual-entry-stop arbitration winner (a flat position resting
     // one long stop-only ENTRY + one short stop-only ENTRY, both touched
@@ -4012,10 +4014,10 @@ private:
     double cover_samebar_market_adds_on_exit(
         const PendingOrder& order, double fill_price,
         PositionReductionCause cause = PositionReductionCause::SCRIPT_ORDER);
-    void cancel_oca_group(const std::string& oca_name, const std::string& exclude_id);
+    void cancel_oca_group(std::string oca_name, std::string exclude_id);
     // Pine v6 oca.reduce: when one sibling fills qty Q, reduce remaining
     // siblings' qty by Q. Siblings whose qty becomes <= 0 are cancelled.
-    void reduce_oca_group(const std::string& oca_name, const std::string& exclude_id,
+    void reduce_oca_group(std::string oca_name, std::string exclude_id,
                           double filled_qty);
     void purge_exit_orders(bool retain_for_pending_entries = false);
 
@@ -4063,16 +4065,16 @@ private:
         bool* limit_leg = nullptr) const;
     bool pending_flat_market_pair_is_live(const PendingOrder& order) const;
     void invalidate_pending_flat_market_pair(int64_t created_seq);
-    void compact_filled_pending_orders(const std::vector<size_t>& filled_indices,
+    void compact_filled_pending_orders(std::vector<uint64_t>& retired_incarnations,
                                        int exit_closed_from_bar,
                                        uint64_t exit_closed_from_incarnation,
                                        bool exit_closed_was_long);
     // Apply a fill to engine state: dispatches by order.type to the
     // per-type apply_*_order_fill helpers below, plus runs the risk
     // gate, intraday-fill cap, OCA cancellation, and bookkeeping that
-    // is common to every fill kind.
-    void apply_filled_order_to_state(PendingOrder& order,
-                                     size_t order_index,
+    // is common to every fill kind. The caller resolves an incarnation to a
+    // current index; admission borrows the book, then dispatch owns a value.
+    void apply_filled_order_to_state(size_t order_index,
                                      double fill_price,
                                      bool fill_is_limit,
                                      const Bar& bar,
@@ -4080,7 +4082,7 @@ private:
                                      int& exit_closed_from_bar,
                                      uint64_t& exit_closed_from_incarnation,
                                      bool& exit_closed_was_long,
-                                     std::vector<size_t>& filled_indices,
+                                     std::vector<uint64_t>& retired_incarnations,
                                      bool flat_dual_stop_pair = false);
     bool stop_entry_margin_admission_declines(
         const PendingOrder& order, double fill_price, const Bar& bar,
@@ -4171,7 +4173,7 @@ private:
     // are left untouched (qty=NaN → full remaining close, as before).
     void reconcile_deferred_layered_exits(
         const std::string& entry_id,
-        std::vector<std::size_t>& zero_reservation_indices);
+        std::vector<uint64_t>& zero_reservation_incarnations);
     void apply_raw_order_fill(PendingOrder& order, double fill_price,
                               double& trail_best_path_state,
                               int& exit_closed_from_bar,
@@ -4502,6 +4504,8 @@ private:
     // request_abort() arriving during a delegating overload's own setup
     // (e.g. the SymInfo/overrides overload's syminfo/inputs copy) is never
     // silently wiped by a second, later clear.
+    // The caller has already validated the complete chart bar array; do not
+    // rescan here or clear an abort that arrived during preflight/setup.
     void run_tf_impl(const Bar* input_bars, int n_input,
                      const std::string& input_tf,
                      const std::string& script_tf,
@@ -4525,6 +4529,16 @@ public:
     virtual ~BacktestEngine() = default;
     virtual void on_bar(const Bar& bar) = 0;
 
+    // All run() overloads preflight the entire chart array before modifying
+    // configuration, resetting state, preparing scripts or dispatching bars.
+    // Require n >= 0, a non-null pointer when n > 0, finite enclosed OHLC,
+    // volume that is finite >= 0 or NaN (unavailable), and strictly increasing
+    // timestamps with representable positive int64 deltas. Finite signed/zero
+    // prices, off-grid prices and gaps are structurally admitted, without a
+    // guarantee about their financial or extreme-calendar arithmetic.
+    // Rejection sets last_error() and preserves state except entry-time error,
+    // run-status and abort bookkeeping. n == 0 retains empty-new-run semantics.
+    // Processing exceptions after preflight do not imply state rollback.
     void run(const Bar* bars, int n);
 
     void run(const Bar* input_bars, int n_input,

--- a/scripts/broker_state_hash_waivers.txt
+++ b/scripts/broker_state_hash_waivers.txt
@@ -97,7 +97,7 @@ fold_exit_trail_peak_         # doc: "Transient companion for TRAIL exits"; NaN 
 last_exit_fill_was_trail_     # set by evaluate_fill_price, consumed same call chain by apply_filled_order_to_state
 intraday_loss_evaluating_     # transient evaluation flag: reentrancy guard, true only inside evaluate_max_intraday_loss, always false on return
 scratch_skip_ids_             # doc: "Not state -- must be empty across calls"
-scratch_filled_indices_       # doc: "Always cleared before use"
+scratch_filled_incarnations_  # doc: "Always cleared before use"
 named_entry_cancelled_incarnation_in_current_eval_  # doc: "invoke_chart_on_bar clears the map before each script execution"
 
 # --- Per-source-bar same-bar strategy.close batching scratch: the code's

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -24,6 +24,29 @@ using namespace internal;
 
 namespace {
 
+// A pass keeps identities and ordering hints, never borrowed vector elements.
+// The hint makes the unchanged-book path constant time; OCA erasure requires
+// re-resolution by incarnation. A reused label/priority cannot match this key.
+struct PendingOrderHandle {
+    uint64_t incarnation;
+    size_t index_hint;
+
+    size_t resolve(const std::vector<PendingOrder>& orders) const {
+        if (index_hint < orders.size()
+            && orders[index_hint].incarnation == incarnation) return index_hint;
+        for (size_t i = 0; i < orders.size(); ++i) {
+            if (orders[i].incarnation == incarnation) return i;
+        }
+        return orders.size();
+    }
+};
+
+bool same_pending_order(const PendingOrder& a, const PendingOrder& b) {
+    // Preserve address identity for legacy hand-built zero-ID fixtures; an
+    // owned matched-order value uses the production object's nonzero identity.
+    return &a == &b || (a.incarnation != 0 && a.incarnation == b.incarnation);
+}
+
 // Both post-full-close cleanup sites must use this exact predicate. The
 // physical same-id fact is snapshotted when deferred close_all is called,
 // because the filling close drains pyramid_entries_ before cleanup runs.
@@ -352,19 +375,28 @@ void BacktestEngine::process_pending_orders(const Bar& bar, bool before_pooc_scr
         // with an empty set every order classifies Skip and the pass is a
         // structural no-op. Bail before paying the scan.
         if (opposing_pass == 1 && pass0_opposing_skip_ids.empty()) break;
-    std::vector<size_t>& filled_indices = scratch_filled_indices_;
-    filled_indices.clear();
+    std::vector<uint64_t>& retired_incarnations = scratch_filled_incarnations_;
+    retired_incarnations.clear();
     // TV generally cancels stale SAME-DIRECTION entries after a full exit.
     // Opposite entries, same-call-bar under-cap co-queues, resting pure LIMITs,
     // and the physically-live same-ID pure-STOP close_all cell are the narrow
     // independently-proven exceptions below.
 
-    for (size_t i = 0; i < pending_orders_.size(); i++) {
+    std::vector<PendingOrderHandle> pass_orders;
+    pass_orders.reserve(pending_orders_.size());
+    for (size_t i = 0; i < pending_orders_.size(); ++i) {
+        pass_orders.push_back({pending_orders_[i].incarnation, i});
+    }
+    for (const PendingOrderHandle handle : pass_orders) {
+        size_t i = handle.resolve(pending_orders_);
+        if (i == pending_orders_.size()) continue; // canceled earlier this pass
+        FillEvaluation fill;
+        {
         PendingOrder& order = pending_orders_[i];
         if (intraday_loss_cancel_pending_) {
             // strategy.risk.max_intraday_loss fired on an earlier fill of
             // this sweep: TradingView cancels every pending order there.
-            filled_indices.push_back(i);
+            retired_incarnations.push_back(order.incarnation);
             continue;
         }
         auto eligibility = classify_order_eligibility(
@@ -373,19 +405,20 @@ void BacktestEngine::process_pending_orders(const Bar& bar, bool before_pooc_scr
             exit_closed_was_long, bar, flat_dual_stop_pair);
         if (eligibility == OrderEligibility::Remove) {
             invalidate_pending_flat_market_pair(order.created_seq);
-            filled_indices.push_back(i);
+            retired_incarnations.push_back(order.incarnation);
             continue;
         }
         if (eligibility == OrderEligibility::Skip) {
             continue;
         }
 
-        auto fill = evaluate_fill_price(
+        fill = evaluate_fill_price(
             order, i, bar, opposing_pass, trail_best_path_state,
             pass0_opposing_skip_ids);
         if (fill.kind != FillEvaluation::Kind::Fill) {
             continue;
         }
+        } // release the book borrow before a pre-exit margin intervention
 
         // finding-308: TV books forced liquidation chronologically on the
         // intrabar path. If this priced exit fills strictly AFTER the bar's
@@ -396,7 +429,7 @@ void BacktestEngine::process_pending_orders(const Bar& bar, bool before_pooc_scr
         // exactly like the end-of-bar call sites do.
         if (fill.exit_path_fill
             && ((before_pooc_script && broker_fill_event_seq_ == fills_at_pass_start
-                 && pooc_trail_money_pre_exit_scope(bar, order, fill.exit_path_position)
+                 && pooc_trail_money_pre_exit_scope(bar, pending_orders_[i], fill.exit_path_position)
                  && tv_money_long_margin_call(bar, /*carried_pooc_pre_close=*/true,
                                               /*opening_only=*/false, fill.exit_path_position))
                 || margin_call_slice_before_priced_exit(
@@ -404,7 +437,14 @@ void BacktestEngine::process_pending_orders(const Bar& bar, bool before_pooc_scr
             refresh_frozen_default_sizing_after_margin_call();
         }
 
-        const bool path_winner_stop_margin_decline =
+        // A margin intervention can consume a revived bracket and shift this
+        // same book. Re-resolve the selected object before admission as well.
+        i = handle.resolve(pending_orders_);
+        if (i == pending_orders_.size()) continue;
+        bool path_winner_stop_margin_decline;
+        {
+        const PendingOrder& order = pending_orders_[i];
+        path_winner_stop_margin_decline =
             continue_after_stop_margin_decline_scope
             && ((dual_entry_path_ == DualEntryStopPathWinner::LongFirst
                  && order.is_long)
@@ -413,13 +453,14 @@ void BacktestEngine::process_pending_orders(const Bar& bar, bool before_pooc_scr
             && check_risk_allow_entry(order.is_long)
             && stop_entry_margin_admission_declines(
                 order, fill.fill_price, bar, flat_dual_stop_pair);
+        }
         const double realized_before_fill = net_profit_sum_;
         apply_filled_order_to_state(
-            order, i, fill.fill_price, fill.is_limit_fill, bar,
+            i, fill.fill_price, fill.is_limit_fill, bar,
             trail_best_path_state,
             exit_closed_from_bar, exit_closed_from_incarnation,
             exit_closed_was_long,
-            filled_indices, flat_dual_stop_pair);
+            retired_incarnations, flat_dual_stop_pair);
         if (risk_max_intraday_loss_ > 0.0) {
             // The closing fill's own realized P&L is not yet part of the
             // equity TradingView checks at this tick (pinned t1).
@@ -435,7 +476,7 @@ void BacktestEngine::process_pending_orders(const Bar& bar, bool before_pooc_scr
         materialize_relative_exit_prices_for_live_position();
     }
     compact_filled_pending_orders(
-        filled_indices, exit_closed_from_bar, exit_closed_from_incarnation,
+        retired_incarnations, exit_closed_from_bar, exit_closed_from_incarnation,
         exit_closed_was_long);
     }  // opposing_pass
 
@@ -515,11 +556,11 @@ BacktestEngine::CoofFillResult BacktestEngine::process_next_pending_order(
     for (int opposing_pass = 0; opposing_pass < 2; ++opposing_pass) {
         if (opposing_pass == 1 && pass0_opposing_skip_ids.empty()) break;
 
-        std::vector<size_t>& filled_indices = scratch_filled_indices_;
-        filled_indices.clear();
+        std::vector<uint64_t>& retired_incarnations = scratch_filled_incarnations_;
+        retired_incarnations.clear();
 
         struct FillCandidate {
-            size_t order_index;
+            PendingOrderHandle order;
             FillEvaluation fill;
             double path_position;
             bool was_trail;
@@ -537,7 +578,7 @@ BacktestEngine::CoofFillResult BacktestEngine::process_next_pending_order(
                 exit_closed_was_long, bar);
             if (eligibility == OrderEligibility::Remove) {
                 invalidate_pending_flat_market_pair(order.created_seq);
-                filled_indices.push_back(i);
+                retired_incarnations.push_back(order.incarnation);
                 continue;
             }
             if (eligibility == OrderEligibility::Skip) continue;
@@ -668,7 +709,7 @@ BacktestEngine::CoofFillResult BacktestEngine::process_next_pending_order(
             // naturally tie at position zero and fall back to creation order.
             internal::first_touch_position(bar, fill.fill_price, &path_position);
             candidates.push_back({
-                i, fill, path_position, last_exit_fill_was_trail_,
+                {order.incarnation, i}, fill, path_position, last_exit_fill_was_trail_,
                 order.created_seq, chart_waypoint_price});
         }
 
@@ -689,7 +730,7 @@ BacktestEngine::CoofFillResult BacktestEngine::process_next_pending_order(
         // historical book. Other order races and scheduler modes retain
         // the existing one-fill/recalc path.
         const bool group_resting_stops = [&] {
-            if (candidates.size() < 2 || !filled_indices.empty()
+            if (candidates.size() < 2 || !retired_incarnations.empty()
                 || !calc_on_order_fills_ || !coof_scheduler_active_
                 || !coof_evaluating_path_segment_ || !coof_hist_is_segment_
                 || process_orders_on_close_ || bar_magnifier_enabled_
@@ -721,7 +762,9 @@ BacktestEngine::CoofFillResult BacktestEngine::process_next_pending_order(
             }
             if (reserved > position_qty_ + kQtyEpsilon) return false;
             for (const FillCandidate& candidate : candidates) {
-                const PendingOrder& pending = pending_orders_[candidate.order_index];
+                const size_t index = candidate.order.resolve(pending_orders_);
+                if (index == pending_orders_.size()) return false;
+                const PendingOrder& pending = pending_orders_[index];
                 if (candidate.was_trail || candidate.fill.is_limit_fill
                     || !candidate.fill.exit_path_fill
                     || pending.stop_price > bar.open
@@ -735,7 +778,10 @@ BacktestEngine::CoofFillResult BacktestEngine::process_next_pending_order(
         size_t grouped_fills = 0;
 
         for (const FillCandidate& candidate : candidates) {
-            PendingOrder& order = pending_orders_[candidate.order_index];
+            const size_t order_index = candidate.order.resolve(pending_orders_);
+            if (order_index == pending_orders_.size()
+                || std::find(retired_incarnations.begin(), retired_incarnations.end(),
+                             candidate.order.incarnation) != retired_incarnations.end()) continue;
             last_exit_fill_was_trail_ = candidate.was_trail;
 
             // Candidate discovery looks across the whole remaining segment,
@@ -751,17 +797,17 @@ BacktestEngine::CoofFillResult BacktestEngine::process_next_pending_order(
             // Capture before the fill kernel: other order kinds may erase OCA
             // siblings, invalidating references into the pending-order vector.
             const bool fresh_coof_market_entry =
-                order.type == OrderType::MARKET
-                && order.created_during_coof_recalc
-                && order.created_bar == bar_index_
+                pending_orders_[order_index].type == OrderType::MARKET
+                && pending_orders_[order_index].created_during_coof_recalc
+                && pending_orders_[order_index].created_bar == bar_index_
                 && side_before_fill == PositionSide::FLAT;
-            const uint64_t opening_incarnation = order.incarnation;
+            const uint64_t opening_incarnation = candidate.order.incarnation;
             apply_filled_order_to_state(
-                order, candidate.order_index, candidate.fill.fill_price,
+                order_index, candidate.fill.fill_price,
                 candidate.fill.is_limit_fill, bar,
                 trail_best_path_state, exit_closed_from_bar,
                 exit_closed_from_incarnation, exit_closed_was_long,
-                filled_indices);
+                retired_incarnations);
             if (risk_max_intraday_loss_ > 0.0) {
                 // See process_pending_orders: the closing fill's own P&L is
                 // excluded at its own tick.
@@ -793,12 +839,8 @@ BacktestEngine::CoofFillResult BacktestEngine::process_next_pending_order(
             // candidate has passed through the ordinary fill kernel.
             if (group_resting_stops && position_side_ != PositionSide::FLAT) continue;
 
-            std::sort(filled_indices.begin(), filled_indices.end());
-            filled_indices.erase(
-                std::unique(filled_indices.begin(), filled_indices.end()),
-                filled_indices.end());
             compact_filled_pending_orders(
-                filled_indices, exit_closed_from_bar,
+                retired_incarnations, exit_closed_from_bar,
                 exit_closed_from_incarnation,
                 exit_closed_was_long);
             finish_intraday_loss_cancel();
@@ -817,12 +859,8 @@ BacktestEngine::CoofFillResult BacktestEngine::process_next_pending_order(
             return result;
         }
 
-        std::sort(filled_indices.begin(), filled_indices.end());
-        filled_indices.erase(
-            std::unique(filled_indices.begin(), filled_indices.end()),
-            filled_indices.end());
         compact_filled_pending_orders(
-            filled_indices, exit_closed_from_bar,
+            retired_incarnations, exit_closed_from_bar,
             exit_closed_from_incarnation,
             exit_closed_was_long);
         if (result.filled) {
@@ -4527,12 +4565,10 @@ bool BacktestEngine::same_bar_market_close_artifact_is_live(
         return false;
     }
     const std::string target_id = order.id.substr(kClosePrefix.size());
-    if (pending_orders_.empty()
-        || &order < pending_orders_.data()
-        || &order >= pending_orders_.data() + pending_orders_.size()) {
-        return false;
-    }
-    const size_t self = static_cast<size_t>(&order - pending_orders_.data());
+    const auto live = std::find_if(pending_orders_.begin(), pending_orders_.end(),
+        [&](const PendingOrder& pending) { return same_pending_order(pending, order); });
+    if (live == pending_orders_.end()) return false;
+    const size_t self = static_cast<size_t>(live - pending_orders_.begin());
     for (size_t j = self + 1; j < pending_orders_.size(); ++j) {
         const PendingOrder& sib = pending_orders_[j];
         if (sib.type == OrderType::MARKET
@@ -4756,17 +4792,21 @@ void BacktestEngine::invalidate_pending_flat_market_pair(int64_t created_seq) {
 // cleaned out. Opposite-direction-prep stops armed during a previous
 // position cycle survive (probe 93).
 void BacktestEngine::compact_filled_pending_orders(
-        const std::vector<size_t>& filled_indices,
+        std::vector<uint64_t>& retired_incarnations,
         int exit_closed_from_bar,
         uint64_t exit_closed_from_incarnation,
         bool exit_closed_was_long) {
-    if (filled_indices.empty()) return;
-    // filled_indices is built by push_back(i) with i strictly increasing over
-    // the inner fill loop (at most one push per iteration), so it is already
-    // sorted ascending with no duplicates. A binary search over the vector
-    // replaces a per-call hash-table build for the membership test below.
-    auto is_filled = [&](size_t idx) {
-        return std::binary_search(filled_indices.begin(), filled_indices.end(), idx);
+    if (retired_incarnations.empty()) return;
+    // Fill/path order need not be incarnation order (replacement preserves
+    // priority). Sort the identity ledger, never infer retirement from a slot
+    // that an immediate OCA cancellation may have shifted or erased.
+    std::sort(retired_incarnations.begin(), retired_incarnations.end());
+    retired_incarnations.erase(
+        std::unique(retired_incarnations.begin(), retired_incarnations.end()),
+        retired_incarnations.end());
+    auto is_filled = [&](uint64_t incarnation) {
+        return std::binary_search(retired_incarnations.begin(), retired_incarnations.end(),
+                                  incarnation);
     };
     PositionSide closed_side =
         exit_closed_was_long ? PositionSide::LONG : PositionSide::SHORT;
@@ -4784,7 +4824,7 @@ void BacktestEngine::compact_filled_pending_orders(
         // (they MUST stay in lockstep): a same-direction entry co-queued on the
         // close's own call bar survives ONLY if it was within the pyramiding cap
         // at placement. A co-queued STOP that does NOT fill on the close bar
-        // reaches compaction without ever entering filled_indices, so without
+        // reaches compaction without ever entering retired_incarnations, so without
         // this term it would be wiped here even though classify spared it (the
         // reverted M1 hit exactly this — R-KEEP-stop failed under a classify-only
         // fix). Over-cap co-queues and ordinary different-ID prior-bar carries
@@ -4808,7 +4848,7 @@ void BacktestEngine::compact_filled_pending_orders(
             && !resting_limit_entry_carry
             // round 8 family S, rule 2 (lockstep with classify_order_eligibility).
             && !pending_orders_[read].sbmt_kept_over_cap;
-        if (!is_filled(read)
+        if (!is_filled(pending_orders_[read].incarnation)
             && !stale_same_direction_entry_after_exit) {
             if (write != read) pending_orders_[write] = std::move(pending_orders_[read]);
             ++write;
@@ -5255,7 +5295,6 @@ bool BacktestEngine::stop_entry_margin_admission_declines(
 // cancellation, and tracks the same-direction-after-exit cleanup that
 // the post-loop compaction needs to mirror.
 void BacktestEngine::apply_filled_order_to_state(
-        PendingOrder& order,
         size_t order_index,
         double fill_price,
         bool fill_is_limit,
@@ -5264,9 +5303,18 @@ void BacktestEngine::apply_filled_order_to_state(
         int& exit_closed_from_bar,
         uint64_t& exit_closed_from_incarnation,
         bool& exit_closed_was_long,
-        std::vector<size_t>& filled_indices,
+        std::vector<uint64_t>& retired_incarnations,
         bool flat_dual_stop_pair) {
-    const bool inherits_pooc_close_fill =
+    PendingOrder matched_order;
+    bool inherits_pooc_close_fill;
+    // Admission decisions shared with post-dispatch opening ownership. They
+    // are fill-local values, independent of the pending vector's lifetime.
+    bool admitted_flat_on_frozen_sizing_price = false;
+    bool admitted_flat_on_price_gap_band = false;
+    bool will_trigger_cap = false;
+    {
+    PendingOrder& order = pending_orders_.at(order_index);
+    inherits_pooc_close_fill =
         intraday_cap_count_pooc_full_close_fills_
         && order.incarnation != 0
         && order.incarnation
@@ -5276,7 +5324,7 @@ void BacktestEngine::apply_filled_order_to_state(
             intraday_cap_pooc_close_inheritor_incarnation_ = 0;
         }
         invalidate_pending_flat_market_pair(order.created_seq);
-        filled_indices.push_back(order_index);
+        retired_incarnations.push_back(order.incarnation);
     };
     // design-declined-reversal-close-leg: a close flagged by the reversal
     // decline is Removed by classify_order_eligibility in the ordinary kernel,
@@ -5303,15 +5351,6 @@ void BacktestEngine::apply_filled_order_to_state(
     if (order.dormant_bracket && !dormant_bracket_trail_leg_live(order)) {
         return;
     }
-    // Fill-local proof that KI-54 admitted this order as a flat open on its
-    // frozen sizing price. Merely carrying a snapshot is insufficient: true
-    // reversals are admitted on their actual fill, and paired reentries may
-    // fill from flat despite having been placed from a live position.
-    bool admitted_flat_on_frozen_sizing_price = false;
-    // This call only: a true-flat positive gap admitted on rounded price
-    // still needs its existing opening-margin checkpoint after the fill.
-    bool admitted_flat_on_price_gap_band = false;
-
     if (order.type == OrderType::MARKET || order.type == OrderType::ENTRY) {
         PositionSide requested = order.is_long ? PositionSide::LONG : PositionSide::SHORT;
         bool is_opposite_entry =
@@ -5774,8 +5813,9 @@ void BacktestEngine::apply_filled_order_to_state(
             if (index != order_index
                 && (pending_orders_[index].type != OrderType::EXIT
                     || pending_orders_[index].id.compare(0, kClosePrefix.size(), kClosePrefix) != 0
-                    || std::find(filled_indices.begin(), filled_indices.end(), index)
-                           == filled_indices.end())) {
+                    || std::find(retired_incarnations.begin(), retired_incarnations.end(),
+                                 pending_orders_[index].incarnation)
+                           == retired_incarnations.end())) {
                 return false;
             }
         }
@@ -6339,7 +6379,6 @@ void BacktestEngine::apply_filled_order_to_state(
     //   - Second impl recharged the counter after each cap-cycle so
     //     multiple cap-closes fired per chart-day (3459 engine vs
     //     1957 TV trades on 97b — 43% over-count).
-    bool will_trigger_cap = false;
     if (max_intraday_filled_orders_ > 0) {
         const int64_t cur_day = intraday_order_day_key();
         if (cur_day != intraday_day_) {
@@ -6370,7 +6409,13 @@ void BacktestEngine::apply_filled_order_to_state(
             (intraday_fill_count_ >= max_intraday_filled_orders_);
     }
 
-    filled_indices.push_back(order_index);
+    retired_incarnations.push_back(order.incarnation);
+    // Admission updates above belong to the live object. From dispatch on,
+    // keep an owned matched value: entry cleanup and OCA may erase/move book
+    // elements before trade metadata and cap handling finish using this order.
+    matched_order = order;
+    }
+    PendingOrder& order = matched_order;
 
     // Track trades before fill to set exit_comment/exit_id on new trades
     size_t trades_before = trades_.size();
@@ -6868,7 +6913,7 @@ void BacktestEngine::apply_filled_order_to_state(
         }
         if (!pyramid_entries_.empty()) {
             reconcile_deferred_layered_exits(
-                pyramid_entries_.back().entry_id, filled_indices);
+                pyramid_entries_.back().entry_id, retired_incarnations);
         }
     }
 
@@ -6890,7 +6935,7 @@ void BacktestEngine::apply_filled_order_to_state(
         && (order.type == OrderType::MARKET
             || order.type == OrderType::ENTRY
             || order.type == OrderType::RAW_ORDER)) {
-        reconcile_deferred_layered_exits(order.id, filled_indices);
+        reconcile_deferred_layered_exits(order.id, retired_incarnations);
     }
 
     if (position_side_ == PositionSide::FLAT) {
@@ -7108,7 +7153,7 @@ bool BacktestEngine::replaced_percent_short_market_is_live(
         return false;
     }
     for (const PendingOrder& other : pending_orders_) {
-        if (&other == &order) continue;
+        if (same_pending_order(other, order)) continue;
         if (other.type == OrderType::EXIT) {
             const bool bracket = std::isfinite(other.stop_price)
                 || std::isfinite(other.limit_price)
@@ -7828,7 +7873,7 @@ void BacktestEngine::apply_exit_order_fill(PendingOrder& order, double fill_pric
 
 void BacktestEngine::reconcile_deferred_layered_exits(
         const std::string& entry_id,
-        std::vector<std::size_t>& zero_reservation_indices) {
+        std::vector<uint64_t>& zero_reservation_incarnations) {
     if (entry_id.empty()) return;
     const double live_pos = position_qty_;
     if (live_pos <= kQtyEpsilon) return;
@@ -7887,7 +7932,7 @@ void BacktestEngine::reconcile_deferred_layered_exits(
             o.trail_points = std::numeric_limits<double>::quiet_NaN();
             o.trail_price = std::numeric_limits<double>::quiet_NaN();
             o.trail_offset = std::numeric_limits<double>::quiet_NaN();
-            zero_reservation_indices.push_back(i);
+            zero_reservation_incarnations.push_back(o.incarnation);
             continue;
         }
         o.qty = res;
@@ -8039,9 +8084,9 @@ void BacktestEngine::materialize_relative_exit_prices_for_live_position() {
 // the reversal would have flipped, must not fire either (the pre-fix engine let
 // it fill and went flat, then re-entered on a later mid-span signal TV no-ops).
 // Flag every matching pending close; classify_order_eligibility and the
-// apply-time guard then Remove it from both fill kernels. NEVER erase
-// pending_orders_ in place and NEVER push later indices into filled_indices
-// here — that would corrupt the fill loop / compaction binary-search invariant.
+// apply-time guard then Remove it from both fill kernels. Keep this as in-place
+// suppression: later classification/admission must observe the same predicate
+// and retire each affected incarnation at its existing checkpoint.
 //
 // Binding (design doc item 3, verified against the actual queue_deferred_close_
 // order / strategy.close conventions):

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -486,7 +486,9 @@ double BacktestEngine::cover_samebar_market_adds_on_exit(const PendingOrder& ord
 
 
 // Internal helper: cancel OCA group members (except the one that just filled)
-void BacktestEngine::cancel_oca_group(const std::string& oca_name, const std::string& exclude_id) {
+void BacktestEngine::cancel_oca_group(std::string oca_name, std::string exclude_id) {
+    // Direct callers may borrow both strings from the vector being erased.
+    // Value parameters keep membership/exclusion stable throughout remove_if.
     if (oca_name.empty()) return;
     pending_orders_.erase(
         std::remove_if(pending_orders_.begin(), pending_orders_.end(),
@@ -503,8 +505,8 @@ void BacktestEngine::cancel_oca_group(const std::string& oca_name, const std::st
 // Siblings using default sizing (qty == NaN) cannot have a meaningful
 // per-order qty applied at place time, so we conservatively cancel them
 // (this matches the prior, blanket-cancel behaviour for that subset).
-void BacktestEngine::reduce_oca_group(const std::string& oca_name,
-                                      const std::string& exclude_id,
+void BacktestEngine::reduce_oca_group(std::string oca_name,
+                                      std::string exclude_id,
                                       double filled_qty) {
     if (oca_name.empty()) return;
     if (!(filled_qty > 0.0)) return;  // nothing to subtract

--- a/src/engine_run.cpp
+++ b/src/engine_run.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <limits>
 #include <stdexcept>
 #include <unordered_set>
 
@@ -16,6 +17,43 @@ namespace pineforge {
 using namespace internal;
 
 namespace {
+[[noreturn]] void reject_chart_bar(int index, const char* rule) {
+    throw std::invalid_argument("chart bar[" + std::to_string(index) + "]." + rule);
+}
+
+// Structural admission only: no price-domain, grid, calendar or financial
+// arithmetic policy. Scan the entire supplied array before any run mutation.
+// Each public run() calls this once; run_tf_impl receives validated input.
+void validate_chart_bars(const Bar* bars, int n) {
+    if (n < 0) throw std::invalid_argument("chart bar count must be non-negative");
+    if (n > 0 && bars == nullptr)
+        throw std::invalid_argument("chart bars must be non-null for a nonempty array");
+    for (int i = 0; i < n; ++i) {
+        const Bar& bar = bars[i];
+        if (!std::isfinite(bar.open)) reject_chart_bar(i, "open must be finite");
+        if (!std::isfinite(bar.high)) reject_chart_bar(i, "high must be finite");
+        if (!std::isfinite(bar.low)) reject_chart_bar(i, "low must be finite");
+        if (!std::isfinite(bar.close)) reject_chart_bar(i, "close must be finite");
+        if (bar.low > std::min(bar.open, bar.close))
+            reject_chart_bar(i, "low must not exceed open or close");
+        if (bar.high < std::max(bar.open, bar.close))
+            reject_chart_bar(i, "high must not be below open or close");
+        // NaN is unavailable activity, distinct from a known zero total.
+        if (!std::isnan(bar.volume) && (!std::isfinite(bar.volume) || bar.volume < 0))
+            reject_chart_bar(i, "volume must be non-negative finite or NaN (unavailable)");
+        if (i > 0) {
+            const int64_t previous = bars[i - 1].timestamp;
+            if (bar.timestamp <= previous)
+                reject_chart_bar(i, "timestamp must be strictly increasing");
+            // With increasing signed values, a difference can overflow only
+            // when the previous timestamp is negative. This addition is safe;
+            // do not subtract the timestamps before checking representability.
+            if (previous < 0 && bar.timestamp > std::numeric_limits<int64_t>::max() + previous)
+                reject_chart_bar(i, "timestamp delta exceeds int64 range");
+        }
+    }
+}
+
 // ABI v4 live-runtime surface (task 4): installs this run's forced path
 // order as the thread-local internal::bar_path_uses_high_first override for
 // exactly the duration of the scope, restoring whatever override value was
@@ -911,6 +949,8 @@ void BacktestEngine::run(const Bar* bars, int n) {
     last_error_.clear();
     last_run_status_ = 0;
     abort_requested_.store(false, std::memory_order_relaxed);
+    try {
+    validate_chart_bars(bars, n);
     if (n > 0 && bars != nullptr) {
         last_bar_time_ = bars[n - 1].timestamp;
         last_bar_index_ = n - 1;
@@ -922,7 +962,6 @@ void BacktestEngine::run(const Bar* bars, int n) {
     // order for exactly the duration of this call (see the file-scope
     // PathOrderScope above).
     PathOrderScope path_order_scope(path_order_mode_);
-    try {
     if (!account_currency_fx_timestamps_.empty() && calc_on_order_fills_) {
         throw std::runtime_error(
             "timestamped account-currency FX does not support calc_on_order_fills");
@@ -1476,8 +1515,15 @@ void BacktestEngine::run(const Bar* input_bars, int n_input,
     last_error_.clear();
     last_run_status_ = 0;
     abort_requested_.store(false, std::memory_order_relaxed);
+    try {
+    validate_chart_bars(input_bars, n_input);
     run_tf_impl(input_bars, n_input, input_tf, script_tf, bar_magnifier,
                 magnifier_samples, magnifier_dist);
+    } catch (const std::exception& e) {
+        last_error_ = e.what();
+    } catch (...) {
+        last_error_ = "unknown error during BacktestEngine::run";
+    }
 }
 
 void BacktestEngine::run_tf_impl(const Bar* input_bars, int n_input,
@@ -2253,6 +2299,7 @@ void BacktestEngine::run(const Bar* input_bars, int n_input,
     // calls consume it once the bar loop actually starts.
     abort_requested_.store(false, std::memory_order_relaxed);
     try {
+    validate_chart_bars(input_bars, n_input);
     // Store syminfo and inputs
     syminfo_ = syminfo;
     syminfo_mintick_ = syminfo.mintick;

--- a/src/engine_stream.cpp
+++ b/src/engine_stream.cpp
@@ -24,6 +24,7 @@ Bar price_point(double price, double volume, int64_t timestamp) {
 bool BacktestEngine::stream_begin(const Bar* warmup_bars, int n_warmup,
                                   const std::string& input_tf,
                                   const std::string& script_tf) {
+    const StreamPhase phase_before_begin = stream_phase_;
     last_error_.clear();
     try {
         if (calc_on_order_fills_) {
@@ -128,15 +129,22 @@ bool BacktestEngine::stream_begin(const Bar* warmup_bars, int n_warmup,
         barstate_islast_ = true;
         return true;
     } catch (const std::exception& e) {
-        stream_warmup_mode_ = false;
-        stream_phase_ = StreamPhase::IDLE;
-        stream_observe_actions_ = false;
+        // An already-running stream always rejects before warmup or setup.
+        // Reporting that rejection must not terminate its existing lifecycle.
+        // Failures after starting a new setup retain the discard/replay rule.
+        if (phase_before_begin != StreamPhase::REALTIME) {
+            stream_warmup_mode_ = false;
+            stream_phase_ = StreamPhase::IDLE;
+            stream_observe_actions_ = false;
+        }
         last_error_ = e.what();
         return false;
     } catch (...) {
-        stream_warmup_mode_ = false;
-        stream_phase_ = StreamPhase::IDLE;
-        stream_observe_actions_ = false;
+        if (phase_before_begin != StreamPhase::REALTIME) {
+            stream_warmup_mode_ = false;
+            stream_phase_ = StreamPhase::IDLE;
+            stream_observe_actions_ = false;
+        }
         last_error_ = "unknown error during BacktestEngine::stream_begin";
         return false;
     }
@@ -230,13 +238,17 @@ bool BacktestEngine::stream_push_tick(const TradeTick& tick) {
                 tick.price, tick.quantity, stream_next_input_open_ms_);
             stream_has_input_bar_ = true;
         } else {
+            // Validate accumulation before touching OHLC as well as volume.
+            // A rejected update must not poison this interval or consume its
+            // timestamp/sequence. A new interval takes the fresh-bar branch.
+            const double accumulated_volume = stream_input_bar_.volume + tick.quantity;
+            if (!std::isfinite(accumulated_volume)) {
+                throw std::runtime_error("stream tick volume overflow");
+            }
             stream_input_bar_.high = std::max(stream_input_bar_.high, tick.price);
             stream_input_bar_.low = std::min(stream_input_bar_.low, tick.price);
             stream_input_bar_.close = tick.price;
-            stream_input_bar_.volume += tick.quantity;
-            if (!std::isfinite(stream_input_bar_.volume)) {
-                throw std::runtime_error("stream tick volume overflow");
-            }
+            stream_input_bar_.volume = accumulated_volume;
         }
 
         stream_last_price_ = tick.price;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    test_bulk_preflight
     test_opening_obligation
     test_high_value_price_admission
     test_integer_opening_budget
@@ -75,6 +76,7 @@ set(TEST_SOURCES
     test_engine_trade_accessors
     test_engine_risk
     test_strategy_oca
+    test_pending_order_identity
     test_oca_raw_pyramid_add
     test_strategy_pyramiding
     test_pyramiding_count_partial_drain
@@ -195,6 +197,7 @@ set(TEST_SOURCES
     test_dropped_reversal_mc_first
     test_percent_equity_open_entry_fee
     test_streaming
+    test_stream_preflight_rejections
     test_calc_on_order_fills
     test_coof_cascade_eligibility
     test_coof_open_recalc_context

--- a/tests/test_bracket_lifecycle_declined_reversal.cpp
+++ b/tests/test_bracket_lifecycle_declined_reversal.cpp
@@ -279,7 +279,7 @@ private:
 static std::vector<Bar> short_mc_bars(const Bar& post_event_bar) {
     return {
         mk(1000, 100, 100, 100, 100),                 // bar0: place S
-        mk(2000, 100, 101,  99,  90),                 // bar1: S fills @100; arm
+        mk(2000, 100, 101,  90,  90),                 // bar1: S fills @100; low includes signal close
         mk(3000,  91,  91,  91,  91),                 // bar2: L declines; kill
         mk(4000, 165, 170, 160, 168),                 // bar3: MC partial @170
         post_event_bar,                               // bar4

--- a/tests/test_bulk_preflight.cpp
+++ b/tests/test_bulk_preflight.cpp
@@ -1,0 +1,317 @@
+// Structural chart-input admission, independent of strategy/broker decisions.
+// --baseline-safe runs only a finite malformed tail, never null/extreme-time UB.
+#include <pineforge/engine.hpp>
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <iomanip>
+#include <limits>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+int failures = 0;
+int rejections = 0;
+#define CHECK(x) do { if (!(x)) { std::fprintf(stderr, "FAIL line %d: %s\n", __LINE__, #x); ++failures; } } while (0)
+
+void write_bar(std::ostream& out, const Bar& b) {
+    out << b.open << ',' << b.high << ',' << b.low << ',' << b.close
+        << ',' << b.volume << ',' << b.timestamp << ';';
+}
+bool same_number(double a, double b) {
+    return (std::isnan(a) && std::isnan(b)) || a == b;
+}
+bool same_bar(const Bar& a, const Bar& b) {
+    return same_number(a.open, b.open) && same_number(a.high, b.high)
+        && same_number(a.low, b.low) && same_number(a.close, b.close)
+        && same_number(a.volume, b.volume) && a.timestamp == b.timestamp;
+}
+class Probe final : public BacktestEngine {
+public:
+    int preparations = 0;
+    int configurations = 0;
+    int callbacks = 0;
+    bool abort_on_prepare = false;
+    bool throw_on_prepare = false;
+    std::vector<Bar> observed;
+    void prepare_script_run(const Bar*, int, bool) override {
+        ++preparations;
+        observed.clear();
+        if (abort_on_prepare) request_abort();
+        if (throw_on_prepare) throw std::runtime_error("sentinel preparation failure");
+    }
+    void configure_security_evaluators() override { ++configurations; }
+    void on_bar(const Bar& b) override { ++callbacks; observed.push_back(b); }
+    bool abort_pending() const { return abort_requested_.load(std::memory_order_relaxed); }
+    size_t curve_size() const { return equity_curve_.size(); }
+    double capital() const { return initial_capital_; }
+    double pointvalue() const { return syminfo_.pointvalue; }
+    std::string input_value() const { return get_input_string("audit_value", ""); }
+    void seed_retained_queues() {
+        PendingOrder order{};
+        order.id = "retained";
+        pending_orders_.push_back(order);
+        StreamOrderAction action{};
+        action.sequence = 42;
+        action.order_id = "retained";
+        stream_order_actions_.push_back(action);
+    }
+    // Owned values, not raw object bytes or a hash-only state oracle.
+    std::string snapshot() const {
+        std::ostringstream out;
+        out << std::hexfloat << preparations << ',' << configurations << ',' << callbacks << ';';
+        for (const auto& b : observed) write_bar(out, b);
+        out << '|' << initial_capital_ << ',' << pyramiding_ << ',' << slippage_
+            << ',' << commission_value_ << ',' << static_cast<int>(commission_type_)
+            << ',' << default_qty_value_ << ',' << static_cast<int>(default_qty_type_)
+            << ',' << process_orders_on_close_ << ',' << calc_on_order_fills_
+            << ',' << close_entries_rule_any_ << ',' << qty_step_ << ',' << syminfo_mintick_;
+        for (const auto& s : {syminfo_.ticker, syminfo_.tickerid, syminfo_.currency,
+             syminfo_.basecurrency, syminfo_.type, syminfo_.timezone, syminfo_.session,
+             syminfo_.volumetype, syminfo_.description}) out << '|' << s;
+        out << '|' << syminfo_.mintick << ',' << syminfo_.pointvalue << ',' << syminfo_.qty_step;
+        for (const auto& kv : std::map<std::string, std::string>(inputs_.begin(), inputs_.end()))
+            out << '|' << kv.first << '=' << kv.second;
+        out << '|' << input_tf_ << ',' << script_tf_ << ',' << security_input_tf_
+            << ',' << script_tf_seconds_ << ',' << bar_magnifier_enabled_
+            << ',' << magnifier_samples_ << ',' << static_cast<int>(magnifier_dist_)
+            << ',' << bar_index_ << ',' << last_bar_index_ << ',' << last_bar_time_
+            << ',' << diag_input_bars_processed_ << ',' << diag_script_bars_processed_
+            << ',' << diag_magnifier_sub_bars_processed_ << ',' << diag_magnifier_sample_ticks_processed_
+            << ',' << diag_script_tf_ratio_ << ',' << diag_needs_aggregation_;
+        write_bar(out, current_bar_);
+        for (const auto* series : {&_src_open_, &_src_high_, &_src_low_, &_src_close_, &_src_volume_}) {
+            out << '|' << series->size() << ':';
+            for (int i = 0; i < series->size(); ++i) out << (*series)[i] << ',';
+        }
+        out << '|' << equity_curve_.size();
+        for (const auto& e : equity_curve_) out << ';' << e.time_ms << ',' << e.equity << ',' << e.open_profit;
+        out << '|' << trades_.size() << ',' << range_end_trades_.size()
+            << ',' << signed_position_size() << ',' << position_entry_price_ << ',' << net_profit_sum_;
+        for (const auto& o : pending_orders_) out << '|' << o.id << ',' << o.qty;
+        for (const auto& a : stream_order_actions_) out << '|' << a.sequence << ',' << a.order_id;
+        for (const auto h : broker_state_hashes_) out << '|' << h;
+        out << '|' << stream_state_hash(); // supplementary, includes stream/aggregator cursors
+        return out.str();
+    }
+};
+
+enum class Route { Single, TF, Auto, Aggregate, Magnifier, Full, FullAuto, FullAggregate, FullMagnifier };
+const Route routes[] = {Route::Single, Route::TF, Route::Auto, Route::Aggregate, Route::Magnifier,
+                       Route::Full, Route::FullAuto, Route::FullAggregate, Route::FullMagnifier};
+const char* name(Route r) {
+    const char* names[] = {"single", "tf", "auto", "aggregate", "magnifier", "full", "full-auto", "full-aggregate", "full-magnifier"};
+    return names[static_cast<int>(r)];
+}
+bool aggregated(Route r) { return r == Route::Aggregate || r == Route::FullAggregate; }
+void invoke(Probe& p, Route r, const Bar* bars, int n) {
+    if (r == Route::Single) { p.run(bars, n); return; }
+    const bool autodetect = r == Route::Auto || r == Route::FullAuto;
+    const bool magnifier = r == Route::Magnifier || r == Route::FullMagnifier;
+    const std::string input_tf = autodetect ? "" : "1";
+    const std::string script_tf = autodetect ? "" : (aggregated(r) ? "3" : "1");
+    if (r < Route::Full) {
+        p.run(bars, n, input_tf, script_tf, magnifier);
+    } else {
+        SymInfo symbol;
+        symbol.ticker = "changed";
+        symbol.pointvalue = 50;
+        symbol.mintick = 0.25;
+        symbol.qty_step = 0.5;
+        StrategyOverrides overrides;
+        overrides.initial_capital = 54321;
+        overrides.commission_value = 0.2;
+        overrides.commission_type = 0;
+        overrides.default_qty_value = 2;
+        overrides.default_qty_type = 0;
+        overrides.pyramiding = 2;
+        overrides.slippage = 1;
+        overrides.process_orders_on_close = 1;
+        overrides.calc_on_order_fills = 0;
+        overrides.close_entries_rule = 1;
+        p.run(bars, n, input_tf, script_tf, {{"audit_value", "changed"}}, symbol,
+              &overrides, magnifier);
+    }
+}
+std::vector<Bar> bars(int n) {
+    std::vector<Bar> result;
+    for (int i = 0; i < n; ++i)
+        result.push_back(Bar{100.0+i, 102.0+i, 99.0+i, 101.0+i, 1.0+i, int64_t(i)*60000});
+    return result;
+}
+void seed(Probe& p) {
+    p.set_input("audit_value", "original");
+    p.set_broker_state_hash_recording(true);
+    const Bar prior[] = {{20,22,19,21,1,600000}, {21,23,20,22,2,660000}, {22,24,21,23,3,720000}};
+    p.run(prior, 3);
+    CHECK(p.last_error().empty());
+    p.seed_retained_queues();
+}
+void rejected(Route r, const Bar* data, int n, const std::string& rule, bool seeded = true) {
+    Probe p;
+    if (seeded) seed(p);
+    p.request_abort(); // idle request must be cleared once, even on rejection
+    const auto before = p.snapshot();
+    invoke(p, r, data, n);
+    if (p.last_error().find(rule) == std::string::npos || before != p.snapshot()) {
+        std::fprintf(stderr, "route=%s n=%d expected=%s error=%s state_equal=%d\n",
+                     name(r), n, rule.c_str(), p.last_error().c_str(), before == p.snapshot());
+    }
+    CHECK(p.last_error().find(rule) != std::string::npos);
+    CHECK(p.snapshot() == before);
+    CHECK(!p.abort_pending());
+    CHECK(p.last_run_status() == 0);
+    CHECK(std::string(strategy_get_last_error(&p)) == p.last_error());
+    ++rejections;
+}
+void safe_tail_failure() {
+    auto input = bars(257);
+    input.back().high = input.back().close - 1;
+    for (auto r : routes) rejected(r, input.data(), int(input.size()), "bar[256].high");
+}
+void malformed_matrix() {
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    const double inf = std::numeric_limits<double>::infinity();
+    double Bar::*fields[] = {&Bar::open, &Bar::high, &Bar::low, &Bar::close};
+    const char* names[] = {"open", "high", "low", "close"};
+    for (auto r : routes) {
+        auto input = bars(257);
+        rejected(r, nullptr, 1, "bars");
+        rejected(r, nullptr, 2, "bars");
+        rejected(r, input.data(), -1, "count");
+        rejected(r, nullptr, -1, "count");
+        for (int pos : {0, 128, 256}) {
+            const auto good = input[pos];
+            const auto prefix = "bar[" + std::to_string(pos) + "].";
+            for (int f = 0; f < 4; ++f) for (double v : {nan, inf, -inf}) {
+                input[pos] = good;
+                input[pos].*fields[f] = v;
+                rejected(r, input.data(), int(input.size()), prefix + names[f]);
+            }
+            for (double v : {-1.0, inf, -inf}) {
+                input[pos] = good;
+                input[pos].volume = v;
+                rejected(r, input.data(), int(input.size()), prefix + "volume");
+            }
+            const Bar shapes[] = {{102,101,100,103,3,good.timestamp}, {102,104,103,103,3,good.timestamp},
+                {103,104,102,101,3,good.timestamp}, {103,102,100,101,3,good.timestamp},
+                {102,100,104,103,3,good.timestamp}};
+            for (const auto& bad : shapes) {
+                input[pos] = bad;
+                rejected(r, input.data(), int(input.size()), prefix);
+            }
+            input[pos] = good;
+        }
+        input[256].timestamp = input[255].timestamp;
+        rejected(r, input.data(), int(input.size()), "bar[256].timestamp");
+        --input[256].timestamp;
+        rejected(r, input.data(), int(input.size()), "bar[256].timestamp");
+        const Bar extreme[] = {{1,1,1,1,0,std::numeric_limits<int64_t>::min()},
+                               {1,1,1,1,0,std::numeric_limits<int64_t>::max()}};
+        rejected(r, extreme, 2, "bar[1].timestamp");
+        const Bar crossing[] = {{1,1,1,1,0,-1}, {1,1,1,1,0,std::numeric_limits<int64_t>::max()}};
+        rejected(r, crossing, 2, "bar[1].timestamp");
+        auto short_input = bars(3);
+        short_input[2].low = short_input[2].high + 1;
+        rejected(r, short_input.data(), 3, "bar[2].", false);
+    }
+}
+void positive_controls() {
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    const Bar controls[] = {{0,0,0,0,0,0}, {-10,-8,-12,-9,nan,0},
+        {100.003,100.007,100.001,100.005,0.125,0},
+        {100,102,99,101,std::numeric_limits<double>::max(),0}};
+    for (auto r : routes) {
+        for (const auto& b : controls) {
+            Probe p;
+            invoke(p, r, &b, 1);
+            CHECK(p.last_error().empty());
+            CHECK(p.preparations == 1);
+            if (!aggregated(r)) {
+                CHECK(p.observed.size() == 1);
+                if (p.observed.size() == 1) CHECK(same_bar(p.observed[0], b));
+            }
+        }
+        auto input = bars(3);
+        input[0].volume = 0;
+        input[1].volume = 0.125;
+        input[2].volume = nan;
+        Probe p;
+        invoke(p, r, input.data(), 3);
+        CHECK(p.last_error().empty());
+        CHECK(p.observed.size() == (aggregated(r) ? 1u : 3u));
+        if (!aggregated(r) && p.observed.size() == 3)
+            for (size_t i = 0; i < input.size(); ++i) CHECK(same_bar(p.observed[i], input[i]));
+        if (aggregated(r) && p.observed.size() == 1) {
+            CHECK(p.observed[0].open == 100 && p.observed[0].close == 103);
+            CHECK(std::isnan(p.observed[0].volume));
+        }
+        input[2].timestamp = 240000;
+        invoke(p, r, input.data(), 3);
+        CHECK(p.last_error().empty()); // gaps admitted; existing aggregation semantics retained
+        input = bars(2);
+        input[0].timestamp = -120000;
+        input[1].timestamp = -60000;
+        invoke(p, r, input.data(), 2);
+        CHECK(p.last_error().empty()); // modest pre-epoch domain, no extreme-calendar claim
+        seed(p);
+        invoke(p, r, nullptr, 0);
+        CHECK(p.last_error().empty());
+        CHECK(p.observed.empty() && p.curve_size() == 0);
+        invoke(p, r, input.data(), 0);
+        CHECK(p.last_error().empty());
+        CHECK(p.observed.empty() && p.curve_size() == 0);
+        if (r >= Route::Full) CHECK(p.pointvalue() == 50 && p.capital() == 54321 && p.input_value() == "changed");
+    }
+}
+void abort_and_error_transport() {
+    auto input = bars(6);
+    for (auto r : routes) {
+        Probe p;
+        p.request_abort();
+        invoke(p, r, input.data(), 6);
+        CHECK(p.last_error().empty() && p.last_run_status() == 0);
+        p.abort_on_prepare = true;
+        const auto count = p.callbacks;
+        invoke(p, r, input.data(), 6);
+        CHECK(p.last_error().empty() && p.last_run_status() == 1);
+        CHECK(p.callbacks == count);
+        p.abort_on_prepare = false;
+        p.throw_on_prepare = true;
+        invoke(p, r, input.data(), 6);
+        CHECK(p.last_error() == "sentinel preparation failure");
+        CHECK(p.last_run_status() == 0);
+        p.throw_on_prepare = false;
+        invoke(p, r, input.data(), 6);
+        CHECK(p.last_error().empty() && p.last_run_status() == 0);
+    }
+}
+} // namespace
+int main(int argc, char** argv) {
+    if (argc == 2 && std::strcmp(argv[1], "--valid-receipt") == 0) {
+        const auto input = bars(6);
+        for (auto r : routes) {
+            Probe p;
+            invoke(p, r, input.data(), int(input.size()));
+            CHECK(p.last_error().empty());
+            std::printf("%s %s\n", name(r), p.snapshot().c_str());
+        }
+        return failures ? 1 : 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--controls") == 0) {
+        positive_controls();
+        abort_and_error_transport();
+        return failures ? 1 : 0;
+    }
+    safe_tail_failure();
+    if (!(argc == 2 && std::strcmp(argv[1], "--baseline-safe") == 0)) {
+        malformed_matrix();
+        positive_controls();
+        abort_and_error_transport();
+    }
+    std::printf("bulk preflight: %d rejection cases, %d failures\n", rejections, failures);
+    return failures ? 1 : 0;
+}

--- a/tests/test_dropped_reversal_mc_first.cpp
+++ b/tests/test_dropped_reversal_mc_first.cpp
@@ -608,7 +608,7 @@ void test_synth_no_deficit_dormant_stop_waits() {
     const std::vector<Bar> bars = synth_bars({
         {100.00, 100.20, 99.80, 100.00},   // [0]
         {100.00, 100.20, 99.80, 100.00},   // [1] signal close
-        {100.00, 100.30, 99.70, 100.50},   // [2] entry bar @100.00; reversal signal
+        {100.00, 100.50, 99.70, 100.50},   // [2] entry bar @100.00; high includes reversal signal close
         {101.40, 101.50, 100.20, 100.30},  // [3] reversal declined at 101.40; stop level 101.00 already gapped through
         {100.40, 101.20, 100.10, 100.50},  // [4] the fresh re-issued stop fills at its level 101.00
         {100.00, 100.20, 99.80, 100.00},   // [5]
@@ -644,7 +644,7 @@ std::vector<Bar> synth_e2_bars() {
     return synth_bars({
         {100.00, 100.20, 99.80, 100.00},   // [0]
         {100.00, 100.20, 99.80, 100.00},   // [1] signal close (short)
-        {100.00, 100.30, 99.70, 100.50},   // [2] entry bar @100.00; reversal signal at its close
+        {100.00, 100.50, 99.70, 100.50},   // [2] entry bar @100.00; high includes reversal signal close
         {101.50, 114.00, 100.80, 112.00},  // [3] the declined-reversal bar (low first)
         {110.00, 111.00, 109.00, 110.00},  // [4]
         {110.00, 110.20, 109.80, 110.00},  // [5]
@@ -766,7 +766,7 @@ void test_synth_admitted_pair_purges_held_bracket() {
     const std::vector<Bar> bars = synth_bars({
         {100.00, 100.20, 99.80, 100.00},   // [0]
         {100.00, 100.20, 99.80, 100.00},   // [1] signal close (short)
-        {100.00, 100.30, 99.70, 100.50},   // [2] entry bar @100.00; reversal signal at its close
+        {100.00, 100.50, 99.70, 100.50},   // [2] entry bar @100.00; high includes reversal signal close
         {100.20, 100.60, 99.90, 100.40},   // [3] the pair is admitted at 100.20
         {100.40, 105.50, 100.10, 105.00},  // [4] a live "X" would fill @105.00 here
         {105.00, 105.20, 104.80, 105.00},  // [5]

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -282,7 +282,7 @@ static void test_request_security_gaps_on_emits_na_between_completions() {
         {102.0, 103.0, 101.0, 102.0, 50, 2'700'000},
         {103.0, 104.0, 102.0, 103.0, 50, 3'600'000},  // first 60m completion
         {104.0, 105.0, 103.0, 104.0, 50, 4'500'000},
-        {105.0, 106.0, 104.0, 105.0, 50, 3900'000},
+        {105.0, 106.0, 104.0, 105.0, 50, 5'400'000},
         {106.0, 107.0, 105.0, 106.0, 50, 6'300'000},
         {107.0, 108.0, 106.0, 107.0, 50, 7'200'000},  // second 60m completion
     };
@@ -290,6 +290,7 @@ static void test_request_security_gaps_on_emits_na_between_completions() {
 
     const auto& seen = strat.seen();
     CHECK(seen.size() == 8);
+    if (seen.size() != 8) return; // Keep the failed size check; avoid invalid indexing.
     CHECK(std::isnan(seen[0]));
 
     bool saw_non_nan = false;

--- a/tests/test_pending_order_identity.cpp
+++ b/tests/test_pending_order_identity.cpp
@@ -1,0 +1,485 @@
+// Native literal lifecycle fixtures. No Pine, market files, reference trades,
+// or generated expected results. RAW quantity/fee policy is deliberately fixed.
+#include <pineforge/engine.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+const double missing = std::numeric_limits<double>::quiet_NaN();
+#define REQUIRE(x) do { if (!(x)) throw std::runtime_error( \
+    std::string(__func__) + ":" + std::to_string(__LINE__) + ": " #x); } while (false)
+
+Bar point(double price, int index) {
+    return {price, price, price, price, 1, int64_t(index) * 60000};
+}
+
+// Test-only access to private helper calls, including aliased string arguments.
+// Explicit member-pointer instantiation avoids changing the production class
+// definition or redefining access keywords in standard/library headers.
+template<class Tag, typename Tag::Type Member>
+struct PrivateMember {
+    friend typename Tag::Type access(Tag) { return Member; }
+};
+struct Cancel {
+#ifdef PF_IDENTITY_BASELINE
+    using Type = void (BacktestEngine::*)(const std::string&, const std::string&);
+#else
+    using Type = void (BacktestEngine::*)(std::string, std::string);
+#endif
+    friend Type access(Cancel);
+};
+template struct PrivateMember<Cancel, &BacktestEngine::cancel_oca_group>;
+struct Reduce {
+#ifdef PF_IDENTITY_BASELINE
+    using Type = void (BacktestEngine::*)(const std::string&, const std::string&, double);
+#else
+    using Type = void (BacktestEngine::*)(std::string, std::string, double);
+#endif
+    friend Type access(Reduce);
+};
+template struct PrivateMember<Reduce, &BacktestEngine::reduce_oca_group>;
+struct Refresh {
+    using Type = void (BacktestEngine::*)(size_t, size_t);
+    friend Type access(Refresh);
+};
+template struct PrivateMember<Refresh, &BacktestEngine::stream_refresh_action_metadata>;
+#ifndef PF_IDENTITY_BASELINE
+struct Retire {
+    using Type = void (BacktestEngine::*)(std::vector<uint64_t>&, int, uint64_t, bool);
+    friend Type access(Retire);
+};
+template struct PrivateMember<Retire, &BacktestEngine::compact_filled_pending_orders>;
+#endif
+
+class Book final : public BacktestEngine {
+public:
+    using BacktestEngine::open_trade_entry_id;
+    Book() {
+        initial_capital_ = 100000;
+        pyramiding_ = 10;
+        margin_long_ = margin_short_ = 0;
+        current_bar_ = point(100, 0);
+        bar_index_ = 0;
+    }
+    void on_bar(const Bar&) override {}
+    void seed(bool long_side, double qty = 2) {
+        strategy_order("seed", long_side, qty);
+        current_bar_ = point(100, 1);
+        bar_index_ = 1;
+        process_pending_orders(current_bar_);
+        REQUIRE(position_qty_ == qty);
+        REQUIRE(pending_orders_.empty());
+        REQUIRE(broker_fill_event_seq_ == 1);
+        stream_observe_actions_ = true;
+    }
+    uint64_t raw(const std::string& id, bool buy, double qty, double limit,
+                 double stop, const std::string& group = "", int oca = 0) {
+        strategy_order(id, buy, qty, limit, stop, group, oca);
+        auto& o = pending_orders_.back();
+        REQUIRE(o.id == id && o.incarnation != 0);
+        o.comment = "comment for " + id;
+        return o.incarnation;
+    }
+    uint64_t passive(const std::string& id, bool long_side, double qty,
+                     const std::string& group = "", int oca = 0) {
+        return raw(id, long_side, qty, missing, long_side ? 120 : 80, group, oca);
+    }
+    uint64_t winner(bool long_side, int oca, double qty = 2,
+                    const std::string& id = "A") {
+        return raw(id, !long_side, qty, long_side ? 110 : 90, missing, "G", oca);
+    }
+    uint64_t unrelated(bool long_side) {
+        return raw("C", long_side, 7, long_side ? 80 : 120, missing);
+    }
+    void entry_winner() {
+        strategy_entry("A", true, missing, 110, 1, "comment for A", "G", 1);
+    }
+    void default_market_entry() {
+        strategy_entry("A", true, missing, missing, missing, "comment for A", "G", 1);
+    }
+    void step(bool coof, bool long_side, int index = 2, uint64_t expected_events = 1) {
+        // All priced objects have phase 1; source order remains [B,A,C],
+        // while only A is touched. COOF gets a monotonic remaining segment.
+        current_bar_ = long_side ? Bar{100, 115, 100, 115, 1, int64_t(index)*60000}
+                                 : Bar{100, 100, 85, 85, 1, int64_t(index)*60000};
+        bar_index_ = index;
+        const auto first_action = stream_order_actions_.size();
+        const auto first_trade = trades_.size();
+        calc_on_order_fills_ = coof;
+        if (coof) {
+            coof_scheduler_active_ = true;
+            coof_evaluating_path_segment_ = true;
+            coof_hist_is_segment_ = true;
+            int closed_bar = -1;
+            uint64_t closed_incarnation = 0;
+            bool was_long = false;
+            auto result = process_next_pending_order(current_bar_, true,
+                closed_bar, closed_incarnation, was_long);
+            REQUIRE(result.filled && result.fill_events == expected_events);
+            REQUIRE(result.fill_price == (long_side ? 110 : 90));
+            coof_scheduler_active_ = false;
+            coof_evaluating_path_segment_ = false;
+            coof_hist_is_segment_ = false;
+        } else {
+            process_pending_orders(current_bar_);
+        }
+        (this->*access(Refresh{}))(first_action, first_trade);
+    }
+    void at_point(bool coof, double price, int index) {
+        current_bar_ = point(price, index);
+        bar_index_ = index;
+        calc_on_order_fills_ = coof;
+        const auto a = stream_order_actions_.size(), t = trades_.size();
+        if (coof) {
+            int closed = -1;
+            uint64_t incarnation = 0;
+            bool side = false;
+            process_next_pending_order(current_bar_, true, closed, incarnation, side);
+        } else process_pending_orders(current_bar_);
+        (this->*access(Refresh{}))(a, t);
+    }
+    std::vector<std::string> ids() const {
+        std::vector<std::string> result;
+        for (const auto& o : pending_orders_) result.push_back(o.id);
+        return result;
+    }
+    PendingOrder get(const std::string& id) const {
+        for (const auto& o : pending_orders_) if (o.id == id) return o;
+        throw std::runtime_error("missing pending " + id);
+    }
+    uint64_t fills() const { return broker_fill_event_seq_; }
+    double size() const { return position_qty_; }
+    PositionSide side() const { return position_side_; }
+    const std::vector<Trade>& closed() const { return trades_; }
+    void expect_A(bool long_side) const {
+        REQUIRE(position_side_ == PositionSide::FLAT);
+        REQUIRE(broker_fill_event_seq_ == 2);
+        REQUIRE(trades_.size() == 1);
+        REQUIRE(trades_[0].qty == 2);
+        REQUIRE(trades_[0].exit_price == (long_side ? 110 : 90));
+        REQUIRE(trades_[0].pnl == 20);
+        REQUIRE(trades_[0].exit_id == "A");
+        REQUIRE(trades_[0].exit_comment == "comment for A");
+        REQUIRE(stream_order_actions_.size() == 1);
+        const auto& a = stream_order_actions_.front();
+        REQUIRE(!a.is_entry && a.is_long == long_side && a.quantity == 2);
+        REQUIRE(a.order_id == "A" && a.comment == "comment for A");
+    }
+    void direct_cancel(size_t index) {
+        (this->*access(Cancel{}))(pending_orders_.at(index).oca_name, pending_orders_.at(index).id);
+    }
+    void direct_reduce(size_t index, double qty) {
+        (this->*access(Reduce{}))(pending_orders_.at(index).oca_name, pending_orders_.at(index).id, qty);
+    }
+    void cancel(const std::string& id) { strategy_cancel(id); }
+    void set_capacity(int value) { pyramiding_ = value; }
+    void set_cap(int value) { max_intraday_filled_orders_ = value; }
+    void observe() { stream_observe_actions_ = true; }
+    void fee(CommissionType kind, double value) { commission_type_ = kind; commission_value_ = value; }
+#ifndef PF_IDENTITY_BASELINE
+    void retire(const std::vector<uint64_t>& ids) {
+        auto owned_ids = ids;
+        (this->*access(Retire{}))(owned_ids, -1, 0, false);
+    }
+#endif
+};
+
+void cancel_shape(bool coof, bool long_side, int shape) {
+    Book b;
+    b.seed(long_side);
+    if (shape != 1) b.passive("B", long_side, 1, "G", 1);
+    if (shape == 2) b.passive("D", long_side, 1, "G", 1);
+    const auto a = b.winner(long_side, 1);
+    if (shape == 1) b.passive("B", long_side, 1, "G", 1);
+    if (shape == 2) b.passive("E", long_side, 1, "G", 1);
+    const auto c = b.unrelated(long_side);
+    if (shape == 0) REQUIRE(b.ids() == (std::vector<std::string>{"B", "A", "C"}));
+    b.step(coof, long_side);
+    b.expect_A(long_side);
+    REQUIRE(b.ids() == (std::vector<std::string>{"C"}));
+    REQUIRE(b.get("C").incarnation == c && c != a);
+    b.at_point(coof, long_side ? 80 : 120, 3);
+    REQUIRE(b.ids().empty());
+    REQUIRE(b.fills() == 3 && b.size() == 7);
+    REQUIRE(b.side() == (long_side ? PositionSide::LONG : PositionSide::SHORT));
+    REQUIRE(b.closed().size() == 1); // matched A cannot refill
+    REQUIRE(b.stream_order_action_at(1).order_id == "C");
+    REQUIRE(b.stream_order_action_at(1).entry_incarnation == c);
+}
+
+void reduce_shape(bool coof, bool long_side) {
+    Book b;
+    b.seed(long_side);
+    b.passive("B", long_side, 1, "G", 2);
+    b.passive("D", long_side, 2, "G", 2);
+    b.winner(long_side, 2);
+    const auto e = b.passive("E", long_side, 5, "G", 2);
+    b.passive("default", long_side, missing, "G", 2);
+    const auto c = b.unrelated(long_side);
+    b.step(coof, long_side);
+    b.expect_A(long_side);
+    REQUIRE(b.ids() == (std::vector<std::string>{"E", "C"}));
+    REQUIRE(b.get("E").qty == 3 && b.get("E").incarnation == e);
+    REQUIRE(b.get("C").qty == 7 && b.get("C").incarnation == c);
+}
+
+void no_effect_before_winner(bool coof) {
+    Book b;
+    b.seed(true);
+    b.set_capacity(1);
+    b.raw("B", true, 1, missing, missing, "G", 1); // matched, capped add
+    b.raw("A", false, 2, missing, missing, "G", 1);
+    b.unrelated(true);
+    REQUIRE(b.ids() == (std::vector<std::string>{"B", "A", "C"}));
+    b.at_point(coof, 100, 2);
+    REQUIRE(b.ids() == (std::vector<std::string>{"C"}));
+    REQUIRE(b.fills() == 2 && b.closed().size() == 1);
+    REQUIRE(b.closed()[0].exit_id == "A" && b.closed()[0].qty == 2);
+    REQUIRE(b.closed()[0].exit_comment == "comment for A");
+}
+
+void continue_after_erasure(bool coof) {
+    Book b;
+    b.seed(true);
+    b.set_capacity(1);
+    b.raw("B", true, 1, missing, missing, "G", 1);
+    b.raw("A", false, 2, missing, missing, "G", 1);
+    const auto c = b.raw("C", true, 7, missing, missing);
+    b.at_point(coof, 100, 2);
+    if (coof) {
+        REQUIRE(b.ids() == (std::vector<std::string>{"C"}));
+        REQUIRE(b.fills() == 2);
+        b.at_point(coof, 100, 2);
+    }
+    REQUIRE(b.ids().empty() && b.fills() == 3 && b.size() == 7);
+    REQUIRE(b.closed().size() == 1 && b.closed()[0].exit_id == "A");
+    REQUIRE(b.stream_order_actions_len() == 2);
+    REQUIRE(b.stream_order_action_at(1).entry_incarnation == c);
+}
+
+void no_effect_oca_then_live_candidate(bool coof) {
+    Book b;
+    b.set_capacity(1);
+    b.raw("seed", true, 2, missing, missing);
+    b.raw("B", true, 1, missing, missing, "G", 1);
+    b.default_market_entry();
+    b.raw("D", true, 1, missing, missing, "G", 1);
+    const auto c = b.raw("C", true, 3, missing, 110);
+    // Seed through the real one-fill entry point. All later orders were
+    // genuinely placed from flat; C's existing priced-add exception admits it.
+    b.at_point(true, 100, 1);
+    REQUIRE(b.fills() == 1 && b.size() == 2);
+    REQUIRE(b.ids() == (std::vector<std::string>{"B", "A", "D", "C"}));
+    b.observe();
+    // B and A are capped no-effects. Established OCA semantics still cancel
+    // B/D for default-sized A; no broker event means COOF must continue to C
+    // in this SAME candidate batch after the erase, not return/re-discover it.
+    b.step(coof, true);
+    REQUIRE(b.fills() == 2 && b.size() == 5 && b.ids().empty());
+    REQUIRE(b.closed().empty());
+    REQUIRE(b.stream_order_actions_len() == 1);
+    REQUIRE(b.stream_order_action_at(0).order_id == "C");
+    REQUIRE(b.stream_order_action_at(0).entry_incarnation == c);
+    REQUIRE(b.stream_order_action_at(0).quantity == 3);
+    REQUIRE(b.stream_order_action_at(0).price == 110);
+}
+
+void post_oca_cap_metadata(bool coof) {
+    Book b;
+    b.observe();
+    b.set_cap(1);
+    b.passive("B", true, 1, "G", 1);
+    b.entry_winner();
+    b.passive("C", true, 7);
+    REQUIRE(b.ids() == (std::vector<std::string>{"B", "A", "C"}));
+    b.step(coof, true, 2, 2);
+    REQUIRE(b.ids() == (std::vector<std::string>{"C"}));
+    REQUIRE(b.side() == PositionSide::FLAT && b.fills() == 2);
+    REQUIRE(b.closed().size() == 1);
+    REQUIRE(b.closed()[0].entry_id == "A");
+    REQUIRE(b.closed()[0].entry_price == 110 && b.closed()[0].exit_price == 115);
+    REQUIRE(b.closed()[0].pnl == 5);
+    REQUIRE(b.closed()[0].exit_id.empty());
+    REQUIRE(b.closed()[0].exit_comment == "Close Position (Max number of filled orders in one day)");
+    REQUIRE(b.stream_order_actions_len() == 2);
+    REQUIRE(b.stream_order_action_at(0).order_id == "A");
+    REQUIRE(b.stream_order_action_at(0).comment == "comment for A");
+    REQUIRE(b.stream_order_action_at(1).price == 115);
+}
+
+void direct_helpers(bool reduce) {
+    Book b;
+    b.passive("earlier", true, 2, "G", 1);
+    b.passive("A", true, 2, "G", 1);
+    b.passive("other group", true, 9, "H", 1);
+    b.passive("later", true, 1, "G", 1);
+    b.passive("survivor", true, 5, "G", 1);
+    if (reduce) {
+        const auto before = b.ids();
+        b.direct_reduce(1, 0);
+        REQUIRE(b.ids() == before && b.get("earlier").qty == 2);
+        b.direct_reduce(1, -1);
+        REQUIRE(b.ids() == before);
+        b.direct_reduce(1, 2);
+        REQUIRE(b.ids() == (std::vector<std::string>{"A", "other group", "survivor"}));
+        REQUIRE(b.get("survivor").qty == 3);
+    } else {
+        b.direct_cancel(1);
+        REQUIRE(b.ids() == (std::vector<std::string>{"A", "other group"}));
+    }
+    // No active-pass switch may delay direct helper visibility.
+    REQUIRE(b.get("A").qty == 2 && b.get("other group").qty == 9);
+    REQUIRE(b.fills() == 0);
+}
+
+void replacement_and_retirement(bool coof) {
+    Book b;
+    b.seed(true);
+    b.passive("B", true, 1, "G", 1);
+    const auto old_a = b.winner(true, 1);
+    const auto priority = b.get("A").created_seq;
+    b.unrelated(true);
+    const auto replacement = b.winner(true, 1);
+    REQUIRE(replacement != old_a && b.get("A").created_seq == priority);
+    // Replacement is appended with retained priority; fill sorting must not
+    // mistake declaration/incarnation order for execution/retirement order.
+    REQUIRE(b.ids() == (std::vector<std::string>{"B", "C", "A"}));
+#ifndef PF_IDENTITY_BASELINE
+    b.retire({old_a});
+    REQUIRE(b.get("A").incarnation == replacement);
+#endif
+    b.step(coof, true);
+    b.expect_A(true);
+    REQUIRE(b.ids() == (std::vector<std::string>{"C"}));
+    b.cancel("C");
+    const auto fresh = b.raw("A", false, 1, missing, missing);
+    REQUIRE(fresh != replacement && fresh != old_a);
+#ifndef PF_IDENTITY_BASELINE
+    b.retire({replacement, old_a, replacement});
+    REQUIRE(b.get("A").incarnation == fresh);
+#endif
+    b.at_point(coof, 100, 3);
+    REQUIRE(b.ids().empty() && b.fills() == 3);
+    REQUIRE(b.side() == PositionSide::SHORT && b.size() == 1);
+    REQUIRE(b.stream_order_action_at(1).entry_incarnation == fresh);
+}
+
+void untouched_ordering(bool coof) {
+    Book b;
+    b.raw("one", true, 1, missing, missing);
+    b.raw("two", true, 2, missing, missing);
+    b.raw("three", true, 3, missing, missing);
+    b.at_point(coof, 100, 1);
+    if (coof) {
+        REQUIRE(b.fills() == 1 && b.ids() == (std::vector<std::string>{"two", "three"}));
+        b.at_point(coof, 100, 1);
+        REQUIRE(b.fills() == 2 && b.ids() == (std::vector<std::string>{"three"}));
+        b.at_point(coof, 100, 1);
+    }
+    REQUIRE(b.fills() == 3 && b.size() == 6 && b.ids().empty());
+    REQUIRE(b.open_trade_entry_id(0) == "one");
+    REQUIRE(b.open_trade_entry_id(1) == "two");
+    REQUIRE(b.open_trade_entry_id(2) == "three");
+}
+
+void fee_control(bool coof, CommissionType fee, double expected) {
+    Book b;
+    b.fee(fee, fee == CommissionType::PERCENT ? 1 : 2);
+    b.seed(true);
+    b.passive("B", true, 1, "G", 1);
+    b.winner(true, 1);
+    b.unrelated(true);
+    b.step(coof, true);
+    REQUIRE(b.ids() == (std::vector<std::string>{"C"}));
+    REQUIRE(b.closed().size() == 1 && b.closed()[0].commission == expected);
+    REQUIRE(b.closed()[0].pnl == 20 - expected);
+    REQUIRE(b.closed()[0].exit_id == "A");
+}
+
+class CallbackBook final : public BacktestEngine {
+public:
+    int observed_close_callbacks = 0;
+    uint64_t replaced = 0, fresh = 0;
+    CallbackBook() {
+        initial_capital_ = 100000;
+        pyramiding_ = 10;
+        margin_long_ = margin_short_ = 0;
+        calc_on_order_fills_ = true;
+    }
+    void on_bar(const Bar&) override {
+        if (coof_fill_recalc_active_) {
+            if (trades_.size() == 1 && observed_close_callbacks == 0) {
+                REQUIRE(position_side_ == PositionSide::FLAT);
+                REQUIRE(pending_orders_.size() == 1 && pending_orders_[0].id == "C");
+                REQUIRE(trades_[0].exit_id == "A");
+                ++observed_close_callbacks;
+                strategy_order("A", false, 1); // same label, new object in callback
+                fresh = pending_orders_.back().incarnation;
+                REQUIRE(fresh != 0 && fresh != replaced);
+            }
+            return;
+        }
+        if (bar_index_ == 0) strategy_order("seed", true, 2);
+        if (bar_index_ == 1) {
+            strategy_order("B", true, 1, missing, 120, "G", 1);
+            strategy_order("A", false, 2, 110, missing, "G", 1);
+            replaced = pending_orders_.back().incarnation;
+            strategy_order("C", true, 7, 80);
+        }
+    }
+    void verify() const {
+        REQUIRE(observed_close_callbacks == 1 && fresh != replaced);
+        REQUIRE(trades_.size() == 1 && broker_fill_event_seq_ == 3);
+        REQUIRE(position_side_ == PositionSide::SHORT && position_qty_ == 1);
+        REQUIRE(pending_orders_.size() == 1 && pending_orders_[0].id == "C");
+        REQUIRE(pyramid_entries_.size() == 1 && pyramid_entries_[0].entry_incarnation == fresh);
+    }
+};
+void actual_coof_callback() {
+    CallbackBook b;
+    const Bar bars[] = {point(100, 0), point(100, 1),
+        {100, 115, 95, 105, 1, 120000}, point(105, 3)};
+    b.run(bars, 4);
+    b.verify();
+}
+} // namespace
+
+int main(int argc, char** argv) {
+    int failed = 0, passed = 0;
+    const std::string filter = argc > 1 ? argv[1] : "";
+    auto check = [&](const std::string& name, const std::function<void()>& body) {
+        if (!filter.empty() && name.find(filter) == std::string::npos) return;
+        try { body(); ++passed; std::cout << "PASS " << name << '\n'; }
+        catch (const std::exception& e) { ++failed; std::cerr << "FAIL " << name << ": " << e.what() << '\n'; }
+    };
+    for (bool coof : {false, true}) {
+        const std::string mode = coof ? "coof" : "normal";
+        for (bool long_side : {false, true}) {
+            const std::string prefix = mode + (long_side ? "/long" : "/short");
+            for (int shape = 0; shape < 3; ++shape)
+                check(prefix + "/cancel/" + std::to_string(shape), [&] { cancel_shape(coof, long_side, shape); });
+            check(prefix + "/reduce", [&] { reduce_shape(coof, long_side); });
+        }
+        check(mode + "/no-effect-before-winner", [&] { no_effect_before_winner(coof); });
+        check(mode + "/continue-after-erasure", [&] { continue_after_erasure(coof); });
+        check(mode + "/no-effect-oca-then-live-candidate", [&] { no_effect_oca_then_live_candidate(coof); });
+        check(mode + "/post-oca-cap-metadata", [&] { post_oca_cap_metadata(coof); });
+        check(mode + "/replacement-retirement", [&] { replacement_and_retirement(coof); });
+        check(mode + "/untouched-order", [&] { untouched_ordering(coof); });
+        check(mode + "/fixed-fee-control", [&] { fee_control(coof, CommissionType::CASH_PER_ORDER, 4); });
+        check(mode + "/percent-fee-control", [&] { fee_control(coof, CommissionType::PERCENT, 4.2); });
+        check(mode + "/per-contract-fee-control", [&] { fee_control(coof, CommissionType::CASH_PER_CONTRACT, 8); });
+    }
+    check("direct/cancel-borrowed-selectors", [&] { direct_helpers(false); });
+    check("direct/reduce-borrowed-selectors", [&] { direct_helpers(true); });
+    check("coof/actual-callback-reissue", actual_coof_callback);
+    std::cout << passed << " passed; " << failed << " failed\n";
+    return failed || !passed ? 1 : 0;
+}

--- a/tests/test_percent_equity_open_entry_fee.cpp
+++ b/tests/test_percent_equity_open_entry_fee.cpp
@@ -32,14 +32,14 @@ bool near(double lhs, double rhs, double tolerance = 1e-9) {
     return std::abs(lhs - rhs) <= tolerance;
 }
 
-Bar bar(double price) {
+Bar bar(double price, int64_t timestamp = 2000) {
     Bar result;
     result.open = price;
     result.high = price;
     result.low = price;
     result.close = price;
     result.volume = 1.0;
-    result.timestamp = 2000;
+    result.timestamp = timestamp;
     return result;
 }
 
@@ -315,7 +315,7 @@ void test_margin_ledger_is_independent_of_default_percent() {
 
 void test_fifo_partial_scales_surviving_paid_fee_snapshot() {
     PartialFeeSnapshotProbe probe;
-    const Bar bars[] = {bar(100.0), bar(100.0), bar(100.0)};
+    const Bar bars[] = {bar(100.0, 2000), bar(100.0, 62000), bar(100.0, 122000)};
     probe.run(bars, 3);
 
     CHECK(near(probe.remaining_qty, 6.0));
@@ -328,7 +328,7 @@ void test_fifo_partial_scales_surviving_paid_fee_snapshot() {
 
 void test_percent_typed_reversal_does_not_double_debit_old_fee() {
     PercentTypedReversalProbe probe;
-    const Bar bars[] = {bar(100.0), bar(100.0)};
+    const Bar bars[] = {bar(100.0, 2000), bar(100.0, 62000)};
     probe.run(bars, 2);
 
     CHECK(probe.trade_count() == 1);

--- a/tests/test_stream_preflight_rejections.cpp
+++ b/tests/test_stream_preflight_rejections.cpp
@@ -1,0 +1,199 @@
+#include <pineforge/engine.hpp>
+
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+using namespace pineforge;
+
+namespace {
+int checks = 0;
+int failures = 0;
+
+#define CHECK(condition)                                                       \
+    do {                                                                       \
+        ++checks;                                                              \
+        if (!(condition)) {                                                    \
+            std::fprintf(stderr, "FAIL line %d: %s\n", __LINE__, #condition);   \
+            ++failures;                                                        \
+        }                                                                      \
+    } while (0)
+
+Bar bar(double price, int64_t timestamp, double volume = 1.0) {
+    return Bar{price, price, price, price, volume, timestamp};
+}
+
+class Probe final : public BacktestEngine {
+public:
+    std::vector<Bar> observed;
+
+    Probe() {
+        initial_capital_ = 10000;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1;
+    }
+
+    void on_bar(const Bar& value) override {
+        observed.push_back(value);
+        if (bar_index_ == 0) strategy_entry("L", true);
+        if (bar_index_ == 1) strategy_close_all();
+    }
+
+    double position() const { return signed_position_size(); }
+};
+
+struct Snapshot {
+    uint64_t stream_hash;
+    uint64_t broker_hash;
+    bool realtime;
+    double position;
+    int trades;
+    std::vector<Bar> observed;
+    std::vector<StreamOrderAction> actions;
+};
+
+Snapshot snapshot(const Probe& engine) {
+    Snapshot result{engine.stream_state_hash(), engine.broker_state_hash(),
+                    engine.stream_is_realtime(), engine.position(),
+                    engine.trade_count(), engine.observed, {}};
+    for (int i = 0; i < engine.stream_order_actions_len(); ++i)
+        result.actions.push_back(engine.stream_order_action_at(i));
+    return result;
+}
+
+void same(const Snapshot& actual, const Snapshot& expected) {
+    // Error text is a per-call diagnostic, not the economic/stream state.
+    CHECK(actual.stream_hash == expected.stream_hash);
+    CHECK(actual.broker_hash == expected.broker_hash);
+    CHECK(actual.realtime == expected.realtime);
+    CHECK(actual.position == expected.position);
+    CHECK(actual.trades == expected.trades);
+    CHECK(actual.observed.size() == expected.observed.size());
+    for (size_t i = 0; i < actual.observed.size() && i < expected.observed.size(); ++i) {
+        const auto& a = actual.observed[i];
+        const auto& b = expected.observed[i];
+        CHECK(a.timestamp == b.timestamp && a.open == b.open && a.high == b.high
+              && a.low == b.low && a.close == b.close && a.volume == b.volume);
+    }
+    CHECK(actual.actions.size() == expected.actions.size());
+    for (size_t i = 0; i < actual.actions.size() && i < expected.actions.size(); ++i) {
+        const auto& a = actual.actions[i];
+        const auto& b = expected.actions[i];
+        CHECK(a.sequence == b.sequence && a.timestamp_ms == b.timestamp_ms
+              && a.bar_index == b.bar_index && a.is_entry == b.is_entry
+              && a.is_long == b.is_long && a.quantity == b.quantity
+              && a.price == b.price && a.order_id == b.order_id
+              && a.comment == b.comment && a.entry_incarnation == b.entry_incarnation
+              && a.closed_trade_index == b.closed_trade_index);
+    }
+}
+
+void begin(Probe& engine) {
+    const Bar warmup[] = {bar(100, 0)};
+    CHECK(engine.stream_begin(warmup, 1, "1", "1"));
+}
+
+void test_rejected_begin_preserves_live_lifecycle(bool confirmed_bars,
+                                                bool invalid_arguments) {
+    Probe engine, control;
+    begin(engine);
+    begin(control);
+    if (confirmed_bars) {
+        CHECK(engine.stream_push_bar(bar(100, 60000)));
+        CHECK(control.stream_push_bar(bar(100, 60000)));
+    } else {
+        CHECK(engine.stream_push_tick({60100, 10, 100, 1}));
+        CHECK(control.stream_push_tick({60100, 10, 100, 1}));
+    }
+    CHECK(engine.position() == 1);
+    CHECK(engine.stream_order_actions_len() == 1);
+    const auto before = snapshot(engine);
+    const Bar different_warmup[] = {bar(700, 0), bar(800, 60000)};
+    CHECK(!engine.stream_begin(invalid_arguments ? nullptr : different_warmup,
+                               invalid_arguments ? -1 : 2,
+                               invalid_arguments ? "invalid" : "1", "1"));
+    CHECK(engine.last_error().find("already realtime") != std::string::npos);
+    same(snapshot(engine), before);
+
+    // The rejected setup must neither replay warmup nor disable later output.
+    bool continued;
+    if (confirmed_bars) {
+        continued = engine.stream_push_bar(bar(102, 120000));
+        CHECK(control.stream_push_bar(bar(102, 120000)));
+    } else {
+        continued = engine.stream_push_tick({60200, 11, 101, 1});
+        CHECK(control.stream_push_tick({60200, 11, 101, 1}));
+        if (continued) {
+            CHECK(engine.stream_advance_time(120000));
+            CHECK(control.stream_advance_time(120000));
+            CHECK(engine.stream_push_tick({120100, 12, 102, 1}));
+            CHECK(control.stream_push_tick({120100, 12, 102, 1}));
+        }
+    }
+    CHECK(continued);
+    if (!continued) return;  // The baseline failure is already established.
+    CHECK(engine.last_error().empty());
+    CHECK(engine.position() == 0);
+    CHECK(engine.stream_order_actions_len() == 2);
+    same(snapshot(engine), snapshot(control));
+}
+
+void test_overflow_rejection_preserves_forming_bar_and_cursors() {
+    Probe engine, control;
+    begin(engine);
+    begin(control);
+    const double largest = std::numeric_limits<double>::max();
+    CHECK(engine.stream_push_tick({60100, 10, 100, largest}));
+    CHECK(control.stream_push_tick({60100, 10, 100, largest}));
+    const auto before = snapshot(engine);
+
+    // Each quantity is finite; only this interval's aggregate is unrepresentable.
+    CHECK(!engine.stream_push_tick({60200, 11, 110, largest}));
+    CHECK(engine.last_error().find("volume overflow") != std::string::npos);
+    same(snapshot(engine), before);
+
+    // Reuse the rejected sequence and timestamp with a valid quantity. The
+    // result must equal a stream that never received the rejected input.
+    const bool continued = engine.stream_push_tick({60200, 11, 101, 0});
+    CHECK(continued);
+    if (!continued) return;
+    CHECK(control.stream_push_tick({60200, 11, 101, 0}));
+    CHECK(engine.stream_advance_time(120000));
+    CHECK(control.stream_advance_time(120000));
+    CHECK(engine.observed.size() == 2);
+    if (engine.observed.size() == 2) {
+        const auto& formed = engine.observed[1];
+        CHECK(formed.timestamp == 60000 && formed.open == 100 && formed.high == 101
+              && formed.low == 100 && formed.close == 101 && formed.volume == largest);
+    }
+    CHECK(engine.stream_push_tick({120100, 12, 102, 0}));
+    CHECK(control.stream_push_tick({120100, 12, 102, 0}));
+    CHECK(engine.stream_order_actions_len() == 2);
+    same(snapshot(engine), snapshot(control));
+}
+
+void test_new_interval_does_not_add_previous_volume() {
+    Probe engine;
+    begin(engine);
+    const double largest = std::numeric_limits<double>::max();
+    CHECK(engine.stream_push_tick({60100, 10, 100, largest}));
+    CHECK(engine.stream_push_tick({120100, 11, 101, largest}));
+    CHECK(engine.stream_advance_time(180000));
+    CHECK(engine.observed.size() == 3);
+    if (engine.observed.size() == 3) {
+        CHECK(engine.observed[1].volume == largest);
+        CHECK(engine.observed[2].volume == largest);
+    }
+}
+}  // namespace
+
+int main() {
+    for (bool bars : {false, true})
+        for (bool invalid : {false, true})
+            test_rejected_begin_preserves_live_lifecycle(bars, invalid);
+    test_overflow_rejection_preserves_forming_bar_and_cursors();
+    test_new_interval_does_not_add_previous_volume();
+    std::printf("%d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_trail_ref_entry_bar_extreme.cpp
+++ b/tests/test_trail_ref_entry_bar_extreme.cpp
@@ -354,6 +354,9 @@ void test_changed_points_restart_changed_offset_keeps() {
         {true, 1, 2314.37, "famz-trail-L-20260425-D"},
         {true, 2, 2314.43, "famz-trail-L-20260425-E"},
     };
+    // Synthetic parity padding only; retain every actual event bar below.
+    Bar short_padding = kEth1225_0645;
+    short_padding.timestamp -= 15 * 60 * 1000;
     for (const Case& c : cases) {
         // The tapes' parity: the entry bar's close carries bar_index odd.
         // Short: bars 06:45 (0), 07:00 signal (1), 07:15 entry (2) — pad one
@@ -361,7 +364,7 @@ void test_changed_points_restart_changed_offset_keeps() {
         // 00:45 entry (1).
         std::vector<Bar> bars = c.is_long
             ? std::vector<Bar>{kEth0425_0030, kEth0425_0045, kEth0425_0100, kEth0425_0115}
-            : std::vector<Bar>{kEth1225_0645, kEth1225_0645, kEth1225_0700, kEth1225_0715,
+            : std::vector<Bar>{short_padding, kEth1225_0645, kEth1225_0700, kEth1225_0715,
                                kEth1225_0730, kEth1225_0745};
         Goat p(10000.0);
         p.signal_bar = c.is_long ? 0 : 2;


### PR DESCRIPTION
Malformed historical bars could reach callbacks or reset an existing book before failing. Rejected stream initialization disabled a running lifecycle, tick-volume overflow changed the forming bar before rejection, and OCA erasure could shift pending-vector indices so an unrelated order was retired or its metadata was used for a fill.

Validate the complete historical bar array before bulk mutation, preserve the active stream and forming bar for the two rejected operations, and resolve/retire pending orders by incarnation with owned metadata across erasure. OCA cancellation remains immediately visible to fill callbacks. Five invalid native unit fixtures now use valid OHLC envelopes and chronological timestamps; their financial assertions are unchanged and were checked against both baseline and candidate.

This strengthens native input and order-lifetime contracts. C function signatures and PODs are unchanged; C++ consumers require a matching rebuild. Grading metrics, references and registry membership are unchanged.

Validation: complete native build; 262 tests passed and one existing WebSocket test skipped because this host libcurl lacks that feature. Independent Grok review of commit `d1cc7d8ec40673b5f573de30ae59d7a9fb84163c` is GREEN (P0/P1/P2: 0/0/0). Cloud experiment `exp-native-lifecycle-contracts-20260910` completed all 72 cases. The independent readback verified all 144 output payloads; all 4,190 raw CSVs, counts and grade objects match the controls (4,182 excellent / 8 strong). No malformed-input rejections or engine errors occurred in this fixed population. Earlier transient store-child test failure and successful isolated/full reruns remain recorded in the evidence pack.

Formal gate `pineforge-pr-gate-w2frc` remains **FAIL: target.not-positive**, solely because compatibility improvement is zero. Candidate snapshot: `3535c0453be9650209b7e2dbe3a7d66c733fcbed078e4d8f49a5ab8cb73808f5`. No PASS receipt or baseline promotion is claimed. The owner explicitly authorized publication of this and future native fixes under the same proof conditions despite zero parity improvement. This is an owner-approved native-correctness exception; the formal gate result remains FAIL and baseline promotion remains deferred.

Part of #227.
