### PR TITLE
Add native FIFO settlement with historical execution costs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(pineforge STATIC
     src/engine_lower_tf.cpp
     src/engine_metrics.cpp
     src/engine_orders.cpp
+    src/engine_execution.cpp
     src/engine_path_resolve.cpp
     src/engine_report.cpp
     src/engine_risk.cpp

--- a/docs/native-settlement.md
+++ b/docs/native-settlement.md
@@ -1,0 +1,89 @@
+# Native resolved execution settlement
+
+`BacktestEngine::settle_resolved_execution` is a protected C++ extension for
+trusted matching adapters. It applies an already admitted, matched execution
+to the engine's existing physical lot book and emits the resulting close and
+open observations. It adds no second position ledger or persistent selector.
+
+The caller supplies an `execution::Action` and `execution::Fill` from
+`<pineforge/execution.hpp>`. These values describe immediate effects:
+
+| Action | Effect |
+| --- | --- |
+| `Flatten{}` | Close every physical lot. |
+| `order_action::Reduce{units}` | Close up to a finite, nonnegative quantity in FIFO order; never open or reverse. |
+| `order_action::Transact{signed_units}` | Buy positive units or sell negative units; reduce opposite exposure first, then open any remainder. |
+
+`Fill` carries the resolved finite price, order ID, comment, incarnation and
+an optional total commission in account currency. Zero and negative prices
+are representable; the caller decides which prices its instrument permits.
+Settlement does not apply another tick rounding, slippage, lot step,
+pyramiding cap or affordability decision.
+
+## Physical lots and quantities
+
+FIFO allocation retains surviving lot identities, entry prices, paid costs
+and proportional excursions. The surviving physical quantities determine the
+resulting position and weighted entry price. For example, reducing lots
+`{0.1, 0.2}` by `0.1` leaves the existing `0.2` lot, even when regrouping
+binary64 arithmetic as `aggregate_before - reduction` differs by one ulp.
+
+A finite quantity request can leave a positive floating residual. No native
+epsilon silently discards it. `Flatten` explicitly closes all lots and avoids
+using rounded aggregate equality to mean a whole-book close. Quantities whose
+changes cannot be represented are refused before settlement.
+
+## Costs and marked equity
+
+Every opening lot receives its paid entry commission before its entry
+observation is emitted. Partial closes allocate this stored payment in
+proportion to closed quantity for every commission type. The survivor keeps
+the unconsumed cost. Later fee schedule or FX changes do not rewrite a payment
+already made.
+
+The current execution is quoted separately. Percent and per-contract charges
+follow each physical quantity. A cash-per-order charge belongs to the entire
+native execution, including both legs of a reversal; it is allocated across
+the close/open effects with the final effect receiving the floating residue.
+An explicit `Fill::commission_account` overrides the modeled total and can
+represent a zero-fee waiver or a negative rebate. A nonfinite quote, or a
+nonzero quote attached to a no-effect quantity, is refused.
+
+For example, with a cash ticket of 6, opening 3 units and reducing 1 unit
+allocates 2 of the paid entry ticket plus 6 for the reduction to the closed
+row. The remaining 2 units carry entry cost 4. Flattening those units costs
+another ticket of 6: total paid across the three executions is 18.
+
+`marked_equity(price)` is initial capital plus realized PnL and marked open
+PnL, minus remaining paid entry costs of every fee type. At an unchanged mark,
+a native execution decreases this value by its current charge, subject to
+ordinary floating-point rounding. A rebate increases it.
+
+## Integration and limits
+
+The kernel currently serves full market exits and selected frozen-transaction
+and same-side materialization paths. Existing source scheduling and dust
+decisions remain at their call sites. Some source instructions still issue
+separate close and open executions. Other legacy close loops are not yet
+grouped into one parent execution; their per-row current ticket behavior is
+not a claim about the native contract.
+
+The shared close builder now consumes historical entry costs. This changes
+the former reconstruction that converted both commission legs at exit-time
+FX, and the former reuse of a complete entry ticket at every partial close.
+TradingView compatibility must be measured against unchanged references.
+Pine sizing and range-end reporting still have separate conventions; the
+native marked-equity helper does not replace all existing report fields.
+
+This API is synchronous. It does not place queued orders, establish matching
+or cancellation authority, reconcile external broker messages, deduplicate
+replayed fills or accept a stored plan as execution authority. Callers own
+those responsibilities and the current event context. The return status
+distinguishes application, no effect and validation failures. Allocation or
+lifecycle exceptions abort the owning run; callers must discard that failed
+run rather than retry a partially committed execution in place. Strong
+rollback on allocation failure is not promised.
+
+The work does not remove `ShortSeedCollisionRole` or complete migration to a
+generic queued order machine. Existing executable state remains represented
+in ABI projections and fingerprints.

--- a/docs/native-settlement.md
+++ b/docs/native-settlement.md
@@ -71,8 +71,9 @@ ordinary floating-point rounding. A rebate increases it.
 
 The kernel currently serves full market exits and selected frozen-transaction
 and same-side materialization paths. Existing source scheduling and dust
-decisions remain at their call sites. Some source instructions still issue
-separate close and open executions. Other legacy close loops are not yet
+decisions remain at their call sites. Migrated frozen transactions and the
+final short-seed crossing settle their close/open effects in one native call.
+Other legacy close loops are not yet
 grouped into one parent execution; their per-row current ticket behavior is
 not a claim about the native contract.
 

--- a/docs/native-settlement.md
+++ b/docs/native-settlement.md
@@ -49,6 +49,14 @@ An explicit `Fill::commission_account` overrides the modeled total and can
 represent a zero-fee waiver or a negative rebate. A nonfinite quote, or a
 nonzero quote attached to a no-effect quantity, is refused.
 
+For a modeled native percent schedule, the resolved notional uses the absolute
+fill price: `abs(fill.price) × quantity × pointvalue × account FX × rate`.
+Thus a positive 1% schedule charges 2 on a two-unit execution at a resolved
+price of -100; the signed price cannot turn that modeled charge into a rebate.
+An explicit negative `Fill::commission_account` remains an observed rebate and
+is preserved as such. Excursion fields remain nonnegative magnitudes, so a
+flat-price rebate may increase run-up but cannot produce a negative drawdown.
+
 For example, with a cash ticket of 6, opening 3 units and reducing 1 unit
 allocates 2 of the paid entry ticket plus 6 for the reduction to the closed
 row. The remaining 2 units carry entry cost 4. Flattening those units costs

--- a/docs/pages/fill-model.md
+++ b/docs/pages/fill-model.md
@@ -104,14 +104,15 @@ authorize a delayed fill: a scheduler must revalidate its order identity and
 current book before settlement. Pending cancellation and replay receipts are
 separate lifecycle contracts.
 
-The current bridge uses this planner for partial reduction and Pine's already
-resolved frozen-transaction close/open split. The existing settlement paths
-still own FIFO lots, fees, slippage, dust thresholds and observations. A shared
-same-side lot append also keeps physical identity and metadata without
-introducing another position book. This is a prerequisite for the unified
-executor; `ShortSeedCollisionRole` and its compatibility projection remain
-until ordered actions replace all of their consumers. This change does not
-reduce the pending-order flag count or provide broker-account reconciliation.
+The native [resolved settlement extension](../native-settlement.md) applies
+`Flatten`, `Reduce` and `Transact` to the existing physical FIFO book, including
+paid entry costs, current execution charges and ordered observations. Full
+market exits and selected frozen-transaction/materialization paths use it.
+Callers still own matching, admission, slippage and source scheduling; other
+legacy settlement paths remain to be migrated. `ShortSeedCollisionRole` and
+its compatibility projection remain until ordered actions replace all of
+their consumers. This step does not reduce the pending-order flag count or
+provide broker-account reconciliation.
 
 ## Opening checkpoint
 

--- a/docs/pages/metrics.md
+++ b/docs/pages/metrics.md
@@ -49,6 +49,19 @@ qty × pointvalue) × 100`, TradingView-arbitrated).
 | `max_consecutive_wins` / `_losses` | Longest run; even trades reset both | — |
 | `avg_bars_in_trade` / `_wins` / `_losses` | Mean of `exit_bar − entry_bar + 1` (**inclusive** of the entry bar, TV convention), script bars | empty set |
 
+Native settlement records fees in account currency at the event where they are
+incurred. Entry fees are snapshotted on each physical lot at its entry fill
+and remain unchanged when a later FX point becomes active. A partial FIFO
+close allocates the paid entry fee in proportion to closed quantity; the
+survivor retains the unconsumed cost. A
+single cash-per-order ticket belongs to the native execution as a whole and is
+allocated proportionally across its physical close/open effects; it is not
+charged once per trade row. The shared native close helper now consumes these
+historical paid costs. Existing legacy Pine paths are not all grouped into
+native executions, so this rule does not claim that every legacy path has the
+same dynamic-FX settlement semantics. Pine sizing, source-specific reporting,
+and range-end conventions remain compatibility behavior.
+
 ## Equity statistics (`metrics.equity`, all-trades only)
 
 The equity curve samples `initial_capital + net_profit + open_profit` at
@@ -77,7 +90,7 @@ truncated curve and metrics over the truncated prefix.
 | Surface | Validated against | Result |
 | --- | --- | --- |
 | Trade statistics (counts, PF, percent bases, averages, largest-%, bars) | Real TradingView Strategy Tester export (`composite-4emarsi-integration-01`, 336 trades, All/Long/Short panels) | Match within TV 2-dp rounding; three TV conventions arbitrated and adopted (net return-on-cost `pnl_pct`, independent largest-%, inclusive bar counts) |
-| Commission + slippage economics | Second TV export, same strategy: commission 0.1 % percent + slippage 2 ticks via `strategy_set_override` ([historical inputs](https://github.com/pineforge-4pass/pineforge-engine/blob/a03ac6d3fb42df5af1db9e39727daf450b2fb71f/validation-adhoc/4emarsi-commission-slippage-ethusdt/inputs.json)) | All 672 fill prices bit-exact (slippage rules pinned: market/stop fills, directional, mintick-composed); commission formula `rate·(entry+exit)·qty·pointvalue` exact — residual per-trade deltas fully explained by TV's account-currency conversion (USDT→USD at previous-UTC-day close; 335/336 trades reproduced to the cent). Extended by a third TV export (`bracket-exit-tp-sl-fixed-01`, BINANCE:ETHUSDT.P): 396/396 trades bit-exact, pinning the limit-fill rules — limit fills are NOT slipped, off-tick limits snap one tick favorably (limit-or-better), gapped limits fill at the raw open, and stop fills confirmed slipped |
+| Commission + slippage economics | Historical TradingView exports: 0.1% commission + 2 ticks via `strategy_set_override` ([archived inputs](https://github.com/pineforge-4pass/pineforge-engine/blob/a03ac6d3fb42df5af1db9e39727daf450b2fb71f/validation-adhoc/4emarsi-commission-slippage-ethusdt/inputs.json)) | Historical fixed-export validation only: 672 fill prices bit-exact and 335/336 commission rows reproduced to the cent after the documented USDT→USD conversion. A separate historical bracket export reproduced 396/396 trades and pinned limit/stop slippage rules. These archived receipts do not claim current dynamic-FX native settlement parity; current native settlement preserves paid entry costs and allocates one execution's costs across physical effects. |
 | TV risk panel (Sharpe, Sortino, drawdown/run-up rows, CAGR) | TV xlsx export (Performance + Risk-adjusted performance sheets) | Every panel value reproduced from the engine curve once TV's conventions are applied — see the definition-delta table below |
 | Equity statistics (max DD ±%, Sharpe/Sortino both variants, CAGR, Calmar, recovery) | quantstats 0.0.81 + empyrical-reloaded 0.5.12 (`scripts/crossvalidate_metrics.py --all`) | All 246 corpus strategies ran, 0 skipped, 0 mismatches; worst engine-convention \|rel Δ\| = 1.886e-11 (`pyramid-cash-fractional-commission-01`, sharpe/sortino_bar vs empyrical); 3 degenerate NaN fields (sharpe_tv, zero monthly variance) agree on degeneracy across engine/numpy/empyrical/quantstats; known library-convention deltas labelled in single-strategy mode |
 | Closed-form unit oracles | `tests/test_metrics.cpp` (e.g. monthly Sharpe 19/20, Sortino 114/61 exact rationals) | Bit-level |

--- a/include/pineforge/engine.hpp
+++ b/include/pineforge/engine.hpp
@@ -16,6 +16,7 @@
 #include "bar.hpp"
 #include "broker_events.hpp"
 #include "quantity_intent.hpp"
+#include "execution.hpp"
 #include "market_admission.hpp"
 #include "reservation_expansion.hpp"
 #include "order_cancellation.hpp"
@@ -248,10 +249,10 @@ struct PyramidEntry {
     // Entry-leg commission in account currency at this slice's actual fill
     // boundary. Percentage commission depends on quote->account FX, so an
     // effective-time provider must not retroactively reprice this already-paid
-    // fee when a later rate becomes active. Closed-trade reporting deliberately
-    // ignores this snapshot: TV converts the complete realized trade at the
-    // exit-time FX rate. NaN is reserved for legacy/synthetic test injection;
-    // every production entry path initializes the snapshot at fill time.
+    // fee when a later rate becomes active. Partial realization allocates this
+    // paid cost proportionally and leaves only the unconsumed cost on the lot,
+    // independently of the current fee schedule. NaN is reserved for legacy/
+    // synthetic injection; every production entry path captures a real quote.
     double entry_commission_account =
         std::numeric_limits<double>::quiet_NaN();
     // Monotonic per-run identity of the PendingOrder object whose broker fill
@@ -1790,6 +1791,18 @@ protected:
     // --- Per-trade extreme tracking ---
     void update_per_trade_extremes();
 
+    // Trusted native matching-adapter extension: settle an already resolved
+    // execution into this engine's one physical book. This does not place an
+    // order, perform admission/slippage, or provide cancellation/replay. The
+    // owning run must abort on an exception; failed commits are not retryable
+    // in place. A saved arithmetic plan is not execution authority.
+    execution::Result settle_resolved_execution(const execution::Action& action,
+                                                const execution::Fill& fill);
+    // Native account value: realized balance plus marked physical lots minus
+    // their remaining paid entry costs, for every fee type. No Pine sizing or
+    // end-of-range reporting convention participates in this value.
+    double marked_equity(double price) const;
+
     // --- Strategy order commands ---
     // NOTE: prior to v0.2 the runtime accepted a leading `double market_price`
     // positional after `is_long`. The implementation never read it; every
@@ -2426,6 +2439,12 @@ protected:
         return std::isfinite(pe.entry_commission_account)
             ? pe.entry_commission_account
             : calc_commission(pe.price, pe.qty);
+    }
+
+    double allocated_entry_commission(const PyramidEntry& pe, double units) const {
+        if (units <= 0.0) return 0.0;
+        const double paid = open_entry_commission(pe);
+        return units >= pe.qty ? paid : paid * (units / pe.qty);
     }
 
     void snapshot_entry_commission(PyramidEntry& pe) const {
@@ -3851,6 +3870,8 @@ private:
                               uint64_t entry_incarnation);
     void execute_market_exit(double fill_price);
     void append_same_side_fill(PyramidEntry lot);
+    void append_quoted_lot(PyramidEntry lot, double total_qty, double average_price);
+    void open_quoted_position(PositionSide requested, PyramidEntry lot);
     // Range-end accounting: record the rows that close a position still
     // open after the final script bar at that bar's close, the way
     // TradingView's deep-backtest report does (engine_orders.cpp). Called by
@@ -4200,6 +4221,14 @@ private:
     // engine_orders.cpp).
     void emit_close_trade(const PyramidEntry& pe, double close_qty,
                           double fill_price, bool was_long);
+    void record_close_trade(Trade trade);
+    void validate_close_trade_counters(const Trade* rows, size_t count) const;
+    // Quote one resolved execution's current charges. Entry costs on the
+    // closed rows are historical allocations. Returns close shares in FIFO
+    // order followed by the opening share (zero when there is no opening).
+    std::vector<double> quote_execution_commissions(
+        const std::vector<double>& closed_units, double opening_units,
+        const execution::Fill& fill) const;
     // The arithmetic of emit_close_trade without its bookkeeping: the Trade
     // row a close of ``close_qty`` of ``pe`` at ``fill_price`` on the
     // current bar would record (pnl, pnl_pct, commission, excursions, bar
@@ -4207,6 +4236,9 @@ private:
     // builds only.
     Trade build_close_trade(const PyramidEntry& pe, double close_qty,
                             double fill_price, bool was_long) const;
+    Trade build_close_trade_with_costs(const PyramidEntry& pe, double close_qty,
+        double fill_price, bool was_long, double entry_commission,
+        double exit_commission) const;
     // FIFO-drain up to qty_limit from pyramid_entries_, in order, splitting the
     // boundary entry as needed. When from_entry is non-null only entries whose
     // entry_id == *from_entry are eligible (others are kept untouched); null

--- a/include/pineforge/execution.hpp
+++ b/include/pineforge/execution.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "order_action.hpp"
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <variant>
+
+namespace pineforge::execution {
+
+// Whole-book reduction is explicit: it never relies on a rounded aggregate
+// quantity being exactly equal to the sum of individual physical lots.
+struct Flatten {};
+using Action = std::variant<Flatten, order_action::Reduce, order_action::Transact>;
+
+// The caller has already matched/admitted the action and resolved its price.
+// Settlement does not apply another lot step, price grid, slippage or entry cap.
+struct Fill {
+    double price;
+    std::string id;
+    std::string comment;
+    uint64_t incarnation = 0;
+    // An observed execution charge in account currency, including rebates.
+    // Otherwise the engine's configured schedule quotes the current fill.
+    std::optional<double> commission_account = std::nullopt;
+};
+
+enum class Status {
+    Applied, NoEffect, InvalidPrice, InvalidQuantity, InvalidBook,
+    UnrepresentableQuantity, InvalidAccounting
+};
+
+struct Result {
+    Status status = Status::NoEffect;
+    // Aggregate projections of the physical effects; the lot/trade roster is
+    // authoritative. Opening units are signed; closing units are nonnegative.
+    double closed_units = 0.0;
+    double opened_units = 0.0;
+};
+
+} // namespace pineforge::execution

--- a/src/engine_execution.cpp
+++ b/src/engine_execution.cpp
@@ -229,10 +229,20 @@ std::vector<double> BacktestEngine::quote_execution_commissions(
     // ticket charge is shared across the entire execution, including a flip's
     // opening remainder. Row count must not multiply a per-order fee.
     std::vector<double> costs(closed_units.size() + 1, 0.0);
+    const auto native_modeled_commission = [&](double quantity) {
+        // Native resolved executions charge a positive percentage against
+        // absolute resolved notional. Keep calc_commission's signed-price
+        // behavior unchanged for all legacy Pine paths.
+        if (commission_type_ == CommissionType::PERCENT) {
+            return std::abs(fill.price) * quantity * syminfo_.pointvalue
+                * active_account_currency_fx() * (commission_value_ / 100.0);
+        }
+        return calc_commission(fill.price, quantity);
+    };
     if (!fill.commission_account && commission_type_ != CommissionType::CASH_PER_ORDER) {
         for (size_t i = 0; i < closed_units.size(); ++i)
-            costs[i] = calc_commission(fill.price, closed_units[i]);
-        costs.back() = opening_units > 0.0 ? calc_commission(fill.price, opening_units) : 0.0;
+            costs[i] = native_modeled_commission(closed_units[i]);
+        costs.back() = opening_units > 0.0 ? native_modeled_commission(opening_units) : 0.0;
         return costs;
     }
     double units = opening_units;

--- a/src/engine_execution.cpp
+++ b/src/engine_execution.cpp
@@ -1,0 +1,283 @@
+#include "engine_internal.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace pineforge {
+namespace {
+template<class T>
+void reserve_effects(std::vector<T>& values, size_t extra) {
+    if (extra > values.max_size() - values.size())
+        throw std::length_error("execution effect capacity exhausted");
+    const size_t required = values.size() + extra;
+    if (required <= values.capacity()) return;
+    const size_t grown = values.capacity() > values.max_size() / 2
+        ? values.max_size() : values.capacity() * 2;
+    values.reserve(std::max(required, grown));
+}
+} // namespace
+
+execution::Result BacktestEngine::settle_resolved_execution(
+        const execution::Action& action, const execution::Fill& fill) {
+    using execution::Status;
+    if (!std::isfinite(fill.price)) return {Status::InvalidPrice};
+    if (fill.commission_account && !std::isfinite(*fill.commission_account))
+        return {Status::InvalidAccounting};
+    const auto no_effect = [&]() -> execution::Result {
+        return {fill.commission_account && *fill.commission_account != 0.0
+            ? Status::InvalidAccounting : Status::NoEffect};
+    };
+
+    const bool flatten = std::holds_alternative<execution::Flatten>(action);
+    const auto* reduce = std::get_if<order_action::Reduce>(&action);
+    const auto* transact = std::get_if<order_action::Transact>(&action);
+    const double requested = reduce ? reduce->units
+        : transact ? std::abs(transact->signed_units) : 0.0;
+    if (!std::isfinite(requested) || (reduce && requested < 0.0))
+        return {Status::InvalidQuantity};
+
+    if (position_side_ != PositionSide::FLAT
+        && position_side_ != PositionSide::LONG
+        && position_side_ != PositionSide::SHORT)
+        return {Status::InvalidBook};
+    if ((position_side_ == PositionSide::FLAT) != pyramid_entries_.empty())
+        return {Status::InvalidBook};
+
+    double held = 0.0;
+    for (const auto& lot : pyramid_entries_) {
+        if (!std::isfinite(lot.qty) || lot.qty <= 0.0 || !std::isfinite(lot.price))
+            return {Status::InvalidBook};
+        held += lot.qty;
+        if (!std::isfinite(held)) return {Status::InvalidBook};
+    }
+    const double signed_held = position_side_ == PositionSide::SHORT ? -held : held;
+    if (!flatten && requested == 0.0) return no_effect();
+    if ((flatten || reduce) && pyramid_entries_.empty()) return no_effect();
+
+    // The scalar planner validates the request's representability. Physical
+    // FIFO allocation below is authoritative for the surviving position: it
+    // must not reject a valid decimal lot merely because a differently grouped
+    // scalar addition has a one-ulp difference.
+    if (reduce && !order_action::plan(signed_held, *reduce))
+        return {Status::UnrepresentableQuantity};
+    if (transact && !order_action::plan(signed_held, *transact))
+        return {Status::UnrepresentableQuantity};
+
+    const PositionSide incoming = transact && transact->signed_units < 0.0
+        ? PositionSide::SHORT : PositionSide::LONG;
+    const bool opposite = transact && position_side_ != PositionSide::FLAT
+        && position_side_ != incoming;
+    const bool closes = flatten || reduce || opposite;
+    const bool was_long = position_side_ == PositionSide::LONG;
+
+    // Stage all physical splits and financial rows before changing the book.
+    std::vector<PyramidEntry> survivors;
+    std::vector<size_t> closing_indices;
+    std::vector<double> closing_quantities;
+    if (!flatten) survivors.reserve(pyramid_entries_.size());
+    closing_indices.reserve(closes ? pyramid_entries_.size() : 0);
+    closing_quantities.reserve(closes ? pyramid_entries_.size() : 0);
+    double closed = 0.0;
+    double remaining = requested;
+    for (size_t index = 0; index < pyramid_entries_.size(); ++index) {
+        const auto& lot = pyramid_entries_[index];
+        const double amount = !closes ? 0.0
+            : flatten ? lot.qty : std::min(lot.qty, remaining);
+        if (amount == 0.0) {
+            survivors.push_back(lot);
+            continue;
+        }
+        const double kept = lot.qty - amount;
+        const double next_closed = closed + amount;
+        if (!std::isfinite(next_closed) || kept == lot.qty
+            || (!flatten && closed != 0.0
+                && (next_closed == closed || next_closed == amount)))
+            return {Status::UnrepresentableQuantity};
+        if (!flatten) {
+            const double next_remaining = requested - next_closed;
+            if (next_remaining < 0.0 || next_remaining == remaining)
+                return {Status::UnrepresentableQuantity};
+            remaining = next_remaining;
+        }
+        closed = next_closed;
+        closing_indices.push_back(index);
+        closing_quantities.push_back(amount);
+        if (kept > 0.0) {
+            auto survivor = lot;
+            const double scale = kept / lot.qty;
+            survivor.qty = kept;
+            survivor.max_runup *= scale;
+            survivor.max_drawdown *= scale;
+            survivor.entry_commission_account = open_entry_commission(lot)
+                - allocated_entry_commission(lot, amount);
+            survivors.push_back(std::move(survivor));
+        }
+    }
+
+    const double opening = !transact ? 0.0 : opposite ? remaining : requested;
+    if (opening > 0.0 && opposite && !survivors.empty())
+        return {Status::UnrepresentableQuantity};
+    const auto current_costs = quote_execution_commissions(closing_quantities, opening, fill);
+    for (double cost : current_costs)
+        if (!std::isfinite(cost)) return {Status::InvalidAccounting};
+    const double opening_commission = current_costs.back();
+    std::vector<Trade> closed_trades;
+    closed_trades.reserve(closing_indices.size());
+    for (size_t i = 0; i < closing_indices.size(); ++i) {
+        const auto& lot = pyramid_entries_[closing_indices[i]];
+        auto trade = build_close_trade_with_costs(lot, closing_quantities[i],
+            fill.price, was_long, allocated_entry_commission(lot, closing_quantities[i]),
+            current_costs[i]);
+        trade.exit_id = fill.id;
+        trade.exit_comment = fill.comment;
+        closed_trades.push_back(std::move(trade));
+    }
+    if (opening > 0.0 && (position_side_ == PositionSide::FLAT || survivors.empty())
+        && (next_position_cycle_seq_ <= 0
+            || next_position_cycle_seq_ == std::numeric_limits<int64_t>::max()))
+        throw std::overflow_error("position cycle sequence exhausted");
+    double after_qty = 0.0;
+    double weighted = 0.0;
+    for (const auto& lot : survivors) {
+        after_qty += lot.qty;
+        weighted += lot.price * lot.qty;
+    }
+    if (opening > 0.0) {
+        const double next = after_qty + opening;
+        if (!std::isfinite(next) || (after_qty > 0.0
+            && (next == after_qty || next == opening)))
+            return {Status::UnrepresentableQuantity};
+        after_qty = next;
+        weighted += fill.price * opening;
+    }
+    const size_t after_lots = survivors.size() + (opening > 0.0 ? 1 : 0);
+    const double after_price = after_lots == 1
+        ? (opening > 0.0 ? fill.price : survivors.front().price)
+        : after_qty > 0.0 ? weighted / after_qty : 0.0;
+    if (!std::isfinite(after_qty) || !std::isfinite(after_price))
+        return {Status::InvalidAccounting};
+
+    // A financial sum must remain representable; reporting-only percentages
+    // or excursion projections do not decide whether an action may settle.
+    double next_profit = net_profit_sum_;
+    double next_gross_profit = gross_profit_sum_;
+    double next_gross_loss = gross_loss_sum_;
+    double next_intraday = intraday_pnl_;
+    for (const auto& trade : closed_trades) {
+        if (!std::isfinite(trade.pnl) || !std::isfinite(trade.commission))
+            return {Status::InvalidAccounting};
+        next_profit += trade.pnl;
+        next_intraday += trade.pnl;
+        if (trade.pnl > 0.0) next_gross_profit += trade.pnl;
+        if (trade.pnl < 0.0) next_gross_loss += trade.pnl;
+    }
+    if (!std::isfinite(next_profit) || !std::isfinite(next_gross_profit)
+        || !std::isfinite(next_gross_loss) || !std::isfinite(next_intraday))
+        return {Status::InvalidAccounting};
+    validate_close_trade_counters(closed_trades.data(), closed_trades.size());
+    if (opening > 0.0 && !survivors.empty()
+        && position_entry_count_ == std::numeric_limits<int>::max())
+        throw std::overflow_error("position entry counter exhausted");
+
+    const size_t first_trade = trades_.size();
+    const size_t first_action = stream_order_actions_.size();
+    const size_t events = closed_trades.size() + (opening > 0.0 ? 1 : 0);
+    if (stream_observe_actions_) {
+        if (events > std::numeric_limits<uint64_t>::max() - stream_action_sequence_)
+            throw std::overflow_error("stream action sequence overflow");
+        reserve_effects(stream_order_actions_, events);
+    }
+    reserve_effects(trades_, closed_trades.size());
+
+    // Commit through the existing accounting/observation sinks. Allocation or
+    // lifecycle exceptions still abort the owning engine run; this internal
+    // synchronous kernel does not promise recovery/replay of a failed commit.
+    for (auto& trade : closed_trades) record_close_trade(std::move(trade));
+    if (closed > 0.0) {
+        if (survivors.empty()) {
+            reset_position_state_to_flat();
+        } else {
+            pyramid_entries_ = std::move(survivors);
+            position_qty_ = after_qty;
+            position_entry_price_ = after_price;
+            position_entry_count_ = static_cast<int>(pyramid_entries_.size());
+        }
+    }
+    if (opening > 0.0) {
+        PyramidEntry lot{fill.price, current_bar_.timestamp, opening, fill.id, bar_index_};
+        lot.entry_incarnation = fill.incarnation;
+        lot.entry_comment = fill.comment;
+        lot.entry_commission_account = opening_commission;
+        if (position_side_ == PositionSide::FLAT) {
+            open_quoted_position(incoming, std::move(lot));
+        } else {
+            append_quoted_lot(std::move(lot), after_qty, after_price);
+        }
+    }
+    if (stream_observe_actions_) stream_refresh_action_metadata(first_action, first_trade);
+    return {Status::Applied, closed,
+            incoming == PositionSide::SHORT ? -opening : opening};
+}
+
+std::vector<double> BacktestEngine::quote_execution_commissions(
+        const std::vector<double>& closed_units, double opening_units,
+        const execution::Fill& fill) const {
+    // Unit/notional schedules are quoted at each physical allocation. A flat
+    // ticket charge is shared across the entire execution, including a flip's
+    // opening remainder. Row count must not multiply a per-order fee.
+    std::vector<double> costs(closed_units.size() + 1, 0.0);
+    if (!fill.commission_account && commission_type_ != CommissionType::CASH_PER_ORDER) {
+        for (size_t i = 0; i < closed_units.size(); ++i)
+            costs[i] = calc_commission(fill.price, closed_units[i]);
+        costs.back() = opening_units > 0.0 ? calc_commission(fill.price, opening_units) : 0.0;
+        return costs;
+    }
+    double units = opening_units;
+    for (double quantity : closed_units) units += quantity;
+    if (units == 0.0) return costs;
+    if (!std::isfinite(units)) {
+        costs.back() = std::numeric_limits<double>::quiet_NaN();
+        return costs;
+    }
+    const double ticket = fill.commission_account
+        ? *fill.commission_account : calc_commission(fill.price, units);
+    if (!std::isfinite(ticket)) {
+        costs.back() = std::numeric_limits<double>::quiet_NaN();
+        return costs;
+    }
+    double remaining_fee = ticket;
+    for (size_t i = 0; i < closed_units.size(); ++i) {
+        double share = opening_units == 0.0 && i + 1 == closed_units.size()
+            ? remaining_fee : ticket * (closed_units[i] / units);
+        // Floating allocation must not invent a negative charge from a
+        // positive ticket (or vice versa); the final effect owns the residue.
+        share = ticket >= 0.0 ? std::clamp(share, 0.0, remaining_fee)
+                              : std::clamp(share, remaining_fee, 0.0);
+        remaining_fee -= share;
+        costs[i] = share;
+    }
+    costs.back() = opening_units > 0.0 ? remaining_fee : 0.0;
+    return costs;
+}
+
+double BacktestEngine::marked_equity(double price) const {
+    if (!std::isfinite(price)
+        || (position_side_ != PositionSide::FLAT && position_side_ != PositionSide::LONG
+            && position_side_ != PositionSide::SHORT)
+        || (position_side_ == PositionSide::FLAT) != pyramid_entries_.empty())
+        return std::numeric_limits<double>::quiet_NaN();
+    double equity = initial_capital_ + net_profit_sum_;
+    const double direction = position_side_ == PositionSide::SHORT ? -1.0 : 1.0;
+    for (const auto& lot : pyramid_entries_) {
+        if (!std::isfinite(lot.qty) || lot.qty <= 0.0 || !std::isfinite(lot.price))
+            return std::numeric_limits<double>::quiet_NaN();
+        equity += direction * (price - lot.price) * lot.qty * syminfo_.pointvalue
+            * active_account_currency_fx() - open_entry_commission(lot);
+    }
+    return equity;
+}
+
+} // namespace pineforge

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -4496,8 +4496,6 @@ bool BacktestEngine::same_bar_market_close_artifact_is_live(
 void BacktestEngine::apply_same_bar_market_tx_reversal(
         PendingOrder& order, double fill_price, const Bar& bar,
         double& trail_best_path_state) {
-    const PositionSide requested =
-        order.is_long ? PositionSide::LONG : PositionSide::SHORT;
     const double tx = order.pine_frozen_market_instruction.transaction()->transaction_units;
     // Pine has already resolved the source instruction to physical units.
     // Native netting owns the close/open split; this adapter retains its
@@ -4517,15 +4515,15 @@ void BacktestEngine::apply_same_bar_market_tx_reversal(
             && result.status != execution::Status::NoEffect)
             throw std::runtime_error("invalid resolved frozen-transaction settlement");
     };
-    if (close_qty >= position_qty_ - kQtyEpsilon) {
+    const double remainder = std::abs(transaction->open_units());
+    if (remainder > kQtyEpsilon && std::isfinite(fill_price)) {
+        // One matched crossing is one execution: validate both effects before
+        // the first close and allocate one current ticket across the split.
+        settle(order_action::Transact{order.is_long ? tx : -tx});
+    } else if (close_qty >= position_qty_ - kQtyEpsilon) {
         settle(execution::Flatten{});
     } else if (close_qty > kQtyEpsilon) {
         settle(order_action::Reduce{close_qty});
-    }
-    const double remainder = std::abs(transaction->open_units());
-    if (remainder > kQtyEpsilon && std::isfinite(fill_price)) {
-        settle(order_action::Transact{
-            requested == PositionSide::LONG ? remainder : -remainder});
     }
     // Mirror the ordinary market-entry kernel's trail handling (open-tick
     // fill: the bar's extreme folds in for same-bar exit evaluation).
@@ -7028,12 +7026,14 @@ void BacktestEngine::apply_market_order_fill(PendingOrder& order, double fill_pr
     if (short_seed_collision_final_short_is_live(order)) {
         const double residual =
             pyramid_entries_[0].qty - pyramid_entries_[1].qty;
-        execute_market_exit(fill_price);
         if (residual > kQtyEpsilon) {
             // Slippage is gated to 0 by the exact-book tagging, so the
             // remnant re-opens at the same broker point the exit filled at.
+            // Include the two physical closes in this one signed execution.
+            const double transaction = pyramid_entries_[0].qty
+                + pyramid_entries_[1].qty + residual;
             const auto result = settle_resolved_execution(
-                order_action::Transact{order.is_long ? residual : -residual},
+                order_action::Transact{order.is_long ? transaction : -transaction},
                 execution::Fill{fill_price, order.id, order.comment, order.incarnation});
             if (result.status != execution::Status::Applied)
                 throw std::runtime_error("invalid resolved remainder settlement");
@@ -7051,6 +7051,7 @@ void BacktestEngine::apply_market_order_fill(PendingOrder& order, double fill_pr
             trail_best_path_state = trail_best_after_fill;
             return;
         }
+        execute_market_exit(fill_price);
         trail_best_path_state = trail_best_price_;
         return;
     }

--- a/src/engine_fills.cpp
+++ b/src/engine_fills.cpp
@@ -4508,18 +4508,24 @@ void BacktestEngine::apply_same_bar_market_tx_reversal(
         held, order_action::Transact{order.is_long ? tx : -tx});
     if (!transaction) return;
     const double close_qty = transaction->close_units();
+    const execution::Fill resolved{
+        apply_fill_slippage(fill_price, order.is_long),
+        order.id, order.comment, order.incarnation};
+    const auto settle = [&](const execution::Action& action) {
+        const auto result = settle_resolved_execution(action, resolved);
+        if (result.status != execution::Status::Applied
+            && result.status != execution::Status::NoEffect)
+            throw std::runtime_error("invalid resolved frozen-transaction settlement");
+    };
     if (close_qty >= position_qty_ - kQtyEpsilon) {
-        execute_market_exit(fill_price);
+        settle(execution::Flatten{});
     } else if (close_qty > kQtyEpsilon) {
-        execute_partial_exit_qty(fill_price, close_qty,
-                                 PositionReductionCause::SCRIPT_ORDER);
+        settle(order_action::Reduce{close_qty});
     }
     const double remainder = std::abs(transaction->open_units());
     if (remainder > kQtyEpsilon && std::isfinite(fill_price)) {
-        const double entry_fill = apply_fill_slippage(fill_price, order.is_long);
-        open_fresh_position(requested, entry_fill, remainder, order.id,
-                            order.incarnation);
-        pyramid_entries_.back().entry_comment = order.comment;
+        settle(order_action::Transact{
+            requested == PositionSide::LONG ? remainder : -remainder});
     }
     // Mirror the ordinary market-entry kernel's trail handling (open-tick
     // fill: the bar's extreme folds in for same-bar exit evaluation).
@@ -7026,10 +7032,11 @@ void BacktestEngine::apply_market_order_fill(PendingOrder& order, double fill_pr
         if (residual > kQtyEpsilon) {
             // Slippage is gated to 0 by the exact-book tagging, so the
             // remnant re-opens at the same broker point the exit filled at.
-            open_fresh_position(
-                order.is_long ? PositionSide::LONG : PositionSide::SHORT,
-                fill_price, residual, order.id, order.incarnation);
-            pyramid_entries_.back().entry_comment = order.comment;
+            const auto result = settle_resolved_execution(
+                order_action::Transact{order.is_long ? residual : -residual},
+                execution::Fill{fill_price, order.id, order.comment, order.incarnation});
+            if (result.status != execution::Status::Applied)
+                throw std::runtime_error("invalid resolved remainder settlement");
             // Mirror the ordinary market-entry kernel's trail handling: the
             // path state keeps the at-fill value, then the bar's remaining
             // extreme folds into trail_best_price_ for same-bar exit
@@ -7419,15 +7426,11 @@ void BacktestEngine::apply_exit_order_fill(PendingOrder& order, double fill_pric
         const double entry_fill = apply_fill_slippage(fill_price, /*is_buy=*/true);
         if (!std::isfinite(entry_fill) || qty <= kQtyEpsilon) return;
 
-        PyramidEntry materialized{};
-        materialized.price = entry_fill;
-        materialized.time = current_bar_.timestamp;
-        materialized.qty = qty;
-        materialized.entry_id = order.id;
-        materialized.entry_bar_index = bar_index_;
-        materialized.entry_comment = order.comment;
-        materialized.entry_incarnation = order.incarnation;
-        append_same_side_fill(std::move(materialized));
+        const auto result = settle_resolved_execution(
+            order_action::Transact{qty},
+            execution::Fill{entry_fill, order.id, order.comment, order.incarnation});
+        if (result.status != execution::Status::Applied)
+            throw std::runtime_error("invalid resolved same-side settlement");
         return;
     }
 
@@ -7451,15 +7454,11 @@ void BacktestEngine::apply_exit_order_fill(PendingOrder& order, double fill_pric
             const double entry_fill =
                 apply_fill_slippage(fill_price, /*is_buy=*/(order.created_position_side == PositionSide::SHORT));
             if (!std::isfinite(entry_fill) || qty <= kQtyEpsilon) return;
-            PyramidEntry artifact{};
-            artifact.price = entry_fill;
-            artifact.time = current_bar_.timestamp;
-            artifact.qty = qty;
-            artifact.entry_id = order.id;
-            artifact.entry_bar_index = bar_index_;
-            artifact.entry_comment = order.comment;
-            artifact.entry_incarnation = order.incarnation;
-            append_same_side_fill(std::move(artifact));
+            const auto result = settle_resolved_execution(
+                order_action::Transact{position_side_ == PositionSide::LONG ? qty : -qty},
+                execution::Fill{entry_fill, order.id, order.comment, order.incarnation});
+            if (result.status != execution::Status::Applied)
+                throw std::runtime_error("invalid resolved same-side settlement");
             return;
         }
         sbmt_frozen_close = true;

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -174,14 +174,11 @@ void BacktestEngine::execute_market_exit(double fill_price) {
     // limit-or-better path via apply_fill_slippage.
     bool is_buy = (position_side_ == PositionSide::SHORT);
     fill_price = apply_fill_slippage(fill_price, is_buy);
-    bool was_long = (position_side_ == PositionSide::LONG);
-
-    // Emit one Trade per pyramid entry (matches TradingView reporting)
-    for (auto& pe : pyramid_entries_) {
-        emit_close_trade(pe, pe.qty, fill_price, was_long);
-    }
-
-    reset_position_state_to_flat();
+    const auto result = settle_resolved_execution(
+        execution::Flatten{}, execution::Fill{fill_price, {}, {}, 0});
+    if (result.status != execution::Status::Applied
+        && result.status != execution::Status::NoEffect)
+        throw std::runtime_error("invalid resolved full-position settlement");
 }
 
 
@@ -319,13 +316,10 @@ double BacktestEngine::fifo_drain(const std::string* from_entry, double qty_limi
             kept.qty = keep_qty;
             kept.max_runup *= keep_scale;
             kept.max_drawdown *= keep_scale;
-            // Percent and per-contract fees follow the surviving quantity.
-            // CASH_PER_ORDER remains one fee for the accepted entry order,
-            // matching calc_commission's established qty-independent shape.
-            if (std::isfinite(kept.entry_commission_account)
-                && commission_type_ != CommissionType::CASH_PER_ORDER) {
-                kept.entry_commission_account *= keep_scale;
-            }
+            // Realizing part of the lot consumes that part of its paid entry
+            // cost. A later rate/type/FX change cannot rewrite the payment.
+            kept.entry_commission_account = open_entry_commission(pe)
+                - allocated_entry_commission(pe, close_qty);
             remaining.push_back(std::move(kept));
         }
     }
@@ -364,13 +358,21 @@ void BacktestEngine::execute_partial_exit_qty(
 // The caller supplies the lot's immutable label, identity and fill metadata;
 // accounting and stream observations still use the engine's sole lot ledger.
 void BacktestEngine::append_same_side_fill(PyramidEntry lot) {
+    snapshot_entry_commission(lot);
     const double total_qty = position_qty_ + lot.qty;
-    position_entry_price_ =
+    const double average_price =
         (position_entry_price_ * position_qty_ + lot.price * lot.qty) / total_qty;
+    append_quoted_lot(std::move(lot), total_qty, average_price);
+}
+
+void BacktestEngine::append_quoted_lot(PyramidEntry lot, double total_qty,
+                                      double average_price) {
+    if (position_entry_count_ == std::numeric_limits<int>::max())
+        throw std::overflow_error("position entry counter exhausted");
+    position_entry_price_ = average_price;
     position_qty_ = total_qty;
     ++position_entry_count_;
     trail_best_price_ = lot.price;
-    snapshot_entry_commission(lot);
     pyramid_entries_.push_back(std::move(lot));
     if (stream_observe_actions_) stream_observe_entry(pyramid_entries_.back());
     const auto& filled = pyramid_entries_.back();
@@ -592,6 +594,13 @@ void BacktestEngine::purge_exit_orders(bool retain_for_pending_entries) {
 // execute_market_entry. Mirrors TradingView's per-pyramid trade reporting.
 Trade BacktestEngine::build_close_trade(const PyramidEntry& pe, double close_qty,
                                         double fill_price, bool was_long) const {
+    return build_close_trade_with_costs(pe, close_qty, fill_price, was_long,
+        allocated_entry_commission(pe, close_qty), calc_commission(fill_price, close_qty));
+}
+
+Trade BacktestEngine::build_close_trade_with_costs(const PyramidEntry& pe, double close_qty,
+        double fill_price, bool was_long, double entry_commission,
+        double exit_commission) const {
     // Realized PnL scales by the instrument point value ($ per point per
     // contract). Crypto/equity (pointvalue=1) is unchanged; futures (e.g. ES=50)
     // multiply the price-difference PnL. The price-difference component is in
@@ -604,8 +613,6 @@ Trade BacktestEngine::build_close_trade(const PyramidEntry& pe, double close_qty
     const double pv = syminfo_.pointvalue;
     double pnl = (was_long ? (fill_price - pe.price) : (pe.price - fill_price))
                  * close_qty * pv * active_account_currency_fx();
-    const double entry_commission = calc_commission(pe.price, close_qty);
-    const double exit_commission  = calc_commission(fill_price, close_qty);
     pnl -= entry_commission + exit_commission;
     // TV "Net P&L %" convention (arbitrated 2026-06-12 vs TV export,
     // trade #258 short: 102.44 USD on 2276.66 entry => 4.50%): NET pnl
@@ -645,7 +652,7 @@ Trade BacktestEngine::build_close_trade(const PyramidEntry& pe, double close_qty
     // a partial close reports the slice's USD excursion, matching TV's
     // per-trade-record qty. Both fields stay >= 0 (Pine accessor convention);
     // the TV-export sign flip happens only in the CSV writer.
-    double slice = (pe.qty > kQtyEpsilon) ? (close_qty / pe.qty) : 1.0;
+    double slice = (pe.qty > 0.0) ? (close_qty / pe.qty) : 1.0;
     double fill_fav = (was_long ? (fill_price - pe.price) : (pe.price - fill_price))
                       * close_qty;
     double runup = std::max(pe.max_runup * slice, fill_fav);
@@ -709,7 +716,11 @@ Trade BacktestEngine::build_close_trade(const PyramidEntry& pe, double close_qty
 
 void BacktestEngine::emit_close_trade(const PyramidEntry& pe, double close_qty,
                                       double fill_price, bool was_long) {
-    Trade trade = build_close_trade(pe, close_qty, fill_price, was_long);
+    record_close_trade(build_close_trade(pe, close_qty, fill_price, was_long));
+}
+
+void BacktestEngine::record_close_trade(Trade trade) {
+    validate_close_trade_counters(&trade, 1);
     const double pnl = trade.pnl;
     const double trade_pnl = trade.pnl;
     trades_.push_back(std::move(trade));
@@ -756,6 +767,43 @@ void BacktestEngine::emit_close_trade(const PyramidEntry& pe, double close_qty,
         }
     } else if (pnl > 0.0) {
         cons_loss_day_count_ = 0;
+    }
+}
+
+void BacktestEngine::validate_close_trade_counters(const Trade* rows, size_t count) const {
+    const int maximum = std::numeric_limits<int>::max();
+    // In an ordinary run each counter can advance at most once per row.
+    // Only an exhausted/near-exhausted counter needs the exact risk-day walk.
+    if (count <= static_cast<size_t>(maximum)) {
+        const int room = maximum - static_cast<int>(count);
+        if (win_trades_count_ <= room && loss_trades_count_ <= room
+            && eventrades_count_ <= room && cons_loss_day_count_ <= room)
+            return;
+    }
+    int64_t wins = win_trades_count_, losses = loss_trades_count_;
+    int64_t evens = eventrades_count_, loss_days = cons_loss_day_count_;
+    int last_day = last_loss_day_;
+    std::optional<int> current_day;
+    for (size_t i = 0; i < count; ++i) {
+        const double pnl = rows[i].pnl;
+        if (pnl > 0.0) {
+            ++wins;
+            loss_days = 0;
+        } else if (pnl < 0.0) {
+            ++losses;
+            if (!current_day) {
+                const BarTime time = _decompose_bar_time_chart_tz();
+                current_day = time.dayofmonth * 100 + time.month;
+            }
+            if (*current_day != last_day) {
+                last_day = *current_day;
+                ++loss_days;
+            }
+        } else {
+            ++evens;
+        }
+        if (wins > maximum || losses > maximum || evens > maximum || loss_days > maximum)
+            throw std::overflow_error("closed trade counter exhausted");
     }
 }
 
@@ -901,18 +949,28 @@ void BacktestEngine::unbind_exit_activations() {
 void BacktestEngine::open_fresh_position(PositionSide requested, double fill_price,
                                          double qty, const std::string& id,
                                          uint64_t entry_incarnation) {
+    PyramidEntry lot{fill_price, current_bar_.timestamp, qty, id, bar_index_};
+    lot.entry_incarnation = entry_incarnation;
+    snapshot_entry_commission(lot);
+    open_quoted_position(requested, std::move(lot));
+}
+
+void BacktestEngine::open_quoted_position(PositionSide requested, PyramidEntry lot) {
+    if (next_position_cycle_seq_ <= 0
+        || next_position_cycle_seq_ == std::numeric_limits<int64_t>::max())
+        throw std::overflow_error("position cycle sequence exhausted");
     position_side_ = requested;
     position_cycle_seq_ = next_position_cycle_seq_++;
-    position_entry_price_ = fill_price;
+    position_entry_price_ = lot.price;
     // The shared post-dispatch lifecycle hook queues the new fill's event.
     // Clear prior-cycle provenance now so reversals cannot expose it even
     // transiently.
     opening_obligations_.invalidate();
-    position_entry_time_ = current_bar_.timestamp;
-    position_qty_ = qty;
+    position_entry_time_ = lot.time;
+    position_qty_ = lot.qty;
     position_entry_count_ = 1;
-    position_open_bar_ = bar_index_;
-    trail_best_price_ = fill_price;
+    position_open_bar_ = lot.entry_bar_index;
+    trail_best_price_ = lot.price;
     pyramid_entries_.clear();
     id_unclosed_qty_.clear();
     cycle_filled_entry_ids_.clear();
@@ -921,12 +979,11 @@ void BacktestEngine::open_fresh_position(PositionSide requested, double fill_pri
     callsite_close_reserved_qty_.clear();
     callsite_close_two_call_first_qty_.clear();
     consumed_partial_exit_ids_.clear();
-    pyramid_entries_.push_back({fill_price, current_bar_.timestamp, qty, id, bar_index_});
-    pyramid_entries_.back().entry_incarnation = entry_incarnation;
-    snapshot_entry_commission(pyramid_entries_.back());
+    pyramid_entries_.push_back(std::move(lot));
     if (stream_observe_actions_) stream_observe_entry(pyramid_entries_.back());
-    id_unclosed_qty_[id] += qty;
-    cycle_filled_entry_ids_.insert(id);
+    const auto& filled = pyramid_entries_.back();
+    id_unclosed_qty_[filled.entry_id] += filled.qty;
+    cycle_filled_entry_ids_.insert(filled.entry_id);
     bind_retained_exit_activations();
 }
 

--- a/src/engine_orders.cpp
+++ b/src/engine_orders.cpp
@@ -708,8 +708,12 @@ Trade BacktestEngine::build_close_trade_with_costs(const PyramidEntry& pe, doubl
     // (see calc_commission) — same convention as pnl above.
     trade.max_runup = std::max(
         0.0, runup * pv * active_account_currency_fx() - entry_commission);
-    trade.max_drawdown = drawdown * pv * active_account_currency_fx()
-                         + entry_commission;
+    // Excursion columns are nonnegative magnitudes even when an observed
+    // entry rebate is negative. Keep positive-fee behavior unchanged while
+    // preventing a rebate from producing an impossible negative drawdown.
+    trade.max_drawdown = std::max(
+        0.0, drawdown * pv * active_account_currency_fx()
+                 + entry_commission);
     return trade;
 }
 

--- a/src/engine_strategy_commands.cpp
+++ b/src/engine_strategy_commands.cpp
@@ -395,9 +395,12 @@ void BacktestEngine::strategy_entry(const std::string& id, bool is_long,
                 * active_account_currency_fx() * (margin_pct / 100.0);
             const double epsilon =
                 std::max(1e-9, std::abs(placement_equity) * 1e-12);
-            if (std::isfinite(required_margin)
-                && std::isfinite(placement_equity)
-                && required_margin > placement_equity + epsilon) {
+            // An infinite required margin (including arithmetic overflow)
+            // cannot be funded by finite equity. NaN still fails the ordered
+            // comparison; it must not turn +infinity into an admitted order.
+            if (std::isfinite(placement_equity)
+                && (required_margin == std::numeric_limits<double>::infinity()
+                    || required_margin > placement_equity + epsilon)) {
                 command.outcome(admission::Outcome::RejectedAffordability);
 
                 if (!reversal) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    test_unbounded_margin_admission
     test_resolved_execution
     test_order_action
     test_order_action_integration

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    test_resolved_execution
     test_order_action
     test_order_action_integration
     test_placement_facts

--- a/tests/test_affordability_fx.cpp
+++ b/tests/test_affordability_fx.cpp
@@ -496,9 +496,10 @@ int main() {
     // E2. TradingView converts a realized trade's complete net symbol-currency
     // PnL at the EXIT bar's daily rate, including both percent-commission legs
     // (335/336 exact; archived investigation linked in docs/pages/metrics.md).
-    // Gross account-currency PnL is 50*2 = 100. The entry fee is paid at
-    // entry-time FX: 400*10%*2*1 = 40. The exit fee is paid at exit-time FX:
-    // 450*10%*2*2 = 90. Net PnL is therefore 100 - 40 - 90 = -30.
+    // With qty 1, gross account-currency PnL is 50*FX2 = 100. The entry fee
+    // is paid at entry-time FX: 400*10%*FX1 = 40. The exit fee is paid at
+    // exit-time FX: 450*10%*FX2 = 90. Net PnL is therefore 100 - 40 - 90 =
+    // -30.
     {
         std::vector<Bar> bars = {mk_bar(1000, 400.0), mk_bar(2000, 450.0)};
         const int64_t timestamps[] = {1500};

--- a/tests/test_affordability_fx.cpp
+++ b/tests/test_affordability_fx.cpp
@@ -493,9 +493,9 @@ int main() {
         CHECK(eng.trades() == 0);
     }
 
-    // E2. TradingView converts a realized trade's complete net symbol-currency
-    // PnL at the EXIT bar's daily rate, including both percent-commission legs
-    // (335/336 exact; archived investigation linked in docs/pages/metrics.md).
+    // E2. The former exit-time reconstruction converted both commission legs
+    // at the closing FX rate (archived TV investigation in docs/pages/metrics.md).
+    // Native settlement instead preserves the actual entry payment.
     // With qty 1, gross account-currency PnL is 50*FX2 = 100. The entry fee
     // is paid at entry-time FX: 400*10%*FX1 = 40. The exit fee is paid at
     // exit-time FX: 450*10%*FX2 = 90. Net PnL is therefore 100 - 40 - 90 =

--- a/tests/test_affordability_fx.cpp
+++ b/tests/test_affordability_fx.cpp
@@ -78,6 +78,7 @@ public:
     }
     int trades() const { return trade_count(); }
     double first_pnl() const { return trades() ? get_trade(0).pnl : kNaN; }
+    const Trade& trade(int index) const { return get_trade(index); }
 };
 
 // A default 100%-of-equity order is placed under FX=1.0 and fills on the
@@ -495,7 +496,9 @@ int main() {
     // E2. TradingView converts a realized trade's complete net symbol-currency
     // PnL at the EXIT bar's daily rate, including both percent-commission legs
     // (335/336 exact; archived investigation linked in docs/pages/metrics.md).
-    // gross 50*2 - entry fee 400*10%*2 - exit fee 450*10%*2 = -70.
+    // Gross account-currency PnL is 50*2 = 100. The entry fee is paid at
+    // entry-time FX: 400*10%*2*1 = 40. The exit fee is paid at exit-time FX:
+    // 450*10%*2*2 = 90. Net PnL is therefore 100 - 40 - 90 = -30.
     {
         std::vector<Bar> bars = {mk_bar(1000, 400.0), mk_bar(2000, 450.0)};
         const int64_t timestamps[] = {1500};
@@ -504,13 +507,13 @@ int main() {
         CHECK(eng.set_account_currency_fx_series(timestamps, rates, 1));
         eng.run(bars.data(), (int)bars.size());
         CHECK(eng.trades() == 1);
-        CHECK(std::abs(eng.first_pnl() - (-70.0)) < 1e-12);
+        CHECK(std::abs(eng.first_pnl() - (-30.0)) < 1e-12);
+        CHECK(std::abs(eng.trade(0).commission - 130.0) < 1e-12);
     }
 
-    // E3. The live entry fee stays at its entry-time account value, while a
-    // closed trade intentionally converts both percent-fee legs at exit-time
-    // FX. Cash fee modes are already account-currency-native and remain
-    // unchanged by the provider.
+    // E3. The entry fee is paid at entry-time FX (10), while the exit fee is
+    // paid at exit-time FX (20). The zero-gross trade therefore reports one
+    // uniform account-currency commission total of 30 and net PnL -30.
     {
         std::vector<Bar> bars = {mk_bar(1000, 100.0), mk_bar(2000, 100.0)};
         const int64_t timestamps[] = {1000, 2000};
@@ -523,8 +526,8 @@ int main() {
         CHECK(std::abs(percent.observed_open_commission() - 10.0) < 1e-12);
         CHECK(std::abs(percent.observed_open_profit() - (-10.0)) < 1e-12);
         CHECK(percent.trades() == 1);
-        CHECK(std::abs(percent.trade(0).commission - 40.0) < 1e-12);
-        CHECK(std::abs(percent.trade(0).pnl - (-40.0)) < 1e-12);
+        CHECK(std::abs(percent.trade(0).commission - 30.0) < 1e-12);
+        CHECK(std::abs(percent.trade(0).pnl - (-30.0)) < 1e-12);
 
         EntryFeeAccessorLifecycleProbe cash_order(
             CommissionType::CASH_PER_ORDER, /*value=*/7.0, /*qty=*/1.0);
@@ -547,8 +550,9 @@ int main() {
     }
 
     // E4. Snapshots follow physical pyramid slices across partial exits and
-    // are replaced on reversal. The partial trade still uses rate-2 realized
-    // reporting (40), while the surviving half of the rate-1 L1 fee is 10.
+    // are replaced on reversal. The partial L1 slice pays entry fee 10 at
+    // entry-time FX plus exit fee 20 at rate-2 FX, so its commission is 30;
+    // the surviving L1 fee remains 10 and L2 remains 20.
     {
         std::vector<Bar> bars = {
             mk_bar(1000, 100.0), mk_bar(2000, 100.0),
@@ -564,7 +568,7 @@ int main() {
         CHECK(std::abs(eng.before_partial_second() - 20.0) < 1e-12);
         CHECK(std::abs(eng.after_partial_first() - 10.0) < 1e-12);
         CHECK(std::abs(eng.after_partial_second() - 20.0) < 1e-12);
-        CHECK(std::abs(eng.partial_trade_commission() - 40.0) < 1e-12);
+        CHECK(std::abs(eng.partial_trade_commission() - 30.0) < 1e-12);
         CHECK(eng.reversal_is_short());
         CHECK(std::abs(eng.reversal_commission() - 20.0) < 1e-12);
 

--- a/tests/test_engine_risk.cpp
+++ b/tests/test_engine_risk.cpp
@@ -104,9 +104,33 @@ public:
 
     // --- intraday-loss surface (TradingView's day-scoped rule) ---
     void set_position(bool is_long, double qty, double entry_price) {
+        if (qty == 0.0) {
+            position_side_ = PositionSide::FLAT;
+            position_qty_ = position_entry_price_ = 0.0;
+            position_cycle_seq_ = 0;
+            position_entry_count_ = 0;
+            position_entry_time_ = 0;
+            position_open_bar_ = -1;
+            pyramid_entries_.clear();
+            return;
+        }
         position_side_ = is_long ? PositionSide::LONG : PositionSide::SHORT;
         position_qty_ = qty;
         position_entry_price_ = entry_price;
+        // A risk-triggered close now settles the authoritative physical book.
+        // Seed the actual lot as well as the cached position projection.
+        position_cycle_seq_ = next_position_cycle_seq_++;
+        position_entry_count_ = 1;
+        position_entry_time_ = current_bar_.timestamp;
+        position_open_bar_ = bar_index_;
+        PyramidEntry lot{};
+        lot.price = entry_price;
+        lot.time = current_bar_.timestamp;
+        lot.qty = qty;
+        lot.entry_id = "risk";
+        lot.entry_bar_index = bar_index_;
+        snapshot_entry_commission(lot);
+        pyramid_entries_ = {std::move(lot)};
     }
     void begin_day(const Bar& b) {
         current_bar_ = b;

--- a/tests/test_market_admission_matrix.cpp
+++ b/tests/test_market_admission_matrix.cpp
@@ -67,7 +67,26 @@ void whole_book_and_command_receipts(){
     Matrix closed;closed.raw("seed",1);closed.fire("seed");closed.close_seed();CHECK(closed.position()==0);closed.add("A",3);closed.add("B",2,false);
     CHECK(closed.mirror("A").paired_flat_market_candidate==1&&closed.mirror("A").explicit_flat_admission_candidate==0);
     closed.pair();CHECK(closed.live("A")&&closed.live("B"));closed.observe("real-close-before-entry","A");closed.observe("real-close-before-entry","B");
-    Matrix invalid;invalid.add("infinite",std::numeric_limits<double>::infinity());CHECK(invalid.has("infinite")&&invalid.mirror("infinite").explicit_flat_admission_candidate==1);invalid.observe("legacy-nonfinite-placement","infinite");
+    // Finite capital cannot fund an infinite request. There is no pending
+    // order to mirror; retain the rejected command itself as audit evidence.
+    Matrix invalid;
+    invalid.add("infinite",std::numeric_limits<double>::infinity());
+    CHECK(!invalid.has("infinite")&&invalid.size()==0);
+    CHECK(invalid.position()==0&&invalid.lots().empty()&&invalid.trades()==0);
+    const auto& events=invalid.market_admission_journal().events();
+    CHECK(events.size()==1);
+    for(const auto& event:events){
+        const auto* command=std::get_if<admission::CommandEvent>(&event);
+        CHECK(command!=nullptr);
+        if(!command)continue;
+        CHECK(command->outcome==admission::Outcome::RejectedAffordability);
+        CHECK(command->admitted_incarnation==0&&command->removed.empty()&&command->before.empty());
+        CHECK(command->observation!=nullptr);
+        if(!command->observation)continue;
+        CHECK(command->observation->kind==admission::CommandKind::Entry);
+        CHECK(command->observation->id=="infinite");
+        CHECK(command->observation->requested_quantity==std::numeric_limits<double>::infinity());
+    }
 }
 }
 int main(){

--- a/tests/test_order_action_integration.cpp
+++ b/tests/test_order_action_integration.cpp
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <cmath>
 #include <limits>
+#include <stdexcept>
 #include <utility>
 
 using namespace pineforge;
@@ -18,9 +19,11 @@ struct Access { friend auto access(Tag) { return Member; } };
 struct PartialExitAccess { friend auto access(PartialExitAccess); };
 struct SameSideAccess { friend auto access(SameSideAccess); };
 struct SameBarTransactionAccess { friend auto access(SameBarTransactionAccess); };
+struct MarketFillAccess { friend auto access(MarketFillAccess); };
 template struct Access<PartialExitAccess, &BacktestEngine::execute_partial_exit_qty>;
 template struct Access<SameSideAccess, &BacktestEngine::append_same_side_fill>;
 template struct Access<SameBarTransactionAccess, &BacktestEngine::apply_same_bar_market_tx_reversal>;
+template struct Access<MarketFillAccess, &BacktestEngine::apply_market_order_fill>;
 
 template<class T> struct MemberArguments;
 template<class C, class R, class A, class B, class D>
@@ -105,6 +108,38 @@ public:
         double trail = std::numeric_limits<double>::quiet_NaN();
         (this->*access(SameBarTransactionAccess{}))(order, raw_price,
             current_bar_, trail);
+    }
+    void exhaust_cycles() { next_position_cycle_seq_ = std::numeric_limits<int64_t>::max(); }
+    uint64_t fingerprint() const { return broker_state_hash(); }
+    void seed_short_collision(double source, double materialized) {
+        seed_two_lots();
+        position_open_bar_ = bar_index_;
+        position_qty_ = source + materialized;
+        position_entry_price_ = 100;
+        pyramid_entries_[0].qty = source;
+        pyramid_entries_[1].qty = materialized;
+        pyramid_entries_[0].price = pyramid_entries_[1].price = 100;
+        pyramid_entries_[0].entry_id = "Long";
+        pyramid_entries_[1].entry_id = "__close__Short";
+        for (auto& lot : pyramid_entries_) lot.entry_bar_index = bar_index_;
+        PendingOrder first{}, final{}, materialize{};
+        first.id = "Long";
+        first.type = final.type = materialize.type = OrderType::MARKET;
+        first.is_long = true;
+        first.short_seed_collision_role = ShortSeedCollisionRole::LONG_ENTRY;
+        final.id = "Short";
+        final.is_long = false;
+        final.incarnation = 44;
+        final.created_bar = bar_index_ - 1;
+        final.tv_carry_qty = materialized;
+        final.short_seed_collision_role = ShortSeedCollisionRole::FINAL_SHORT;
+        materialize.id = "__close__Short";
+        materialize.short_seed_collision_role = ShortSeedCollisionRole::MATERIALIZE_LONG;
+        pending_orders_ = {first, final, materialize};
+    }
+    void settle_short_collision() {
+        double trail = std::numeric_limits<double>::quiet_NaN();
+        (this->*access(MarketFillAccess{}))(pending_orders_[1], 100, current_bar_, trail, false);
     }
 
     const std::vector<PyramidEntry>& lots() const { return pyramid_entries_; }
@@ -277,6 +312,69 @@ void transact_closes_fifo_and_crosses_flat() {
     }
 }
 
+void adapter_crossings_are_one_execution() {
+    for (bool from_short : {false, true}) {
+        Book fees;
+        fees.seed_three_units();
+        fees.per_order_fees(); // two historical tickets of3, one current ticket of3
+        if (from_short) fees.make_short();
+        fees.enable_stream_actions();
+        auto five = transaction_order(from_short, 5, 5);
+        fees.transact(five, 120);
+        CHECK(fees.trades().size() == 2 && fees.lots().size() == 1);
+        if (fees.trades().size() == 2 && fees.lots().size() == 1) {
+            const double paid = fees.trades()[0].commission + fees.trades()[1].commission
+                + fees.lots()[0].entry_commission_account;
+            CHECK(std::abs(paid - 9) < 1e-12);
+            CHECK(std::abs(fees.lots()[0].entry_commission_account - 1.2) < 1e-12);
+        }
+        CHECK(fees.stream_actions() == 3);
+
+        Book exhausted;
+        exhausted.seed_three_units();
+        if (from_short) exhausted.make_short();
+        exhausted.enable_stream_actions();
+        exhausted.exhaust_cycles();
+        const auto before = exhausted.fingerprint();
+        bool threw = false;
+        try { exhausted.transact(five, 120); }
+        catch (const std::overflow_error&) { threw = true; }
+        CHECK(threw);
+        CHECK(exhausted.fingerprint() == before);
+        CHECK(exhausted.trades().empty() && exhausted.stream_actions() == 0);
+        CHECK(exhausted.signed_position() == (from_short ? -3 : 3));
+    }
+
+    Book short_seed;
+    short_seed.seed_short_collision(3, 1);
+    short_seed.per_order_fees();
+    short_seed.enable_stream_actions();
+    short_seed.settle_short_collision();
+    CHECK(short_seed.signed_position() == -2 && short_seed.cycle() == 5);
+    CHECK(short_seed.trades().size() == 2 && short_seed.lots().size() == 1);
+    if (short_seed.trades().size() == 2 && short_seed.lots().size() == 1) {
+        CHECK(short_seed.trades()[0].entry_id == "Long");
+        CHECK(short_seed.trades()[1].entry_id == "__close__Short");
+        const double paid = short_seed.trades()[0].commission + short_seed.trades()[1].commission
+            + short_seed.lots()[0].entry_commission_account;
+        CHECK(std::abs(paid - 9) < 1e-12);
+        CHECK(std::abs(short_seed.lots()[0].entry_commission_account - 1) < 1e-12);
+    }
+    CHECK(short_seed.stream_actions() == 3);
+
+    Book refused;
+    refused.seed_short_collision(3, 1);
+    refused.enable_stream_actions();
+    refused.exhaust_cycles();
+    const auto before = refused.fingerprint();
+    bool threw = false;
+    try { refused.settle_short_collision(); }
+    catch (const std::overflow_error&) { threw = true; }
+    CHECK(threw && refused.fingerprint() == before);
+    CHECK(refused.signed_position() == 4 && refused.trades().empty());
+    CHECK(refused.stream_actions() == 0);
+}
+
 }
 
 int main() {
@@ -284,6 +382,7 @@ int main() {
     reduce_handles_short_side_and_slippage_once();
     append_preserves_lot_metadata_and_stream_action();
     transact_closes_fifo_and_crosses_flat();
+    adapter_crossings_are_one_execution();
     std::printf("order action integration: %d checks, %d failures\n", checks, failures);
     return failures == 0 ? 0 : 1;
 }

--- a/tests/test_order_action_integration.cpp
+++ b/tests/test_order_action_integration.cpp
@@ -157,7 +157,10 @@ void reduce_preserves_fifo_identity_and_scales_survivor() {
     order_fee.per_order_fees();
     order_fee.partial(120.0, 3.0);
     CHECK(order_fee.lots().size() == 1);
-    CHECK(order_fee.lots()[0].entry_commission_account == 3.0);
+    // One cash-per-order ticket is allocated proportionally to the physical
+    // FIFO slices: B survives with 2/3 of its original 3-unit lot, so its
+    // retained paid fee is 3 * 2/3 = 2, not a second full ticket.
+    CHECK(order_fee.lots()[0].entry_commission_account == 2.0);
 }
 
 void reduce_handles_short_side_and_slippage_once() {

--- a/tests/test_pooc_coof_reversal_gross_admission.cpp
+++ b/tests/test_pooc_coof_reversal_gross_admission.cpp
@@ -310,6 +310,12 @@ static void test_green_mutated_two_order_books_fail_closed() {
         CHECK(probe.last_error().empty());
         CHECK(probe.observed_trades == expected_trades);
         CHECK_NEAR(probe.observed_size, expected_size, 1e-9);
+        for (int i = 0; i < probe.trade_count(); ++i) {
+            const auto& trade = probe.get_trade(i);
+            CHECK(std::isfinite(trade.qty) && trade.qty > 0.0);
+            CHECK(std::isfinite(trade.pnl));
+            CHECK(std::isfinite(trade.commission));
+        }
     };
 
     run("same-bar replacement stays on ordinary path",

--- a/tests/test_resolved_execution.cpp
+++ b/tests/test_resolved_execution.cpp
@@ -377,9 +377,32 @@ void zero_fee_waiver_and_rebate() {
         near(rebate.rows()[0].commission,-5);
         CHECK(rebate.rows()[0].exit_id=="RX" && rebate.rows()[0].entry_id=="R");
         CHECK(rebate.rows()[0].qty==2);
+        near(rebate.rows()[0].max_drawdown,0);
+        near(rebate.rows()[0].max_runup,5);
+        near(rebate.rows()[0].pnl,5);
     }
     near(rebate.net(),5);
     near(rebate.marked(100),10005);
+}
+
+void native_percent_fee_uses_absolute_resolved_notional() {
+    Book native;
+    native.fee(CommissionType::PERCENT, 1.0);
+    const auto opened = native.settle(order_action::Transact{2}, -100,
+                                      "NEG", 84);
+    CHECK(opened.status==execution::Status::Applied);
+    CHECK(native.lots().size()==1);
+    if(!native.lots().empty()) near(native.lots()[0].entry_commission_account,2);
+    near(native.marked(-100),9998);
+
+    const auto flat = native.settle(execution::Flatten{}, -100, "NEG-X", 85);
+    CHECK(flat.status==execution::Status::Applied);
+    CHECK(native.position()==0 && native.lots().empty());
+    CHECK(native.rows().size()==1);
+    if(!native.rows().empty()) {
+        near(native.rows()[0].commission,4);
+        near(native.rows()[0].pnl,-4);
+    }
 }
 
 void quote_split_does_not_reprice_entry_costs() {
@@ -664,6 +687,7 @@ int main() {
     transact_same_side_and_reduce_cannot_flip();
     quoted_fee_overrides_unsuitable_modeled_rate();
     zero_fee_waiver_and_rebate();
+    native_percent_fee_uses_absolute_resolved_notional();
     quote_split_does_not_reprice_entry_costs();
     quote_split_across_closed_lots();
     quantity_quoted_fees_are_not_tickets();

--- a/tests/test_resolved_execution.cpp
+++ b/tests/test_resolved_execution.cpp
@@ -1,0 +1,676 @@
+// Literal native settlement contracts; no Engine::run, feed or reference data.
+#include <pineforge/engine.hpp>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+using namespace pineforge;
+namespace {
+int checks = 0, failures = 0;
+#define CHECK(x) do { ++checks; if (!(x)) { ++failures; std::printf("FAIL %d: %s\n", __LINE__, #x); } } while (0)
+void near(double a, double b) {
+    const bool equal = std::abs(a-b) <= 1e-12 * std::max(1.0, std::max(std::abs(a),std::abs(b)));
+    if (!equal) std::printf("actual=%.17g expected=%.17g\n",a,b);
+    CHECK(equal);
+}
+class Book final : public BacktestEngine {
+public:
+    Book() {
+        current_bar_ = {100, 125, 95, 120, 1, 60000};
+        bar_index_ = 1;
+        initial_capital_ = 10000;
+        commission_type_ = CommissionType::CASH_PER_CONTRACT;
+        commission_value_ = 0;
+        stream_observe_actions_ = true;
+        slippage_ = 9;
+        qty_step_ = 10;
+        pyramiding_ = 1;
+    }
+    void on_bar(const Bar&) override {}
+    execution::Result settle(execution::Action action, double price = 120,
+                             const char* id = "N", uint64_t incarnation = 100,
+                             std::optional<double> commission_account = {}) {
+        return settle_resolved_execution(action,
+            execution::Fill{price,id,"native",incarnation,commission_account});
+    }
+    void exhaust_cycles(int64_t next = std::numeric_limits<int64_t>::max()) {
+        next_position_cycle_seq_ = next;
+    }
+    void exhaust_stream() {
+        stream_action_sequence_ = std::numeric_limits<uint64_t>::max();
+    }
+    void exhaust_close_counter(int kind, int remaining = 0) {
+        const int value = std::numeric_limits<int>::max() - remaining;
+        if (kind == 0) win_trades_count_ = value;
+        if (kind == 1) loss_trades_count_ = value;
+        if (kind == 2) eventrades_count_ = value;
+        if (kind == 3) { cons_loss_day_count_ = value; last_loss_day_ = -1; }
+    }
+    void exhaust_entries() { position_entry_count_ = std::numeric_limits<int>::max(); }
+    void stale_projection() { position_qty_ = 10; position_entry_price_ = 999; }
+    void seed(std::vector<double> quantities, bool short_side = false) {
+        position_side_ = short_side ? PositionSide::SHORT : PositionSide::LONG;
+        position_cycle_seq_ = 4;
+        next_position_cycle_seq_ = 5;
+        position_open_bar_ = 0;
+        position_qty_ = 0;
+        double weighted = 0;
+        for (size_t i=0;i<quantities.size();++i) {
+            const double price = 100 + 10*i;
+            PyramidEntry lot{price,1000+static_cast<int64_t>(i),quantities[i],std::string(1,static_cast<char>('A'+i)),0};
+            lot.entry_incarnation = 10+i;
+            lot.max_runup = 60;
+            lot.max_drawdown = 30;
+            snapshot_entry_commission(lot);
+            pyramid_entries_.push_back(lot);
+            position_qty_ += lot.qty;
+            weighted += lot.qty*lot.price;
+            id_unclosed_qty_[lot.entry_id] = lot.qty;
+            cycle_filled_entry_ids_.insert(lot.entry_id);
+        }
+        position_entry_price_ = weighted/position_qty_;
+    }
+    void fee(CommissionType type,double value) { commission_type_=type; commission_value_=value; }
+    void fx(double value) { account_currency_fx_=value; }
+    double position() const { return signed_position_size(); }
+    double average() const { return position_entry_price_; }
+    double net() const { return net_profit_sum_; }
+    double marked(double price) const { return marked_equity(price); }
+    int64_t cycle() const { return position_cycle_seq_; }
+    const auto& lots() const { return pyramid_entries_; }
+    const auto& rows() const { return trades_; }
+    const auto& actions() const { return stream_order_actions_; }
+    uint64_t fingerprint() const { return broker_state_hash(); }
+};
+
+void native_actions() {
+    for (bool short_side : {false,true}) {
+        const double sign = short_side ? -1 : 1;
+        Book b;
+        b.seed({1,2},short_side);
+        const auto r=b.settle(order_action::Transact{-sign*2},120,"reduce",20);
+        CHECK(r.status==execution::Status::Applied);
+        CHECK(r.closed_units==2 && r.opened_units==0);
+        CHECK(b.position()==sign && b.cycle()==4);
+        CHECK(b.rows().size()==2 && b.lots().size()==1);
+        if(b.rows().size()==2) {
+            CHECK(b.rows()[0].entry_id=="A" && b.rows()[0].qty==1);
+            CHECK(b.rows()[1].entry_id=="B" && b.rows()[1].qty==1);
+            CHECK(b.rows()[0].exit_id=="reduce" && b.rows()[1].exit_comment=="native");
+            CHECK(b.rows()[0].exit_price==120); // already resolved: no slippage
+        }
+        if(!b.lots().empty()) {
+            CHECK(b.lots()[0].entry_incarnation==11);
+            CHECK(b.lots()[0].qty==1);
+            CHECK(b.lots()[0].max_runup==30 && b.lots()[0].max_drawdown==15);
+        }
+        CHECK(b.actions().size()==2);
+        if(b.actions().size()==2) {
+            CHECK(!b.actions()[0].is_entry && !b.actions()[1].is_entry);
+            CHECK(b.actions()[0].order_id=="reduce");
+        }
+        auto flat=b.settle(execution::Flatten{});
+        CHECK(flat.status==execution::Status::Applied);
+        CHECK(b.position()==0 && b.lots().empty() && b.cycle()==0);
+
+        Book flip;
+        flip.seed({1,2},short_side);
+        auto crossed=flip.settle(order_action::Transact{-sign*5},120.125,"flip",30);
+        CHECK(crossed.status==execution::Status::Applied);
+        CHECK(crossed.closed_units==3 && crossed.opened_units==-sign*2);
+        CHECK(flip.position()==-sign*2 && flip.cycle()==5);
+        CHECK(flip.lots().size()==1 && flip.rows().size()==2);
+        CHECK(flip.actions().size()==3);
+        if(flip.actions().size()==3) {
+            CHECK(!flip.actions()[0].is_entry && !flip.actions()[1].is_entry);
+            CHECK(flip.actions()[2].is_entry && flip.actions()[2].quantity==2);
+            CHECK(flip.actions()[2].price==120.125);
+            CHECK(flip.actions()[2].order_id=="flip" && flip.actions()[2].comment=="native");
+        }
+    }
+}
+
+void actual_lots_define_quantity() {
+    for (bool short_side : {false,true}) {
+        Book b;
+        b.seed({0.1,0.2},short_side);
+        auto r=b.settle(order_action::Reduce{0.1});
+        CHECK(r.status==execution::Status::Applied);
+        CHECK(b.position()==(short_side?-0.2:0.2));
+        CHECK(b.lots().size()==1 && b.lots()[0].qty==0.2);
+        CHECK(b.average()==110);
+        CHECK(b.settle(execution::Flatten{}).status==execution::Status::Applied);
+        CHECK(b.position()==0 && b.lots().empty());
+    }
+    Book partial;
+    partial.seed({0.1,0.2});
+    CHECK(partial.settle(order_action::Reduce{0.3}).status==execution::Status::Applied);
+    CHECK(partial.lots().size()==1);
+    if(!partial.lots().empty()) CHECK(partial.lots()[0].qty==0.2-(0.3-0.1));
+    CHECK(partial.position()>0); // no epsilon silently destroys positive dust
+    CHECK(partial.settle(execution::Flatten{}).status==execution::Status::Applied);
+    CHECK(partial.position()==0);
+
+    Book explicit_all;
+    explicit_all.seed({1,0.4});
+    CHECK(explicit_all.settle(execution::Flatten{}).status==execution::Status::Applied);
+    CHECK(explicit_all.rows().size()==2);
+    if(explicit_all.rows().size()==2) CHECK(explicit_all.rows()[1].qty==0.4);
+    CHECK(explicit_all.position()==0);
+
+    Book oversized;
+    oversized.seed({1,0.4});
+    CHECK(oversized.settle(order_action::Reduce{99}).status==execution::Status::Applied);
+    CHECK(oversized.position()==0 && oversized.lots().empty());
+}
+
+void no_sizing_or_admission_permissions() {
+    Book b;
+    CHECK(b.settle(order_action::Transact{0.25},120.125,"first",40).status==execution::Status::Applied);
+    CHECK(b.settle(order_action::Transact{0.5},121.125,"second",41).status==execution::Status::Applied);
+    CHECK(b.position()==0.75 && b.lots().size()==2); // qty step10 / cap1 do not re-admit a fill
+    if(b.lots().size()==2) {
+        CHECK(b.lots()[0].qty==0.25 && b.lots()[1].qty==0.5);
+        CHECK(b.lots()[0].price==120.125 && b.lots()[1].price==121.125);
+        CHECK(b.lots()[1].entry_incarnation==41);
+    }
+    Book tiny;
+    CHECK(tiny.settle(order_action::Transact{2e-12}).status==execution::Status::Applied);
+    CHECK(tiny.settle(order_action::Reduce{1e-12}).status==execution::Status::Applied);
+    CHECK(tiny.position()==1e-12 && tiny.lots().size()==1);
+    CHECK(tiny.settle(execution::Flatten{}).status==execution::Status::Applied);
+    CHECK(tiny.position()==0);
+}
+
+void invalid_and_zero_leave_state() {
+    Book b;
+    b.seed({1,2});
+    const auto before=b.fingerprint();
+    for(auto action : {execution::Action{order_action::Reduce{0}},execution::Action{order_action::Transact{0}}}) {
+        CHECK(b.settle(action).status==execution::Status::NoEffect);
+        CHECK(b.fingerprint()==before);
+    }
+    CHECK(b.settle(order_action::Reduce{-1}).status==execution::Status::InvalidQuantity);
+    CHECK(b.settle(order_action::Transact{std::numeric_limits<double>::infinity()}).status==execution::Status::InvalidQuantity);
+    CHECK(b.settle(execution::Flatten{},std::numeric_limits<double>::quiet_NaN()).status==execution::Status::InvalidPrice);
+    CHECK(b.settle(order_action::Reduce{std::numeric_limits<double>::denorm_min()}).status==execution::Status::UnrepresentableQuantity);
+    CHECK(b.fingerprint()==before && b.rows().empty() && b.actions().empty());
+    Book flat;
+    CHECK(flat.settle(order_action::Reduce{99}).status==execution::Status::NoEffect);
+    CHECK(flat.settle(execution::Flatten{}).status==execution::Status::NoEffect);
+    CHECK(flat.position()==0 && flat.actions().empty());
+}
+
+// Cost expectations follow actual cash charged at entry, not a vendor score.
+void historical_costs_are_not_repriced() {
+    Book b;
+    b.fee(CommissionType::PERCENT,1);
+    CHECK(b.settle(order_action::Transact{2},100).status==execution::Status::Applied);
+    CHECK(b.lots()[0].entry_commission_account==2);
+    near(b.marked(100),9998);
+    b.fx(2);
+    CHECK(b.settle(order_action::Reduce{1},100).status==execution::Status::Applied);
+    CHECK(b.rows().size()==1);
+    if(!b.rows().empty()) near(b.rows()[0].commission,3); // entry1 at FX1 + exit2 at FX2
+    near(b.net(),-3);
+    if(!b.lots().empty()) near(b.lots()[0].entry_commission_account,1);
+    near(b.marked(100),9996);
+
+    Book ticket;
+    ticket.fee(CommissionType::CASH_PER_ORDER,6);
+    CHECK(ticket.settle(order_action::Transact{3},100).status==execution::Status::Applied);
+    near(ticket.marked(100),9994);
+    CHECK(ticket.settle(order_action::Reduce{1},100).status==execution::Status::Applied);
+    if(!ticket.rows().empty()) near(ticket.rows()[0].commission,8); // allocated entry2 + this exit6
+    if(!ticket.lots().empty()) near(ticket.lots()[0].entry_commission_account,4);
+    near(ticket.marked(100),9988);
+    CHECK(ticket.settle(execution::Flatten{},100).status==execution::Status::Applied);
+    near(ticket.net(),-18); // one entry ticket6 plus two exit tickets6 each
+    near(ticket.marked(100),9982);
+
+    Book several;
+    several.fee(CommissionType::CASH_PER_ORDER,6);
+    CHECK(several.settle(order_action::Transact{1},100,"A",40).status==execution::Status::Applied);
+    CHECK(several.settle(order_action::Transact{2},100,"B",41).status==execution::Status::Applied);
+    near(several.marked(100),9988);
+    CHECK(several.settle(execution::Flatten{},100).status==execution::Status::Applied);
+    near(several.net(),-18); // two entry tickets plus one exit, not one fee per row
+    near(several.marked(100),9982);
+
+    Book reversal;
+    reversal.fee(CommissionType::CASH_PER_ORDER,6);
+    CHECK(reversal.settle(order_action::Transact{3},100).status==execution::Status::Applied);
+    near(reversal.marked(100),9994);
+    CHECK(reversal.settle(order_action::Transact{-5},100).status==execution::Status::Applied);
+    CHECK(reversal.position()==-2);
+    near(reversal.marked(100),9988); // the single transaction paid one ticket
+    CHECK(reversal.settle(execution::Flatten{},100).status==execution::Status::Applied);
+    near(reversal.net(),-18);
+}
+
+bool overflowed(Book& book, execution::Action action, double price = 120,
+                const char* id = "N", uint64_t incarnation = 100) {
+    try {
+        book.settle(action, price, id, incarnation);
+        return false;
+    } catch (const std::overflow_error&) {
+        return true;
+    }
+}
+
+void transact_same_side_and_reduce_cannot_flip() {
+    Book add;
+    add.seed({1,2});
+    const auto r = add.settle(order_action::Transact{2},130,"add",50);
+    CHECK(r.status==execution::Status::Applied);
+    CHECK(r.closed_units==0 && r.opened_units==2);
+    CHECK(add.position()==5 && add.cycle()==4 && add.lots().size()==3);
+    if(add.lots().size()==3) {
+        CHECK(add.lots()[2].qty==2 && add.lots()[2].price==130);
+        CHECK(add.lots()[2].entry_id=="add" && add.lots()[2].entry_incarnation==50);
+        CHECK(add.lots()[2].entry_comment=="native");
+    }
+    CHECK(add.actions().size()==1);
+    if(!add.actions().empty()) {
+        CHECK(add.actions()[0].is_entry && add.actions()[0].quantity==2);
+        CHECK(add.actions()[0].order_id=="add" && add.actions()[0].price==130);
+        CHECK(add.actions()[0].entry_incarnation==50);
+    }
+
+    Book short_add;
+    short_add.seed({1},true);
+    const auto s = short_add.settle(order_action::Transact{-2},130,"sadd",51);
+    CHECK(s.status==execution::Status::Applied);
+    CHECK(s.closed_units==0 && s.opened_units==-2);
+    CHECK(short_add.position()==-3 && short_add.lots().size()==2);
+    if(short_add.lots().size()==2) CHECK(short_add.lots()[1].qty==2 && short_add.lots()[1].price==130);
+
+    Book reduce;
+    reduce.seed({1,2});
+    const auto x = reduce.settle(order_action::Reduce{99});
+    CHECK(x.status==execution::Status::Applied);
+    CHECK(x.closed_units==3 && x.opened_units==0);
+    CHECK(reduce.position()==0 && reduce.lots().empty() && reduce.cycle()==0);
+    CHECK(reduce.rows().size()==2);
+    if(reduce.rows().size()==2) {
+        CHECK(reduce.rows()[0].qty==1 && reduce.rows()[1].qty==2);
+        CHECK(reduce.rows()[0].entry_id=="A" && reduce.rows()[1].entry_id=="B");
+    }
+}
+
+void quoted_fee_overrides_unsuitable_modeled_rate() {
+    Book inf;
+    inf.fee(CommissionType::CASH_PER_ORDER, std::numeric_limits<double>::infinity());
+    const double mark0 = inf.marked(100);
+    near(mark0, 10000);
+    const auto opened = inf.settle(order_action::Transact{2},100,"Q",70,7);
+    CHECK(opened.status==execution::Status::Applied);
+    CHECK(opened.closed_units==0 && opened.opened_units==2);
+    CHECK(inf.position()==2 && inf.lots().size()==1);
+    if(!inf.lots().empty()) {
+        near(inf.lots()[0].entry_commission_account,7);
+        CHECK(inf.lots()[0].entry_id=="Q" && inf.lots()[0].qty==2);
+        CHECK(inf.lots()[0].entry_incarnation==70);
+    }
+    near(inf.marked(100), 9993);
+    near(mark0 - inf.marked(100), 7);
+    CHECK(inf.actions().size()==1);
+    if(!inf.actions().empty()) {
+        CHECK(inf.actions()[0].is_entry && inf.actions()[0].quantity==2);
+        CHECK(inf.actions()[0].order_id=="Q" && inf.actions()[0].comment=="native");
+        CHECK(inf.actions()[0].entry_incarnation==70 && inf.actions()[0].price==100);
+        CHECK(inf.actions()[0].is_long);
+    }
+
+    Book modeled;
+    modeled.fee(CommissionType::PERCENT, std::numeric_limits<double>::infinity());
+    const auto before = modeled.fingerprint();
+    const auto refused = modeled.settle(order_action::Transact{2},100);
+    CHECK(refused.status==execution::Status::InvalidAccounting);
+    CHECK(refused.closed_units==0 && refused.opened_units==0);
+    CHECK(modeled.fingerprint()==before && modeled.position()==0);
+    CHECK(modeled.lots().empty() && modeled.rows().empty() && modeled.actions().empty());
+}
+
+void zero_fee_waiver_and_rebate() {
+    Book waive;
+    waive.fee(CommissionType::CASH_PER_ORDER, 6);
+    near(waive.marked(100), 10000);
+    CHECK(waive.settle(order_action::Transact{3},100,"W",80,0.0).status==execution::Status::Applied);
+    CHECK(waive.lots().size()==1);
+    if(!waive.lots().empty()) CHECK(waive.lots()[0].entry_commission_account==0);
+    near(waive.marked(100), 10000);
+    CHECK(waive.actions().size()==1);
+    if(!waive.actions().empty()) CHECK(waive.actions()[0].is_entry && waive.actions()[0].order_id=="W");
+    CHECK(waive.settle(execution::Flatten{},100,"WX",81,0.0).status==execution::Status::Applied);
+    CHECK(waive.rows().size()==1);
+    if(!waive.rows().empty()) {
+        near(waive.rows()[0].commission,0);
+        CHECK(waive.rows()[0].exit_id=="WX" && waive.rows()[0].qty==3);
+    }
+    near(waive.net(),0);
+    near(waive.marked(100),10000);
+
+    Book rebate;
+    rebate.fee(CommissionType::CASH_PER_CONTRACT, 9);
+    const double rebate0 = rebate.marked(100);
+    const auto r = rebate.settle(order_action::Transact{2},100,"R",82,-5);
+    CHECK(r.status==execution::Status::Applied);
+    CHECK(rebate.lots().size()==1);
+    if(!rebate.lots().empty()) {
+        near(rebate.lots()[0].entry_commission_account,-5);
+        CHECK(rebate.lots()[0].entry_id=="R");
+    }
+    near(rebate.marked(100), 10005);
+    near(rebate0 - rebate.marked(100), -5);
+    CHECK(rebate.actions().size()==1);
+    if(!rebate.actions().empty()) {
+        CHECK(rebate.actions()[0].is_entry && rebate.actions()[0].order_id=="R");
+        CHECK(rebate.actions()[0].quantity==2);
+    }
+    CHECK(rebate.settle(execution::Flatten{},100,"RX",83,0.0).status==execution::Status::Applied);
+    CHECK(rebate.rows().size()==1);
+    if(!rebate.rows().empty()) {
+        near(rebate.rows()[0].commission,-5);
+        CHECK(rebate.rows()[0].exit_id=="RX" && rebate.rows()[0].entry_id=="R");
+        CHECK(rebate.rows()[0].qty==2);
+    }
+    near(rebate.net(),5);
+    near(rebate.marked(100),10005);
+}
+
+void quote_split_does_not_reprice_entry_costs() {
+    Book b;
+    b.fee(CommissionType::PERCENT, 50);
+    const double mark0 = b.marked(100);
+    near(mark0, 10000);
+    CHECK(b.settle(order_action::Transact{4},100,"E",90,8).status==execution::Status::Applied);
+    CHECK(b.lots().size()==1);
+    if(!b.lots().empty()) near(b.lots()[0].entry_commission_account,8);
+    near(b.marked(100),9992);
+    near(mark0 - b.marked(100),8);
+
+    const double before_flip = b.marked(100);
+    const auto flip = b.settle(order_action::Transact{-6},100,"F",91,12);
+    CHECK(flip.status==execution::Status::Applied);
+    CHECK(flip.closed_units==4 && flip.opened_units==-2);
+    CHECK(b.position()==-2 && b.cycle()==2); // first entry owns cycle1; reversal opens cycle2
+    CHECK(b.rows().size()==1 && b.lots().size()==1);
+    if(!b.rows().empty()) {
+        near(b.rows()[0].commission,16); // paid entry 8 + close share 8 of ticket 12
+        CHECK(b.rows()[0].exit_id=="F" && b.rows()[0].entry_id=="E");
+        CHECK(b.rows()[0].qty==4 && b.rows()[0].exit_price==100);
+        near(b.rows()[0].pnl,-16);
+    }
+    if(!b.lots().empty()) {
+        near(b.lots()[0].entry_commission_account,4); // residue of the one ticket
+        CHECK(b.lots()[0].entry_id=="F" && b.lots()[0].entry_incarnation==91);
+        CHECK(b.lots()[0].qty==2 && b.lots()[0].price==100);
+        CHECK(b.lots()[0].entry_comment=="native");
+    }
+    near(b.marked(100),9980);
+    near(before_flip - b.marked(100),12);
+    CHECK(b.actions().size()==3);
+    if(b.actions().size()==3) {
+        CHECK(b.actions()[0].is_entry && b.actions()[0].order_id=="E");
+        CHECK(b.actions()[0].quantity==4 && b.actions()[0].is_long);
+        CHECK(!b.actions()[1].is_entry && b.actions()[1].order_id=="F");
+        CHECK(b.actions()[1].quantity==4 && b.actions()[1].comment=="native");
+        CHECK(b.actions()[2].is_entry && b.actions()[2].order_id=="F");
+        CHECK(b.actions()[2].quantity==2 && !b.actions()[2].is_long);
+        CHECK(b.actions()[2].price==100 && b.actions()[2].entry_incarnation==91);
+    }
+
+    b.fee(CommissionType::CASH_PER_ORDER, 99);
+    b.fx(8);
+    const double before_close = b.marked(100);
+    near(before_close,9980); // remaining entry 4 is not FX/schedule-repriced
+    CHECK(b.settle(execution::Flatten{},100,"Z",92,3).status==execution::Status::Applied);
+    CHECK(b.rows().size()==2 && b.lots().empty() && b.position()==0);
+    if(b.rows().size()==2) {
+        near(b.rows()[1].commission,7); // stored 4 + this ticket 3, not 99 and not FX 8
+        CHECK(b.rows()[1].entry_id=="F" && b.rows()[1].exit_id=="Z");
+        CHECK(b.rows()[1].qty==2 && b.rows()[1].is_long==false);
+        near(b.rows()[1].pnl,-7);
+    }
+    near(before_close - b.marked(100),3);
+    near(b.net(),-23);
+    near(b.marked(100),9977);
+}
+
+void quote_split_across_closed_lots() {
+    Book split;
+    CHECK(split.settle(order_action::Transact{1},100,"A",40,6).status==execution::Status::Applied);
+    CHECK(split.settle(order_action::Transact{2},100,"B",41,6).status==execution::Status::Applied);
+    CHECK(split.lots().size()==2 && split.position()==3);
+    if(split.lots().size()==2) {
+        near(split.lots()[0].entry_commission_account,6);
+        near(split.lots()[1].entry_commission_account,6);
+    }
+    near(split.marked(100),9988);
+    const double before = split.marked(100);
+    const auto flat = split.settle(execution::Flatten{},100,"X",42,9);
+    CHECK(flat.status==execution::Status::Applied);
+    CHECK(flat.closed_units==3 && flat.opened_units==0);
+    CHECK(split.rows().size()==2 && split.position()==0 && split.lots().empty());
+    if(split.rows().size()==2) {
+        near(split.rows()[0].commission,9); // allocated 6 + share 3 of ticket 9
+        near(split.rows()[1].commission,12); // allocated 6 + residue 6
+        CHECK(split.rows()[0].entry_id=="A" && split.rows()[1].entry_id=="B");
+        CHECK(split.rows()[0].exit_id=="X" && split.rows()[1].exit_id=="X");
+        CHECK(split.rows()[0].qty==1 && split.rows()[1].qty==2);
+        CHECK(split.rows()[0].exit_comment=="native");
+    }
+    near(before - split.marked(100),9);
+    near(split.net(),-21);
+    near(split.marked(100),9979);
+    CHECK(split.actions().size()==4);
+    if(split.actions().size()==4) {
+        CHECK(split.actions()[0].is_entry && split.actions()[0].order_id=="A");
+        CHECK(split.actions()[1].is_entry && split.actions()[1].order_id=="B");
+        CHECK(!split.actions()[2].is_entry && split.actions()[2].order_id=="X");
+        CHECK(!split.actions()[3].is_entry && split.actions()[3].order_id=="X");
+        CHECK(split.actions()[2].quantity==1 && split.actions()[3].quantity==2);
+    }
+}
+
+void quantity_quoted_fees_are_not_tickets() {
+    Book per;
+    per.fee(CommissionType::CASH_PER_CONTRACT, 2);
+    const double mark0 = per.marked(100);
+    CHECK(per.settle(order_action::Transact{3},100,"C",60).status==execution::Status::Applied);
+    CHECK(per.lots().size()==1);
+    if(!per.lots().empty()) near(per.lots()[0].entry_commission_account,6);
+    near(per.marked(100),9994);
+    near(mark0 - per.marked(100),6);
+    const auto cross = per.settle(order_action::Transact{-5},100,"X",61);
+    CHECK(cross.status==execution::Status::Applied);
+    CHECK(cross.closed_units==3 && cross.opened_units==-2);
+    CHECK(per.position()==-2 && per.lots().size()==1 && per.rows().size()==1);
+    if(!per.rows().empty()) near(per.rows()[0].commission,12); // allocated 6 + exit 3*2
+    if(!per.lots().empty()) near(per.lots()[0].entry_commission_account,4); // open 2*2
+    near(per.marked(100),9984); // 10000-12-4; close+open quantity quotes, not one ticket
+}
+
+void quoted_no_effect_and_nonfinite_are_refused() {
+    Book b;
+    b.seed({1,2});
+    const auto before = b.fingerprint();
+    for (auto action : {execution::Action{order_action::Reduce{0}},
+                        execution::Action{order_action::Transact{0}}}) {
+        const auto r = b.settle(action,120,"N",100,1.0);
+        CHECK(r.status==execution::Status::InvalidAccounting);
+        CHECK(r.closed_units==0 && r.opened_units==0);
+        CHECK(b.fingerprint()==before);
+    }
+    CHECK(b.settle(order_action::Reduce{0},120,"N",100,-2.5).status==execution::Status::InvalidAccounting);
+    CHECK(b.settle(order_action::Transact{1},120,"N",100,
+        std::numeric_limits<double>::infinity()).status==execution::Status::InvalidAccounting);
+    CHECK(b.settle(order_action::Transact{1},120,"N",100,
+        std::numeric_limits<double>::quiet_NaN()).status==execution::Status::InvalidAccounting);
+    CHECK(b.settle(order_action::Reduce{0}).status==execution::Status::NoEffect);
+    CHECK(b.settle(order_action::Transact{0},120,"N",100,0.0).status==execution::Status::NoEffect);
+    CHECK(b.fingerprint()==before && b.rows().empty() && b.actions().empty());
+    CHECK(b.position()==3 && b.lots().size()==2);
+
+    Book flat;
+    const auto flat_before = flat.fingerprint();
+    CHECK(flat.settle(order_action::Reduce{99},120,"N",100,2.0).status==execution::Status::InvalidAccounting);
+    CHECK(flat.settle(execution::Flatten{},120,"N",100,-1.0).status==execution::Status::InvalidAccounting);
+    CHECK(flat.settle(order_action::Transact{0},120,"N",100,4.0).status==execution::Status::InvalidAccounting);
+    CHECK(flat.settle(execution::Flatten{}).status==execution::Status::NoEffect);
+    CHECK(flat.settle(order_action::Reduce{99}).status==execution::Status::NoEffect);
+    CHECK(flat.fingerprint()==flat_before && flat.position()==0);
+    CHECK(flat.actions().empty() && flat.rows().empty() && flat.lots().empty());
+}
+
+void finite_zero_and_negative_prices() {
+    Book zero;
+    CHECK(zero.settle(order_action::Transact{2},0,"Z",11).status==execution::Status::Applied);
+    CHECK(zero.position()==2 && zero.lots().size()==1);
+    if(!zero.lots().empty()) {
+        CHECK(zero.lots()[0].price==0 && zero.lots()[0].qty==2);
+        CHECK(zero.lots()[0].entry_id=="Z" && zero.lots()[0].entry_incarnation==11);
+    }
+    near(zero.marked(0),10000);
+    CHECK(zero.actions().size()==1);
+    if(!zero.actions().empty()) CHECK(zero.actions()[0].price==0 && zero.actions()[0].is_entry);
+    CHECK(zero.settle(execution::Flatten{},0,"ZX",12).status==execution::Status::Applied);
+    CHECK(zero.position()==0 && zero.lots().empty());
+    CHECK(zero.rows().size()==1);
+    if(!zero.rows().empty()) {
+        CHECK(zero.rows()[0].entry_price==0 && zero.rows()[0].exit_price==0);
+        CHECK(zero.rows()[0].qty==2 && zero.rows()[0].exit_id=="ZX");
+    }
+
+    Book neg;
+    CHECK(neg.settle(order_action::Transact{1},-8,"S",13).status==execution::Status::Applied);
+    CHECK(neg.position()==1 && neg.lots().size()==1);
+    if(!neg.lots().empty()) CHECK(neg.lots()[0].price==-8 && neg.lots()[0].qty==1);
+    near(neg.marked(-8),10000);
+    near(neg.marked(0),10008);
+    const auto closed = neg.settle(order_action::Reduce{1},-8,"SX",14);
+    CHECK(closed.status==execution::Status::Applied);
+    CHECK(closed.closed_units==1 && closed.opened_units==0);
+    CHECK(neg.position()==0 && neg.lots().empty());
+    CHECK(neg.rows().size()==1);
+    if(!neg.rows().empty()) {
+        CHECK(neg.rows()[0].entry_price==-8 && neg.rows()[0].exit_price==-8);
+        CHECK(neg.rows()[0].exit_id=="SX");
+    }
+}
+
+void exhausted_counters_throw_before_effects() {
+    Book cycle;
+    cycle.seed({1,2});
+    cycle.exhaust_cycles();
+    const auto cycle_before = cycle.fingerprint();
+    CHECK(overflowed(cycle, order_action::Transact{-5},120,"flip",30));
+    CHECK(cycle.fingerprint()==cycle_before);
+    CHECK(cycle.position()==3 && cycle.lots().size()==2 && cycle.cycle()==4);
+    CHECK(cycle.rows().empty() && cycle.actions().empty());
+
+    Book from_flat;
+    from_flat.exhaust_cycles();
+    const auto flat_before = from_flat.fingerprint();
+    CHECK(overflowed(from_flat, order_action::Transact{1}));
+    CHECK(from_flat.fingerprint()==flat_before && from_flat.position()==0);
+    CHECK(from_flat.lots().empty() && from_flat.actions().empty());
+
+    Book nonpos;
+    nonpos.exhaust_cycles(0);
+    const auto nonpos_before = nonpos.fingerprint();
+    CHECK(overflowed(nonpos, order_action::Transact{1}));
+    CHECK(nonpos.fingerprint()==nonpos_before && nonpos.position()==0);
+
+    Book add;
+    add.seed({1});
+    add.exhaust_cycles();
+    CHECK(add.settle(order_action::Transact{1},120,"add",40).status==execution::Status::Applied);
+    CHECK(add.position()==2 && add.cycle()==4 && add.lots().size()==2);
+    CHECK(add.rows().empty());
+    if(add.lots().size()==2) CHECK(add.lots()[1].entry_id=="add");
+
+    Book reduce;
+    reduce.seed({1,2});
+    reduce.exhaust_cycles();
+    const auto reduced = reduce.settle(order_action::Reduce{1});
+    CHECK(reduced.status==execution::Status::Applied);
+    CHECK(reduced.closed_units==1 && reduced.opened_units==0);
+    CHECK(reduce.position()==2 && reduce.cycle()==4 && reduce.lots().size()==1);
+
+    Book stream;
+    stream.seed({1,2});
+    stream.exhaust_stream();
+    const auto stream_before = stream.fingerprint();
+    CHECK(overflowed(stream, execution::Flatten{}));
+    CHECK(stream.fingerprint()==stream_before);
+    CHECK(stream.position()==3 && stream.lots().size()==2 && stream.cycle()==4);
+    CHECK(stream.rows().empty() && stream.actions().empty());
+
+    Book stream_open;
+    stream_open.exhaust_stream();
+    const auto open_before = stream_open.fingerprint();
+    CHECK(overflowed(stream_open, order_action::Transact{1}));
+    CHECK(stream_open.fingerprint()==open_before && stream_open.position()==0);
+    CHECK(stream_open.lots().empty() && stream_open.actions().empty());
+
+    for (int kind = 0; kind < 4; ++kind) {
+        Book counts;
+        counts.seed({1});
+        counts.exhaust_close_counter(kind);
+        const auto before = counts.fingerprint();
+        const double price = kind == 0 ? 120 : kind == 2 ? 100 : 80;
+        CHECK(overflowed(counts, execution::Flatten{}, price));
+        CHECK(counts.fingerprint() == before && counts.position() == 1);
+        CHECK(counts.rows().empty() && counts.actions().empty());
+    }
+    Book batch;
+    batch.seed({1, 2});
+    batch.exhaust_close_counter(0, 1); // one remaining count cannot cover two winners
+    const auto batch_before = batch.fingerprint();
+    CHECK(overflowed(batch, execution::Flatten{}, 120));
+    CHECK(batch.fingerprint() == batch_before && batch.position() == 3);
+    CHECK(batch.rows().empty() && batch.actions().empty());
+
+    Book entries;
+    entries.seed({1});
+    entries.exhaust_entries();
+    const auto entries_before = entries.fingerprint();
+    CHECK(overflowed(entries, order_action::Transact{1}));
+    CHECK(entries.fingerprint() == entries_before && entries.position() == 1);
+    CHECK(entries.rows().empty() && entries.actions().empty());
+}
+
+void physical_book_owns_projection() {
+    for (bool short_side : {false, true}) {
+        Book b;
+        b.seed({1}, short_side);
+        b.stale_projection();
+        const double sign = short_side ? -1 : 1;
+        CHECK(b.settle(order_action::Transact{sign}, 120).status == execution::Status::Applied);
+        CHECK(b.position() == 2 * sign && b.average() == 110);
+        CHECK(b.lots().size() == 2 && b.actions().size() == 1);
+        if (!b.actions().empty()) CHECK(b.actions()[0].quantity == 1 && b.actions()[0].price == 120);
+    }
+}
+}
+int main() {
+    native_actions(); actual_lots_define_quantity(); no_sizing_or_admission_permissions();
+    invalid_and_zero_leave_state(); historical_costs_are_not_repriced();
+    transact_same_side_and_reduce_cannot_flip();
+    quoted_fee_overrides_unsuitable_modeled_rate();
+    zero_fee_waiver_and_rebate();
+    quote_split_does_not_reprice_entry_costs();
+    quote_split_across_closed_lots();
+    quantity_quoted_fees_are_not_tickets();
+    quoted_no_effect_and_nonfinite_are_refused();
+    finite_zero_and_negative_prices();
+    exhausted_counters_throw_before_effects();
+    physical_book_owns_projection();
+    std::printf("resolved execution: %d checks, %d failures\n",checks,failures);
+    return failures?1:0;
+}

--- a/tests/test_unbounded_margin_admission.cpp
+++ b/tests/test_unbounded_margin_admission.cpp
@@ -1,0 +1,71 @@
+// Literal order admission only: no Engine::run, feed or reference engine.
+#include <pineforge/engine.hpp>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+using namespace pineforge;
+namespace {
+int checks = 0, failures = 0;
+#define CHECK(x) do { ++checks; if (!(x)) { ++failures; std::printf("FAIL %d: %s\n", __LINE__, #x); } } while (0)
+
+class Account final : public BacktestEngine {
+public:
+    explicit Account(double capital = 10000) {
+        initial_capital_ = capital;
+        default_qty_type_ = QtyType::FIXED;
+        default_qty_value_ = 1;
+        margin_long_ = margin_short_ = 100;
+        commission_value_ = 0;
+        slippage_ = 0;
+        qty_step_ = 0;
+        syminfo_mintick_ = 0.01;
+        current_bar_ = {100, 100, 100, 100, 1, 60000};
+        bar_index_ = 0;
+    }
+    void on_bar(const Bar&) override {}
+    void request(bool buy, double units, bool stop) {
+        const double absent = std::numeric_limits<double>::quiet_NaN();
+        strategy_entry("order", buy, absent, stop ? 101 : absent, units);
+    }
+    size_t pending() const { return pending_orders_.size(); }
+    bool physical_book_empty() const {
+        return pyramid_entries_.empty() && position_side_ == PositionSide::FLAT
+            && position_qty_ == 0 && trades_.empty() && net_profit_sum_ == 0;
+    }
+};
+}
+
+int main() {
+    for (bool buy : {false, true}) for (bool stop : {false, true}) {
+        // Both explicit infinity and a finite quantity whose notional
+        // overflows exceed finite account resources.
+        for (double units : {std::numeric_limits<double>::infinity(),
+                             -std::numeric_limits<double>::infinity(),
+                             std::numeric_limits<double>::max(), 101.0}) {
+            Account a;
+            a.request(buy, units, stop);
+            CHECK(a.pending() == 0);
+            CHECK(a.physical_book_empty());
+        }
+        Account equality;
+        equality.request(buy, 100, stop); // 100 units * price100 == capital10000
+        CHECK(equality.pending() == 1);
+        CHECK(equality.physical_book_empty());
+
+        Account omitted;
+        omitted.request(buy, std::numeric_limits<double>::quiet_NaN(), stop);
+        CHECK(omitted.pending() == 1); // NaN remains the default-quantity sentinel
+        CHECK(omitted.physical_book_empty());
+
+        // Even the largest finite equity cannot fund an infinite cost.
+        // Adding the comparison tolerance to this balance overflows, so a
+        // plain required > (balance + epsilon) would otherwise miss it.
+        Account largest_balance(std::numeric_limits<double>::max());
+        largest_balance.request(buy, std::numeric_limits<double>::max(), stop);
+        CHECK(largest_balance.pending() == 0);
+        CHECK(largest_balance.physical_book_empty());
+    }
+    std::printf("unbounded margin admission: %d checks, %d failures\n", checks, failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Resolved fills now use native FIFO settlement over the existing physical lot book. Closing a lot consumes its paid entry cost instead of repricing a historical payment at the current FX or fee schedule. One matched reversal allocates one current execution fee across its closing and opening effects, with counter validation before settlement.

The protected C++ extension accepts `Flatten`, `Reduce` and signed `Transact` at an already resolved price. It preserves positive residual lots and supports explicit account-currency fees, including rebates, without another sizing or slippage pass. Full market exits and selected frozen-transaction paths use this kernel. The remaining legacy paths and source-policy dependencies are documented in `docs/native-settlement.md`; this advances #227 toward a standalone engine with codegen-owned PineScript compatibility.

Risk fixtures now use physical lots. Affordability rejects infinite margin against finite capital while preserving finite tolerances and the NaN default-quantity sentinel. The admission matrix verifies that a rejected infinite request leaves no order or position and retains its original request and truthful `RejectedAffordability` record.

Validation on `d3996b4c578024875134e29621844e57451f481d`, codegen `7410c87a51f9ecfa28efe684607de8eec1f04875`:

- Full rebuild and 1,051 literal native checks pass: 97 admission matrix, 56 unbounded admission, 372 settlement, 406 action planner and 120 adapter integration. C ABI source, mirror generation and broker-state coverage checks pass. Existing ABI/fingerprint domains are unchanged; `PendingOrder` remains 65 members with five direct booleans.
- Independent exact-candidate Grok review is GREEN after the fee, crossing and CI findings were addressed.
- Cloud `exp-native-settlement-ci-matrix-20260912` / `pineforge-experiment-run-hw8r4`: 72/72 cases, 4,190/4,190 probes, 4,182 excellent / 8 strong. Every stored grade object equals the preceding merged candidate and official baseline. References, feeds, population, runner configuration and codegen tree are unchanged.
- All 4,069 stored trade sets on each side pass hash and parsing checks. Trade count, timing, side, quantity and prices are unchanged. Five CSVs contain six retained 0.000001 PnL/excursion differences from historical cost allocation, identical to the earlier PR candidate. The only corresponding verifier-content changes are five `engineTradesSha256` values; metrics and decisions are unchanged.
- Snapshot publication `pineforge-publish-snapshot-9d5v6` succeeded. Candidate snapshot: `d0a34c72db0f696a4b71b29cf459d1cc4e8271c093f8bc4a7b63f2bb86fc34d3`.

Formal Cloud gate `pineforge-pr-gate-d7f86` is FAIL solely `target.not-positive`. The owner explicitly authorizes this refactor with zero improvement and no regression. The actual gate failure is retained and scientific baseline promotion remains deferred. The deployed gate raises after logging failure, so actual execution/log evidence is preserved without synthesizing a full verdict or PASS.

This is synchronous settlement, not a completed queued order machine or broker reconciliation API. Source qualifiers and legacy settlement families remain visible follow-up work. Allocation/lifecycle exceptions still require discarding the failed run; strong allocation-failure rollback is not promised.
