### PR TITLE
Introduce native quantity actions and shared lot settlement

### DIFF
--- a/docs/pages/fill-model.md
+++ b/docs/pages/fill-model.md
@@ -87,6 +87,32 @@ captured sources can still pay their exact receiver; later unrelated adds do not
 join the capture. An old-cycle capture loses live-All authority while its ordinary
 finite reservation remains available for the normal settlement path.
 
+### Native quantity actions
+
+`order_action::plan` in `<pineforge/order_action.hpp>` resolves physical units
+against a supplied signed position. `Reduce{units}` accepts a finite,
+nonnegative magnitude, caps it at the held exposure and never opens or flips.
+`Transact{signed_units}` closes opposing exposure first and opens only its
+remaining units. For example, selling 2, 3 or 5 units against a long position
+of 3 leaves long 1, flat or short 2, respectively. A zero request is valid.
+Nonfinite values, overflow and a nonzero request lost to binary64 rounding
+produce no plan.
+
+The plan is immutable arithmetic output. It owns no position ledger, source
+policy, quantity step, cycle counter or execution permission. It does not
+authorize a delayed fill: a scheduler must revalidate its order identity and
+current book before settlement. Pending cancellation and replay receipts are
+separate lifecycle contracts.
+
+The current bridge uses this planner for partial reduction and Pine's already
+resolved frozen-transaction close/open split. The existing settlement paths
+still own FIFO lots, fees, slippage, dust thresholds and observations. A shared
+same-side lot append also keeps physical identity and metadata without
+introducing another position book. This is a prerequisite for the unified
+executor; `ShortSeedCollisionRole` and its compatibility projection remain
+until ordered actions replace all of their consumers. This change does not
+reduce the pending-order flag count or provide broker-account reconciliation.
+
 ## Opening checkpoint
 
 An accepted opening or add can create an opening-affordability checkpoint.

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -3850,6 +3850,7 @@ private:
                               bool explicit_qty_prequantized,
                               uint64_t entry_incarnation);
     void execute_market_exit(double fill_price);
+    void append_same_side_fill(PyramidEntry lot);
     // Range-end accounting: record the rows that close a position still
     // open after the final script bar at that bar's close, the way
     // TradingView's deep-backtest report does (engine_orders.cpp). Called by

--- a/include/pineforge/order_action.hpp
+++ b/include/pineforge/order_action.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <optional>
+
+namespace pineforge::order_action {
+
+struct Reduce { double units; };
+struct Transact { double signed_units; };
+
+// A pure quantity transition. The plan has no identity, queue lifetime,
+// accounting, policy or validity promise; callers apply it synchronously to
+// the authoritative position after their own preconditions pass.
+class Plan {
+public:
+    double before() const noexcept { return before_; }
+    double after() const noexcept { return after_; }
+    double close_units() const noexcept { return close_units_; }
+    double open_units() const noexcept { return open_units_; }
+    bool no_effect() const noexcept { return before_ == after_; }
+
+private:
+    friend std::optional<Plan> plan(double, Reduce) noexcept;
+    friend std::optional<Plan> plan(double, Transact) noexcept;
+    Plan(double before, double after, double close_units, double open_units) noexcept
+        : before_(before), after_(after), close_units_(close_units),
+          open_units_(open_units) {}
+    const double before_;
+    const double after_;
+    const double close_units_;
+    const double open_units_;
+};
+
+inline bool finite(double value) noexcept { return std::isfinite(value); }
+
+inline std::optional<Plan> plan(double signed_position, Reduce request) noexcept {
+    if (!finite(signed_position) || !finite(request.units) || request.units < 0.0)
+        return std::nullopt;
+    const double exposure = std::abs(signed_position);
+    const double close = std::min(request.units, exposure);
+    const double signed_close = signed_position > 0.0 ? -close
+                              : signed_position < 0.0 ? close : 0.0;
+    // The transition is deliberately one binary64 operation. A nonzero
+    // requested reduction that cannot change the representable position is
+    // refused instead of silently claiming execution.
+    const double after = signed_position + signed_close;
+    if (!finite(after) || !finite(close) || !finite(signed_close))
+        return std::nullopt;
+    if (request.units > 0.0 && signed_position != 0.0 && after == signed_position)
+        return std::nullopt;
+    return Plan(signed_position, after, close, 0.0);
+}
+
+inline std::optional<Plan> plan(double signed_position, Transact request) noexcept {
+    if (!finite(signed_position) || !finite(request.signed_units))
+        return std::nullopt;
+    // Compute the resulting position once, before decomposition. This is the
+    // authoritative native arithmetic operation; close/open are its audit
+    // decomposition and never substitute a second position calculation.
+    const double after = signed_position + request.signed_units;
+    if (!finite(after)) return std::nullopt;
+    if (request.signed_units != 0.0 && after == signed_position)
+        return std::nullopt; // nonzero request was absorbed by binary64
+
+    double close = 0.0;
+    double open = request.signed_units;
+    if (signed_position != 0.0 && request.signed_units != 0.0
+        && ((signed_position > 0.0) != (request.signed_units > 0.0))) {
+        close = std::min(std::abs(signed_position), std::abs(request.signed_units));
+        const double remainder = std::abs(request.signed_units) - close;
+        open = request.signed_units > 0.0 ? remainder : -remainder;
+    }
+    if (!finite(close) || close < 0.0 || !finite(open)) return std::nullopt;
+    return Plan(signed_position, after, close, open);
+}
+
+} // namespace pineforge::order_action

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "engine_internal.hpp"
+#include <pineforge/order_action.hpp>
 
 #include <algorithm>
 #include <cctype>
@@ -4498,14 +4499,22 @@ void BacktestEngine::apply_same_bar_market_tx_reversal(
     const PositionSide requested =
         order.is_long ? PositionSide::LONG : PositionSide::SHORT;
     const double tx = order.pine_frozen_market_instruction.transaction()->transaction_units;
-    const double close_qty = std::min(tx, position_qty_);
+    // Pine has already resolved the source instruction to physical units.
+    // Native netting owns the close/open split; this adapter retains its
+    // established dust threshold, slippage and post-fill lifecycle.
+    const double held = position_side_ == PositionSide::LONG
+        ? position_qty_ : -position_qty_;
+    const auto transaction = order_action::plan(
+        held, order_action::Transact{order.is_long ? tx : -tx});
+    if (!transaction) return;
+    const double close_qty = transaction->close_units();
     if (close_qty >= position_qty_ - kQtyEpsilon) {
         execute_market_exit(fill_price);
     } else if (close_qty > kQtyEpsilon) {
         execute_partial_exit_qty(fill_price, close_qty,
                                  PositionReductionCause::SCRIPT_ORDER);
     }
-    const double remainder = tx - close_qty;
+    const double remainder = std::abs(transaction->open_units());
     if (remainder > kQtyEpsilon && std::isfinite(fill_price)) {
         const double entry_fill = apply_fill_slippage(fill_price, order.is_long);
         open_fresh_position(requested, entry_fill, remainder, order.id,
@@ -7410,13 +7419,6 @@ void BacktestEngine::apply_exit_order_fill(PendingOrder& order, double fill_pric
         const double entry_fill = apply_fill_slippage(fill_price, /*is_buy=*/true);
         if (!std::isfinite(entry_fill) || qty <= kQtyEpsilon) return;
 
-        const double total_qty = position_qty_ + qty;
-        position_entry_price_ =
-            (position_entry_price_ * position_qty_ + entry_fill * qty)
-            / total_qty;
-        position_qty_ = total_qty;
-        ++position_entry_count_;
-        trail_best_price_ = entry_fill;
         PyramidEntry materialized{};
         materialized.price = entry_fill;
         materialized.time = current_bar_.timestamp;
@@ -7425,11 +7427,7 @@ void BacktestEngine::apply_exit_order_fill(PendingOrder& order, double fill_pric
         materialized.entry_bar_index = bar_index_;
         materialized.entry_comment = order.comment;
         materialized.entry_incarnation = order.incarnation;
-        snapshot_entry_commission(materialized);
-        pyramid_entries_.push_back(std::move(materialized));
-        if (stream_observe_actions_) stream_observe_entry(pyramid_entries_.back());
-        id_unclosed_qty_[order.id] += qty;
-        cycle_filled_entry_ids_.insert(order.id);
+        append_same_side_fill(std::move(materialized));
         return;
     }
 
@@ -7453,13 +7451,6 @@ void BacktestEngine::apply_exit_order_fill(PendingOrder& order, double fill_pric
             const double entry_fill =
                 apply_fill_slippage(fill_price, /*is_buy=*/(order.created_position_side == PositionSide::SHORT));
             if (!std::isfinite(entry_fill) || qty <= kQtyEpsilon) return;
-            const double total_qty = position_qty_ + qty;
-            position_entry_price_ =
-                (position_entry_price_ * position_qty_ + entry_fill * qty)
-                / total_qty;
-            position_qty_ = total_qty;
-            ++position_entry_count_;
-            trail_best_price_ = entry_fill;
             PyramidEntry artifact{};
             artifact.price = entry_fill;
             artifact.time = current_bar_.timestamp;
@@ -7468,11 +7459,7 @@ void BacktestEngine::apply_exit_order_fill(PendingOrder& order, double fill_pric
             artifact.entry_bar_index = bar_index_;
             artifact.entry_comment = order.comment;
             artifact.entry_incarnation = order.incarnation;
-            snapshot_entry_commission(artifact);
-            pyramid_entries_.push_back(std::move(artifact));
-            if (stream_observe_actions_) stream_observe_entry(pyramid_entries_.back());
-            id_unclosed_qty_[order.id] += qty;
-            cycle_filled_entry_ids_.insert(order.id);
+            append_same_side_fill(std::move(artifact));
             return;
         }
         sbmt_frozen_close = true;

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "engine_internal.hpp"
+#include <pineforge/order_action.hpp>
 
 #include <algorithm>
 #include <cctype>
@@ -340,7 +341,11 @@ double BacktestEngine::fifo_drain(const std::string* from_entry, double qty_limi
 void BacktestEngine::execute_partial_exit_qty(
         double fill_price, double qty_to_close, PositionReductionCause cause) {
     if (position_side_ == PositionSide::FLAT || pyramid_entries_.empty()) return;
-    qty_to_close = std::clamp(qty_to_close, 0.0, position_qty_);
+    const double held = position_side_ == PositionSide::LONG
+        ? position_qty_ : -position_qty_;
+    const auto reduction = order_action::plan(held, order_action::Reduce{qty_to_close});
+    if (!reduction) return;
+    qty_to_close = reduction->close_units();
     if (qty_to_close <= kQtyEpsilon) return;
 
     bool is_buy = (position_side_ == PositionSide::SHORT);
@@ -350,6 +355,27 @@ void BacktestEngine::execute_partial_exit_qty(
     // Close FIFO across all pyramid entries, creating trade records.
     fifo_drain(/*from_entry=*/nullptr, qty_to_close, fill_price, was_long);
     settle_position_after_partial_exit(cause);
+}
+
+
+// Settle an already resolved same-side fill as a distinct physical lot.
+// Admission, sizing, side selection and source interpretation precede this
+// seam. It neither consults a pyramiding cap nor invents a source-policy bit.
+// The caller supplies the lot's immutable label, identity and fill metadata;
+// accounting and stream observations still use the engine's sole lot ledger.
+void BacktestEngine::append_same_side_fill(PyramidEntry lot) {
+    const double total_qty = position_qty_ + lot.qty;
+    position_entry_price_ =
+        (position_entry_price_ * position_qty_ + lot.price * lot.qty) / total_qty;
+    position_qty_ = total_qty;
+    ++position_entry_count_;
+    trail_best_price_ = lot.price;
+    snapshot_entry_commission(lot);
+    pyramid_entries_.push_back(std::move(lot));
+    if (stream_observe_actions_) stream_observe_entry(pyramid_entries_.back());
+    const auto& filled = pyramid_entries_.back();
+    id_unclosed_qty_[filled.entry_id] += filled.qty;
+    cycle_filled_entry_ids_.insert(filled.entry_id);
 }
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(TEST_SOURCES
+    test_order_action
+    test_order_action_integration
     test_placement_facts
     test_order_cancellation
     test_cancellation_mirror_coverage

--- a/tests/test_order_action.cpp
+++ b/tests/test_order_action.cpp
@@ -1,0 +1,145 @@
+#include <pineforge/order_action.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+using namespace pineforge::order_action;
+
+namespace {
+int checks = 0;
+int failures = 0;
+#define CHECK(x) do { ++checks; if (!(x)) { ++failures; std::printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #x); } } while (0)
+constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
+constexpr double Inf = std::numeric_limits<double>::infinity();
+void near(double a, double b) { CHECK(std::abs(a - b) < 1e-12); }
+
+void reductions() {
+    for (double position : {5.0, -5.0, 0.0}) {
+        auto zero = plan(position, Reduce{0.0});
+        CHECK(zero.has_value());
+        if (zero) { CHECK(zero->close_units() == 0.0); CHECK(zero->open_units() == 0.0); CHECK(zero->no_effect()); }
+        auto partial = plan(position, Reduce{2.0});
+        CHECK(partial.has_value());
+        if (partial) {
+            CHECK(partial->before() == position);
+            near(partial->close_units(), position == 0.0 ? 0.0 : 2.0);
+            CHECK(partial->open_units() == 0.0);
+            near(partial->after(), position == 0.0 ? 0.0 : position > 0.0 ? 3.0 : -3.0);
+            CHECK(partial->close_units() >= 0.0);
+            CHECK(partial->after() == 0.0 || (partial->after() > 0.0) == (position > 0.0));
+        }
+        auto oversized = plan(position, Reduce{99.0});
+        CHECK(oversized.has_value());
+        if (oversized) { CHECK(oversized->before() == position); near(oversized->close_units(), std::abs(position)); near(oversized->after(), 0.0); CHECK(oversized->open_units() == 0.0); }
+    }
+    CHECK(!plan(5.0, Reduce{-1.0}));
+    CHECK(!plan(5.0, Reduce{NaN}));
+    CHECK(!plan(5.0, Reduce{Inf}));
+    CHECK(!plan(NaN, Reduce{1.0}));
+    CHECK(!plan(1.0, Reduce{std::numeric_limits<double>::denorm_min()}));
+}
+
+void transactions() {
+    struct Case { double before, delta, after, close, open; };
+    for (const auto c : {
+        Case{5.0, 2.0, 7.0, 0.0, 2.0},
+        Case{5.0, -2.0, 3.0, 2.0, 0.0},
+        Case{5.0, -5.0, 0.0, 5.0, 0.0},
+        Case{5.0, -12.0, -7.0, 5.0, -7.0},
+        Case{-5.0, -2.0, -7.0, 0.0, -2.0},
+        Case{-5.0, 2.0, -3.0, 2.0, 0.0},
+        Case{-5.0, 5.0, 0.0, 5.0, 0.0},
+        Case{-5.0, 12.0, 7.0, 5.0, 7.0},
+        Case{0.0, 3.0, 3.0, 0.0, 3.0},
+        Case{0.0, -3.0, -3.0, 0.0, -3.0},
+        Case{5.0, 0.0, 5.0, 0.0, 0.0},
+    }) {
+        auto result = plan(c.before, Transact{c.delta});
+        CHECK(result.has_value());
+        if (!result) continue;
+        CHECK(result->before() == c.before);
+        near(result->after(), c.after); near(result->close_units(), c.close); near(result->open_units(), c.open);
+        near(c.before + (c.before > 0.0 && c.delta < 0.0 ? -c.close : c.before < 0.0 && c.delta > 0.0 ? c.close : 0.0) + c.open, c.after);
+        CHECK(result->close_units() >= 0.0);
+        CHECK(result->no_effect() == (c.delta == 0.0));
+    }
+    CHECK(!plan(Inf, Transact{1.0}));
+    CHECK(!plan(1.0, Transact{NaN}));
+    CHECK(!plan(1.0, Transact{Inf}));
+    CHECK(!plan(1.0, Transact{-Inf}));
+    CHECK(!plan(std::numeric_limits<double>::max(), Transact{std::numeric_limits<double>::max()}));
+    CHECK(!plan(-std::numeric_limits<double>::max(), Transact{-std::numeric_limits<double>::max()}));
+    CHECK(!plan(1.0, Transact{std::numeric_limits<double>::denorm_min()}));
+
+    const double d = std::numeric_limits<double>::denorm_min();
+    auto sub_open = plan(0.0, Transact{d});
+    CHECK(sub_open.has_value());
+    if (sub_open) {
+        CHECK(sub_open->before() == 0.0);
+        CHECK(sub_open->after() == d);
+        CHECK(sub_open->close_units() == 0.0);
+        CHECK(sub_open->open_units() == d);
+    }
+    auto sub_reduce = plan(2.0 * d, Reduce{d});
+    CHECK(sub_reduce.has_value());
+    if (sub_reduce) {
+        CHECK(sub_reduce->before() == 2.0 * d);
+        CHECK(sub_reduce->after() == d);
+        CHECK(sub_reduce->close_units() == d);
+        CHECK(sub_reduce->open_units() == 0.0);
+    }
+    auto sub_flat = plan(2.0 * d, Transact{-2.0 * d});
+    CHECK(sub_flat.has_value());
+    if (sub_flat) {
+        CHECK(sub_flat->after() == 0.0);
+        CHECK(sub_flat->close_units() == 2.0 * d);
+        CHECK(sub_flat->open_units() == 0.0);
+    }
+    const double near_flat = std::nextafter(1.0, 0.0);
+    auto residual = plan(1.0, Transact{-near_flat});
+    CHECK(residual.has_value());
+    if (residual) {
+        CHECK(residual->after() == 1.0 - near_flat);
+        CHECK(residual->close_units() == near_flat);
+        CHECK(residual->open_units() == 0.0);
+    }
+}
+
+void symmetric_laws() {
+    for (double p : {0.25, 1.0, 5.0, 100.0}) {
+        for (double q : {0.0, 0.125, 1.0, 7.0, 200.0}) {
+            auto long_reduce = plan(p, Reduce{q});
+            auto short_reduce = plan(-p, Reduce{q});
+            CHECK(long_reduce.has_value() == short_reduce.has_value());
+            if (long_reduce && short_reduce) {
+                near(long_reduce->close_units(), short_reduce->close_units());
+                near(long_reduce->after(), -short_reduce->after());
+                CHECK(long_reduce->open_units() == 0.0 && short_reduce->open_units() == 0.0);
+            }
+            auto long_tx = plan(p, Transact{q});
+            auto short_tx = plan(-p, Transact{-q});
+            CHECK(long_tx.has_value() == short_tx.has_value());
+            if (long_tx && short_tx) {
+                near(long_tx->after(), -short_tx->after());
+                near(long_tx->close_units(), short_tx->close_units());
+                near(long_tx->open_units(), -short_tx->open_units());
+            }
+            auto long_opposite = plan(p, Transact{-q});
+            auto short_opposite = plan(-p, Transact{q});
+            CHECK(long_opposite.has_value() == short_opposite.has_value());
+            if (long_opposite && short_opposite) {
+                near(long_opposite->after(), -short_opposite->after());
+                near(long_opposite->close_units(), short_opposite->close_units());
+                near(long_opposite->open_units(), -short_opposite->open_units());
+            }
+        }
+    }
+}
+}
+
+int main() {
+    reductions(); transactions(); symmetric_laws();
+    std::printf("order action planner: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_order_action_integration.cpp
+++ b/tests/test_order_action_integration.cpp
@@ -1,0 +1,256 @@
+// Native order-action integration seams. This test does not call Engine::run,
+// load a feed, compile Pine, or compare against a reference engine.
+#include <pineforge/engine.hpp>
+#include <cstdio>
+#include <cmath>
+#include <limits>
+#include <utility>
+
+using namespace pineforge;
+
+namespace {
+int checks = 0;
+int failures = 0;
+#define CHECK(value) do { ++checks; if (!(value)) { ++failures; std::printf("FAIL %d: %s\n", __LINE__, #value); } } while (0)
+
+template<class Tag, auto Member>
+struct Access { friend auto access(Tag) { return Member; } };
+struct PartialExitAccess { friend auto access(PartialExitAccess); };
+struct SameSideAccess { friend auto access(SameSideAccess); };
+struct SameBarTransactionAccess { friend auto access(SameBarTransactionAccess); };
+template struct Access<PartialExitAccess, &BacktestEngine::execute_partial_exit_qty>;
+template struct Access<SameSideAccess, &BacktestEngine::append_same_side_fill>;
+template struct Access<SameBarTransactionAccess, &BacktestEngine::apply_same_bar_market_tx_reversal>;
+
+template<class T> struct MemberArguments;
+template<class C, class R, class A, class B, class D>
+struct MemberArguments<R (C::*)(A, B, D)> { using third = D; };
+using ReductionCause = typename MemberArguments<
+    decltype(access(PartialExitAccess{}))>::third;
+
+class Book final : public BacktestEngine {
+public:
+    Book() {
+        initial_capital_ = 10000.0;
+        commission_type_ = CommissionType::CASH_PER_CONTRACT;
+        commission_value_ = 1.0;
+        slippage_ = 0;
+        syminfo_mintick_ = 0.01;
+        current_bar_ = {100.0, 130.0, 90.0, 120.0, 1.0, 60000};
+        bar_index_ = 1;
+    }
+
+    void on_bar(const Bar&) override {}
+
+    void seed_two_lots() {
+        position_side_ = PositionSide::LONG;
+        position_cycle_seq_ = 4;
+        position_entry_price_ = 106.0;
+        position_qty_ = 5.0;
+        position_entry_count_ = 2;
+        position_open_bar_ = 0;
+        pyramid_entries_.clear();
+        PyramidEntry a{100.0, 1000, 2.0, "A", 0};
+        a.entry_incarnation = 11;
+        a.entry_commission_account = 2.0;
+        PyramidEntry b{110.0, 2000, 3.0, "B", 0};
+        b.entry_incarnation = 12;
+        b.entry_commission_account = 3.0;
+        pyramid_entries_.push_back(a);
+        pyramid_entries_.push_back(b);
+        id_unclosed_qty_.clear();
+        id_unclosed_qty_["A"] = 2.0;
+        id_unclosed_qty_["B"] = 3.0;
+        trades_.clear();
+        net_profit_sum_ = 0.0;
+        gross_profit_sum_ = 0.0;
+        gross_loss_sum_ = 0.0;
+        win_trades_count_ = loss_trades_count_ = eventrades_count_ = 0;
+    }
+
+    void seed_three_units() {
+        seed_two_lots();
+        position_qty_ = 3.0;
+        position_entry_price_ = (100.0 + 220.0) / 3.0;
+        pyramid_entries_[0].qty = 1.0;
+        pyramid_entries_[1].qty = 2.0;
+        pyramid_entries_[0].entry_commission_account = 1.0;
+        pyramid_entries_[1].entry_commission_account = 2.0;
+        id_unclosed_qty_["A"] = 1.0;
+        id_unclosed_qty_["B"] = 2.0;
+    }
+
+    void partial(double raw_price, double qty) {
+        (this->*access(PartialExitAccess{}))(raw_price, qty,
+            static_cast<ReductionCause>(0));
+    }
+
+    void append(PyramidEntry lot) {
+        (this->*access(SameSideAccess{}))(std::move(lot));
+    }
+
+    void enable_stream_actions() { stream_observe_actions_ = true; }
+    void set_slippage(int ticks) { slippage_ = ticks; }
+    void make_short() { position_side_ = PositionSide::SHORT; }
+
+    void transact(PendingOrder& order, double raw_price) {
+        double trail = std::numeric_limits<double>::quiet_NaN();
+        (this->*access(SameBarTransactionAccess{}))(order, raw_price,
+            current_bar_, trail);
+    }
+
+    const std::vector<PyramidEntry>& lots() const { return pyramid_entries_; }
+    const std::vector<Trade>& trades() const { return trades_; }
+    double signed_position() const { return signed_position_size(); }
+    PositionSide side() const { return position_side_; }
+    int64_t cycle() const { return position_cycle_seq_; }
+    int stream_actions() const { return stream_order_actions_len(); }
+};
+
+void reduce_preserves_fifo_identity_and_scales_survivor() {
+    Book book;
+    book.seed_two_lots();
+    book.partial(120.0, 3.0);
+
+    CHECK(book.trades().size() == 2);
+    CHECK(book.trades()[0].entry_id == "A");
+    CHECK(book.trades()[0].qty == 2.0);
+    CHECK(book.trades()[1].entry_id == "B");
+    CHECK(book.trades()[1].qty == 1.0);
+    CHECK(book.lots().size() == 1);
+    CHECK(book.lots()[0].entry_id == "B");
+    CHECK(book.lots()[0].entry_incarnation == 12);
+    CHECK(book.lots()[0].qty == 2.0);
+    CHECK(book.lots()[0].entry_commission_account == 2.0);
+    CHECK(book.signed_position() == 2.0);
+    CHECK(book.cycle() == 4);
+
+    Book zero;
+    zero.seed_two_lots();
+    zero.partial(120.0, 0.0);
+    CHECK(zero.trades().empty() && zero.signed_position() == 5.0);
+    zero.partial(120.0, -1.0);
+    CHECK(zero.trades().empty() && zero.signed_position() == 5.0);
+    zero.partial(120.0, std::numeric_limits<double>::quiet_NaN());
+    CHECK(zero.trades().empty() && zero.signed_position() == 5.0);
+
+    Book oversized;
+    oversized.seed_two_lots();
+    oversized.partial(120.0, 99.0);
+    CHECK(oversized.signed_position() == 0.0);
+    CHECK(oversized.lots().empty());
+    CHECK(oversized.trades().size() == 2);
+}
+
+void reduce_handles_short_side_and_slippage_once() {
+    Book book;
+    book.seed_two_lots();
+    book.make_short();
+    book.set_slippage(2);
+    book.partial(120.0, 2.0);
+    CHECK(book.signed_position() == -3.0);
+    CHECK(book.trades().size() == 1);
+    CHECK(!book.trades()[0].is_long);
+    CHECK(book.trades()[0].exit_price == 121.0);
+
+    Book long_side;
+    long_side.seed_two_lots();
+    long_side.set_slippage(2);
+    long_side.partial(120.0, 2.0);
+    CHECK(long_side.trades().size() == 1);
+    CHECK(long_side.trades()[0].exit_price == 119.0);
+}
+
+void append_preserves_lot_metadata_and_stream_action() {
+    Book book;
+    book.seed_two_lots();
+    book.enable_stream_actions();
+    PyramidEntry lot{120.0, 3000, 1.0, "C", 1};
+    lot.entry_comment = "native add";
+    lot.entry_incarnation = 13;
+    lot.market_pyramid_add = false;
+    book.append(lot);
+
+    CHECK(book.lots().size() == 3);
+    CHECK(book.lots().back().entry_id == "C");
+    CHECK(book.lots().back().entry_incarnation == 13);
+    CHECK(!book.lots().back().market_pyramid_add);
+    CHECK(book.lots().back().entry_commission_account == 1.0);
+    CHECK(book.signed_position() == 6.0);
+    CHECK(book.stream_actions() == 1);
+    CHECK(book.stream_order_action_at(0).is_entry);
+    CHECK(book.stream_order_action_at(0).quantity == 1.0);
+    CHECK(book.stream_order_action_at(0).entry_incarnation == 13);
+}
+
+PendingOrder transaction_order(bool is_long, double own, double total) {
+    PendingOrder order{};
+    order.id = is_long ? "BUY" : "SELL";
+    order.type = OrderType::MARKET;
+    order.is_long = is_long;
+    order.incarnation = 44;
+    order.pine_frozen_market_instruction =
+        PineFrozenMarketInstruction::transaction(own, total);
+    return order;
+}
+
+void transact_closes_fifo_and_crosses_flat() {
+    Book partial;
+    partial.seed_three_units();
+    auto sell_two = transaction_order(false, 2.0, 2.0);
+    partial.transact(sell_two, 120.0);
+    CHECK(partial.signed_position() == 1.0);
+    CHECK(partial.trades().size() == 1);
+    CHECK(partial.trades()[0].qty == 1.0);
+    CHECK(partial.trades()[0].entry_id == "A");
+
+    Book stream;
+    stream.seed_three_units();
+    stream.enable_stream_actions();
+    auto stream_sell = transaction_order(false, 2.0, 2.0);
+    stream.transact(stream_sell, 120.0);
+    CHECK(stream.stream_actions() == 1);
+    CHECK(!stream.stream_order_action_at(0).is_entry);
+    CHECK(stream.stream_order_action_at(0).quantity == 1.0);
+
+    Book exact;
+    exact.seed_three_units();
+    auto sell_three = transaction_order(false, 3.0, 3.0);
+    exact.transact(sell_three, 120.0);
+    CHECK(exact.signed_position() == 0.0);
+    CHECK(exact.trades().size() == 2);
+    CHECK(exact.trades()[0].qty == 2.0 && exact.trades()[1].qty == 1.0);
+
+    Book crossing;
+    crossing.seed_three_units();
+    auto sell_three_again = transaction_order(false, 3.0, 3.0);
+    crossing.transact(sell_three_again, 120.0);
+    CHECK(crossing.signed_position() == 0.0);
+    CHECK(crossing.trades().size() == 2);
+    // Equal transaction and held quantities produce a flat position and no
+    // phantom opening lot; the signed planner's open remainder is zero.
+    CHECK(crossing.lots().empty());
+}
+
+void transact_crosses_with_open_remainder() {
+    Book book;
+    book.seed_three_units();
+    auto sell_five = transaction_order(false, 5.0, 5.0);
+    book.transact(sell_five, 120.0);
+    CHECK(book.signed_position() == -2.0);
+    CHECK(book.lots().size() == 1);
+    CHECK(book.lots().back().entry_id == "SELL");
+    CHECK(book.lots().back().qty == 2.0);
+    CHECK(book.lots().back().entry_incarnation == 44);
+    CHECK(book.trades().size() == 2);
+}
+}
+
+int main() {
+    reduce_preserves_fifo_identity_and_scales_survivor();
+    append_preserves_lot_metadata_and_stream_action();
+    transact_closes_fifo_and_crosses_flat();
+    transact_crosses_with_open_remainder();
+    std::printf("order action integration: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_order_action_integration.cpp
+++ b/tests/test_order_action_integration.cpp
@@ -45,6 +45,7 @@ public:
     void seed_two_lots() {
         position_side_ = PositionSide::LONG;
         position_cycle_seq_ = 4;
+        next_position_cycle_seq_ = 5;
         position_entry_price_ = 106.0;
         position_qty_ = 5.0;
         position_entry_count_ = 2;
@@ -56,6 +57,8 @@ public:
         PyramidEntry b{110.0, 2000, 3.0, "B", 0};
         b.entry_incarnation = 12;
         b.entry_commission_account = 3.0;
+        b.max_runup = 60.0;
+        b.max_drawdown = 30.0;
         pyramid_entries_.push_back(a);
         pyramid_entries_.push_back(b);
         id_unclosed_qty_.clear();
@@ -92,6 +95,11 @@ public:
     void enable_stream_actions() { stream_observe_actions_ = true; }
     void set_slippage(int ticks) { slippage_ = ticks; }
     void make_short() { position_side_ = PositionSide::SHORT; }
+    void per_order_fees() {
+        commission_type_ = CommissionType::CASH_PER_ORDER;
+        commission_value_ = 3.0;
+        for (auto& lot : pyramid_entries_) lot.entry_commission_account = 3.0;
+    }
 
     void transact(PendingOrder& order, double raw_price) {
         double trail = std::numeric_limits<double>::quiet_NaN();
@@ -122,6 +130,8 @@ void reduce_preserves_fifo_identity_and_scales_survivor() {
     CHECK(book.lots()[0].entry_incarnation == 12);
     CHECK(book.lots()[0].qty == 2.0);
     CHECK(book.lots()[0].entry_commission_account == 2.0);
+    CHECK(book.lots()[0].max_runup == 40.0);
+    CHECK(book.lots()[0].max_drawdown == 20.0);
     CHECK(book.signed_position() == 2.0);
     CHECK(book.cycle() == 4);
 
@@ -140,6 +150,14 @@ void reduce_preserves_fifo_identity_and_scales_survivor() {
     CHECK(oversized.signed_position() == 0.0);
     CHECK(oversized.lots().empty());
     CHECK(oversized.trades().size() == 2);
+    CHECK(oversized.cycle() == 0);
+
+    Book order_fee;
+    order_fee.seed_two_lots();
+    order_fee.per_order_fees();
+    order_fee.partial(120.0, 3.0);
+    CHECK(order_fee.lots().size() == 1);
+    CHECK(order_fee.lots()[0].entry_commission_account == 3.0);
 }
 
 void reduce_handles_short_side_and_slippage_once() {
@@ -151,14 +169,14 @@ void reduce_handles_short_side_and_slippage_once() {
     CHECK(book.signed_position() == -3.0);
     CHECK(book.trades().size() == 1);
     CHECK(!book.trades()[0].is_long);
-    CHECK(book.trades()[0].exit_price == 121.0);
+    CHECK(std::abs(book.trades()[0].exit_price - 120.02) < 1e-12);
 
     Book long_side;
     long_side.seed_two_lots();
     long_side.set_slippage(2);
     long_side.partial(120.0, 2.0);
     CHECK(long_side.trades().size() == 1);
-    CHECK(long_side.trades()[0].exit_price == 119.0);
+    CHECK(std::abs(long_side.trades()[0].exit_price - 119.98) < 1e-12);
 }
 
 void append_preserves_lot_metadata_and_stream_action() {
@@ -173,6 +191,7 @@ void append_preserves_lot_metadata_and_stream_action() {
 
     CHECK(book.lots().size() == 3);
     CHECK(book.lots().back().entry_id == "C");
+    CHECK(book.lots().back().entry_comment == "native add");
     CHECK(book.lots().back().entry_incarnation == 13);
     CHECK(!book.lots().back().market_pyramid_add);
     CHECK(book.lots().back().entry_commission_account == 1.0);
@@ -195,62 +214,73 @@ PendingOrder transaction_order(bool is_long, double own, double total) {
 }
 
 void transact_closes_fifo_and_crosses_flat() {
-    Book partial;
-    partial.seed_three_units();
-    auto sell_two = transaction_order(false, 2.0, 2.0);
-    partial.transact(sell_two, 120.0);
-    CHECK(partial.signed_position() == 1.0);
-    CHECK(partial.trades().size() == 1);
-    CHECK(partial.trades()[0].qty == 1.0);
-    CHECK(partial.trades()[0].entry_id == "A");
+    for (bool from_short : {false, true}) {
+        Book partial;
+        partial.seed_three_units(); // FIFO A=1, B=2
+        if (from_short) partial.make_short();
+        partial.enable_stream_actions();
+        auto two = transaction_order(from_short, 2.0, 2.0);
+        partial.transact(two, 120.0);
+        CHECK(partial.signed_position() == (from_short ? -1.0 : 1.0));
+        CHECK(partial.cycle() == 4);
+        CHECK(partial.trades().size() == 2);
+        if (partial.trades().size() == 2) {
+            CHECK(partial.trades()[0].entry_id == "A" && partial.trades()[0].qty == 1.0);
+            CHECK(partial.trades()[1].entry_id == "B" && partial.trades()[1].qty == 1.0);
+        }
+        CHECK(partial.lots().size() == 1 && partial.lots()[0].entry_id == "B");
+        CHECK(partial.stream_actions() == 2);
+        if (partial.stream_actions() == 2) {
+            CHECK(!partial.stream_order_action_at(0).is_entry);
+            CHECK(!partial.stream_order_action_at(1).is_entry);
+            CHECK(partial.stream_order_action_at(0).quantity == 1.0);
+            CHECK(partial.stream_order_action_at(1).quantity == 1.0);
+        }
 
-    Book stream;
-    stream.seed_three_units();
-    stream.enable_stream_actions();
-    auto stream_sell = transaction_order(false, 2.0, 2.0);
-    stream.transact(stream_sell, 120.0);
-    CHECK(stream.stream_actions() == 1);
-    CHECK(!stream.stream_order_action_at(0).is_entry);
-    CHECK(stream.stream_order_action_at(0).quantity == 1.0);
+        Book exact;
+        exact.seed_three_units();
+        if (from_short) exact.make_short();
+        auto three = transaction_order(from_short, 3.0, 3.0);
+        exact.transact(three, 120.0);
+        CHECK(exact.signed_position() == 0.0 && exact.cycle() == 0);
+        CHECK(exact.lots().empty());
+        CHECK(exact.trades().size() == 2);
+        if (exact.trades().size() == 2) {
+            CHECK(exact.trades()[0].qty == 1.0 && exact.trades()[1].qty == 2.0);
+        }
 
-    Book exact;
-    exact.seed_three_units();
-    auto sell_three = transaction_order(false, 3.0, 3.0);
-    exact.transact(sell_three, 120.0);
-    CHECK(exact.signed_position() == 0.0);
-    CHECK(exact.trades().size() == 2);
-    CHECK(exact.trades()[0].qty == 2.0 && exact.trades()[1].qty == 1.0);
-
-    Book crossing;
-    crossing.seed_three_units();
-    auto sell_three_again = transaction_order(false, 3.0, 3.0);
-    crossing.transact(sell_three_again, 120.0);
-    CHECK(crossing.signed_position() == 0.0);
-    CHECK(crossing.trades().size() == 2);
-    // Equal transaction and held quantities produce a flat position and no
-    // phantom opening lot; the signed planner's open remainder is zero.
-    CHECK(crossing.lots().empty());
+        Book crossing;
+        crossing.seed_three_units();
+        if (from_short) crossing.make_short();
+        crossing.enable_stream_actions();
+        auto five = transaction_order(from_short, 5.0, 5.0);
+        crossing.transact(five, 120.0);
+        CHECK(crossing.signed_position() == (from_short ? 2.0 : -2.0));
+        CHECK(crossing.cycle() == 5);
+        CHECK(crossing.lots().size() == 1);
+        if (!crossing.lots().empty()) {
+            CHECK(crossing.lots()[0].entry_id == (from_short ? "BUY" : "SELL"));
+            CHECK(crossing.lots()[0].qty == 2.0);
+            CHECK(crossing.lots()[0].entry_incarnation == 44);
+        }
+        CHECK(crossing.trades().size() == 2);
+        CHECK(crossing.stream_actions() == 3);
+        if (crossing.stream_actions() == 3) {
+            CHECK(!crossing.stream_order_action_at(0).is_entry);
+            CHECK(!crossing.stream_order_action_at(1).is_entry);
+            CHECK(crossing.stream_order_action_at(2).is_entry);
+            CHECK(crossing.stream_order_action_at(2).quantity == 2.0);
+        }
+    }
 }
 
-void transact_crosses_with_open_remainder() {
-    Book book;
-    book.seed_three_units();
-    auto sell_five = transaction_order(false, 5.0, 5.0);
-    book.transact(sell_five, 120.0);
-    CHECK(book.signed_position() == -2.0);
-    CHECK(book.lots().size() == 1);
-    CHECK(book.lots().back().entry_id == "SELL");
-    CHECK(book.lots().back().qty == 2.0);
-    CHECK(book.lots().back().entry_incarnation == 44);
-    CHECK(book.trades().size() == 2);
-}
 }
 
 int main() {
     reduce_preserves_fifo_identity_and_scales_survivor();
+    reduce_handles_short_side_and_slippage_once();
     append_preserves_lot_metadata_and_stream_action();
     transact_closes_fifo_and_crosses_flat();
-    transact_crosses_with_open_remainder();
     std::printf("order action integration: %d checks, %d failures\n", checks, failures);
     return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
Partial reductions and frozen transaction reversals now share a native quantity planner. `Reduce` accepts a finite nonnegative amount and can only decrease or flatten exposure. Signed `Transact` closes opposing exposure first and opens its remainder. Invalid, overflowed or unrepresentable nonzero quantity changes produce no plan before lot mutation.

The planner owns no mutable book, source policy, sizing, cycle or execution permission. Existing settlement retains FIFO lots, fees, slippage, dust thresholds and lifecycle. Two identical same-side lot append blocks now use one helper, preserving lot identity and stream observations.

This is a prerequisite for the independent backtest/forward executor and progress on #227. It does not add a queued native API, replay authority or broker-account reconciliation. `PendingOrder` remains at five direct booleans; `ShortSeedCollisionRole` and its truthful ABI/hash projections remain until ordered actions replace their consumers. No flag reduction is claimed in this PR.

Validation on `83c2a1c8587caa457400dead2d1412aef0093b73`:

- Full build; 500 literal native checks pass, including both sides, exact flat/crossing, FIFO identity, fee/excursion scaling, one-time slippage and close-before-open stream observations.
- Public C ABI source check and 406-field / 3192-byte compiler prefix proof pass; layouts and fingerprint domains are unchanged.
- Cloud experiment `exp-native-actions-20260911`: 72/72 cases, 4,190/4,190 probes, **4,182 excellent / 8 strong**. Direct comparison with merged `46dd601` has zero trade CSV, count, full-grade or substantive verifier differences. All 4,069 stored trade sets pass byte-hash and parsing integrity checks.
- All non-product case input descriptors, runner configuration and codegen tree are unchanged. Grading rules, reference trades, feeds, input files and population are unchanged.
- Independent exact-head Grok review: **GREEN, P0/P1/P2 = 0/0/0**.

Formal gate `pineforge-pr-gate-rxsnw` is **FAIL solely `target.not-positive`**. The pinned baseline and candidate grade documents are identical. Publication uses the owner’s standing authorization for zero target improvement with no individual regression in this native refactor campaign. The actual FAIL is retained; no PASS or baseline promotion is fabricated.

Candidate snapshot: `8d893f5630865940659c43c5be1c23954a41703694449fdf9cecdbad0ff8812a`.
